### PR TITLE
Populate node.label attributes to the allocated node

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
@@ -30,7 +30,6 @@ import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import org.apache.commons.compress.utils.Sets;
 import org.jenkinsci.plugins.workflow.actions.ArgumentsAction;
 import org.jenkinsci.plugins.workflow.actions.ErrorAction;
-import org.jenkinsci.plugins.workflow.actions.TimingAction;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepAtomNode;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepEndNode;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode;
@@ -70,24 +69,6 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
         this.ignoredSteps = Sets.newHashSet("dir", "echo", "isUnix", "pwd");
     }
 
-    private long calculateAllocationTime(FlowNode node, FlowNode parent) {
-        if (node == null || parent == null) {
-            return 0;
-        }
-        TimingAction childTimingAction = node.getAction(TimingAction.class);
-        TimingAction parentTimingAction = parent.getAction(TimingAction.class);
-
-        if (childTimingAction == null || parentTimingAction == null) {
-            return 0;
-        }
-
-        if (childTimingAction.getStartTime() < parentTimingAction.getStartTime()) {
-            return 0;
-        }
-
-        return childTimingAction.getStartTime() - parentTimingAction.getStartTime();
-    }
-
     private String fetchNodeLabels(FlowNode node) {
         if (node == null) {
             return null;
@@ -121,7 +102,7 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
         try (Scope ignored = setupContext(run, stepStartNode)) {
             verifyNotNull(ignored, "%s - No span found for node %s", run, stepStartNode);
 
-            final long allocationTime = calculateAllocationTime(stepStartNode, PipelineNodeUtil.getPreviousNode(stepStartNode));
+            // TODO: can we calculate the provisioning time between this span and its parent?
             final String label = fetchNodeLabels(PipelineNodeUtil.getPreviousNode(stepStartNode));
             String spanNodeName = "Node: " + nodeName;
             Span nodeSpan = getTracer().spanBuilder(spanNodeName)
@@ -130,7 +111,6 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
                     .setAttribute(JenkinsOtelSemanticAttributes.JENKINS_STEP_ID, stepStartNode.getId())
                     .setAttribute(JenkinsOtelSemanticAttributes.JENKINS_STEP_NAME, nodeName)
                     .setAttribute(JenkinsOtelSemanticAttributes.JENKINS_STEP_NODE_LABEL, label)
-                    .setAttribute(JenkinsOtelSemanticAttributes.JENKINS_STEP_NODE_ALLOCATION_TIME, allocationTime)
                     .startSpan();
             LOGGER.log(Level.FINE, () -> run.getFullDisplayName() + " - > node(" + nodeName + ") - begin " + OtelUtils.toDebugString(nodeSpan));
 

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/jenkins/AbstractPipelineListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/jenkins/AbstractPipelineListener.java
@@ -30,6 +30,11 @@ public class AbstractPipelineListener implements PipelineListener {
     }
 
     @Override
+    public void onAfterStartNodeStep(@Nonnull StepStartNode stepStartNode, @Nonnull String stageName, @Nonnull WorkflowRun run) {
+
+    }
+
+    @Override
     public void onEndNodeStep(@Nonnull StepEndNode nodeStepEndNode, @Nonnull String nodeName, @Nonnull WorkflowRun run) {
 
     }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/jenkins/GraphListenerAdapterToPipelineListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/jenkins/GraphListenerAdapterToPipelineListener.java
@@ -82,9 +82,9 @@ public class GraphListenerAdapterToPipelineListener implements StepListener, Gra
         } else if (PipelineNodeUtil.isEndParallelBlock(node)) {
             // ignore
         } else if (PipelineNodeUtil.isNodeAllocate(node)) {
-            fireOnBeforeStartNodeStep((StepStartNode) node, "Allocate", run);
+            fireOnStartNodeStep((StepStartNode) node, "Allocate", run);
         } else if (PipelineNodeUtil.isNodeReady(node)) {
-            fireOnBeforeStartNodeStep((StepStartNode) node, "Ready", run);
+            fireOnAfterStartNodeStep((StepStartNode) node, "Ready", run);
         } else {
             logFlowNodeDetails(node, run);
         }
@@ -210,13 +210,24 @@ public class GraphListenerAdapterToPipelineListener implements StepListener, Gra
         }
     }
 
-    public void fireOnBeforeStartNodeStep(@Nonnull StepStartNode node, @Nonnull String nodeName, @Nonnull WorkflowRun run) {
+    public void fireOnStartNodeStep(@Nonnull StepStartNode node, @Nonnull String nodeName, @Nonnull WorkflowRun run) {
         for (PipelineListener pipelineListener : PipelineListener.all()) {
-            log(() -> "fireOnBeforeStartNodeStep(" + node.getDisplayName() + "): " + pipelineListener.toString());
+            log(() -> "onStartNodeStep(" + node.getDisplayName() + "): " + pipelineListener.toString());
             try {
                 pipelineListener.onStartNodeStep(node, nodeName, run);
             } catch (RuntimeException e) {
-                LOGGER.log(Level.WARNING, e, () -> "Exception invoking `fireOnBeforeStartNodeStep` on " + pipelineListener);
+                LOGGER.log(Level.WARNING, e, () -> "Exception invoking `onStartNodeStep` on " + pipelineListener);
+            }
+        }
+    }
+
+    public void fireOnAfterStartNodeStep(@Nonnull StepStartNode node, @Nonnull String nodeName, @Nonnull WorkflowRun run) {
+        for (PipelineListener pipelineListener : PipelineListener.all()) {
+            log(() -> "onAfterStartNodeStep(" + node.getDisplayName() + "): " + pipelineListener.toString());
+            try {
+                pipelineListener.onAfterStartNodeStep(node, nodeName, run);
+            } catch (RuntimeException e) {
+                LOGGER.log(Level.WARNING, e, () -> "Exception invoking `onAfterStartNodeStep` on " + pipelineListener);
             }
         }
     }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/jenkins/PipelineListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/jenkins/PipelineListener.java
@@ -33,6 +33,11 @@ public interface PipelineListener {
     void onStartNodeStep(@Nonnull StepStartNode stepStartNode, @Nonnull String nodeName, @Nonnull WorkflowRun run);
 
     /**
+     * Just after the `node` step starts.
+     */
+    void onAfterStartNodeStep(@Nonnull StepStartNode stepStartNode, @Nonnull String nodeName, @Nonnull WorkflowRun run);
+
+    /**
      * Just after the `node` step ends
      */
     void onEndNodeStep(@Nonnull StepEndNode nodeStepEndNode, @Nonnull String nodeName, @Nonnull WorkflowRun run);

--- a/src/main/java/io/jenkins/plugins/opentelemetry/semconv/JenkinsOtelSemanticAttributes.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/semconv/JenkinsOtelSemanticAttributes.java
@@ -61,7 +61,6 @@ public final class JenkinsOtelSemanticAttributes {
     public static final AttributeKey<String>        JENKINS_COMPUTER_NAME = AttributeKey.stringKey("jenkins.computer.name");
 
     public static final AttributeKey<String>        JENKINS_STEP_NODE_LABEL = AttributeKey.stringKey("jenkins.pipeline.step.node.label");
-    public static final AttributeKey<Long>          JENKINS_STEP_NODE_ALLOCATION_TIME = AttributeKey.longKey("jenkins.pipeline.step.node.allocation.time");
 
     /**
      * @see io.opentelemetry.semconv.resource.attributes.ResourceAttributes#SERVICE_NAME

--- a/src/main/java/io/jenkins/plugins/opentelemetry/semconv/JenkinsOtelSemanticAttributes.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/semconv/JenkinsOtelSemanticAttributes.java
@@ -61,6 +61,7 @@ public final class JenkinsOtelSemanticAttributes {
     public static final AttributeKey<String>        JENKINS_COMPUTER_NAME = AttributeKey.stringKey("jenkins.computer.name");
 
     public static final AttributeKey<String>        JENKINS_STEP_NODE_LABEL = AttributeKey.stringKey("jenkins.pipeline.step.node.label");
+    public static final AttributeKey<Long>          JENKINS_STEP_NODE_ALLOCATION_TIME = AttributeKey.longKey("jenkins.pipeline.step.node.allocation.time");
 
     /**
      * @see io.opentelemetry.semconv.resource.attributes.ResourceAttributes#SERVICE_NAME

--- a/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginIntegrationTest.java
@@ -131,6 +131,7 @@ public class JenkinsOtelPluginIntegrationTest {
         MatcherAssert.assertThat(readyNode, CoreMatchers.is(CoreMatchers.notNullValue()));
         attributes = readyNode.get().getData().spanData.getAttributes();
         MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.JENKINS_STEP_NODE_LABEL), CoreMatchers.nullValue());
+        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.JENKINS_STEP_NODE_ALLOCATION_TIME), CoreMatchers.notNullValue());
 
         // WORKAROUND because we don't know how to force the IntervalMetricReader to collect metrics
         Thread.sleep(600);
@@ -231,6 +232,7 @@ public class JenkinsOtelPluginIntegrationTest {
         MatcherAssert.assertThat(readyNode, CoreMatchers.is(CoreMatchers.notNullValue()));
         attributes = readyNode.get().getData().spanData.getAttributes();
         MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.JENKINS_STEP_NODE_LABEL), CoreMatchers.is("linux"));
+        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.JENKINS_STEP_NODE_ALLOCATION_TIME), CoreMatchers.notNullValue());
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginIntegrationTest.java
@@ -131,7 +131,6 @@ public class JenkinsOtelPluginIntegrationTest {
         MatcherAssert.assertThat(readyNode, CoreMatchers.is(CoreMatchers.notNullValue()));
         attributes = readyNode.get().getData().spanData.getAttributes();
         MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.JENKINS_STEP_NODE_LABEL), CoreMatchers.nullValue());
-        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.JENKINS_STEP_NODE_ALLOCATION_TIME), CoreMatchers.notNullValue());
 
         // WORKAROUND because we don't know how to force the IntervalMetricReader to collect metrics
         Thread.sleep(600);
@@ -232,7 +231,6 @@ public class JenkinsOtelPluginIntegrationTest {
         MatcherAssert.assertThat(readyNode, CoreMatchers.is(CoreMatchers.notNullValue()));
         attributes = readyNode.get().getData().spanData.getAttributes();
         MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.JENKINS_STEP_NODE_LABEL), CoreMatchers.is("linux"));
-        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.JENKINS_STEP_NODE_ALLOCATION_TIME), CoreMatchers.notNullValue());
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginIntegrationTest.java
@@ -121,10 +121,15 @@ public class JenkinsOtelPluginIntegrationTest {
         checkChainOfSpans(spans, "Phase: Finalise", jobName);
         MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(10L));
 
-        Optional<Tree.Node<SpanDataWrapper>> actualNodeOptional = spans.breadthFirstSearchNodes(node -> "Node: Allocate".equals(node.getData().spanData.getName()));
-        MatcherAssert.assertThat(actualNodeOptional, CoreMatchers.is(CoreMatchers.notNullValue(Optional.class)));
+        Optional<Tree.Node<SpanDataWrapper>> allocateNode = spans.breadthFirstSearchNodes(node -> "Node: Allocate".equals(node.getData().spanData.getName()));
+        MatcherAssert.assertThat(allocateNode, CoreMatchers.is(CoreMatchers.notNullValue(Optional.class)));
 
-        final Attributes attributes = actualNodeOptional.get().getData().spanData.getAttributes();
+        Attributes attributes = allocateNode.get().getData().spanData.getAttributes();
+        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.JENKINS_STEP_NODE_LABEL), CoreMatchers.nullValue());
+
+        Optional<Tree.Node<SpanDataWrapper>> readyNode = spans.breadthFirstSearchNodes(node -> "Node: Ready".equals(node.getData().spanData.getName()));
+        MatcherAssert.assertThat(readyNode, CoreMatchers.is(CoreMatchers.notNullValue()));
+        attributes = readyNode.get().getData().spanData.getAttributes();
         MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.JENKINS_STEP_NODE_LABEL), CoreMatchers.nullValue());
 
         // WORKAROUND because we don't know how to force the IntervalMetricReader to collect metrics
@@ -216,10 +221,15 @@ public class JenkinsOtelPluginIntegrationTest {
         checkChainOfSpans(spans, "Phase: Finalise", jobName);
         MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(7L));
 
-        Optional<Tree.Node<SpanDataWrapper>> actualNodeOptional = spans.breadthFirstSearchNodes(node -> "Node: Allocate (linux)".equals(node.getData().spanData.getName()));
-        MatcherAssert.assertThat(actualNodeOptional, CoreMatchers.is(CoreMatchers.notNullValue()));
+        Optional<Tree.Node<SpanDataWrapper>> allocateNode = spans.breadthFirstSearchNodes(node -> "Node: Allocate (linux)".equals(node.getData().spanData.getName()));
+        MatcherAssert.assertThat(allocateNode, CoreMatchers.is(CoreMatchers.notNullValue()));
 
-        final Attributes attributes = actualNodeOptional.get().getData().spanData.getAttributes();
+        Attributes attributes = allocateNode.get().getData().spanData.getAttributes();
+        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.JENKINS_STEP_NODE_LABEL), CoreMatchers.is("linux"));
+
+        Optional<Tree.Node<SpanDataWrapper>> readyNode = spans.breadthFirstSearchNodes(node -> "Node: Ready".equals(node.getData().spanData.getName()));
+        MatcherAssert.assertThat(readyNode, CoreMatchers.is(CoreMatchers.notNullValue()));
+        attributes = readyNode.get().getData().spanData.getAttributes();
         MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.JENKINS_STEP_NODE_LABEL), CoreMatchers.is("linux"));
     }
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->

### What

Let's refactor and use the events design pattern for the `agent` and `node` steps as highlighted in https://github.com/jenkinsci/opentelemetry-plugin/pull/22#discussion_r593064238

Populate the node labels to the `Node: ready` span

### Actions

- [x] Populate the labels from the `Node: allocate` to the `Node: ready` -> https://github.com/jenkinsci/opentelemetry-plugin/pull/26/commits/b52639a21ada316f0722f3a601ca24b9c174f0d9

### Important

I was not able to find the way to access to the `parentSpan` attributes therefore I used the `FlowNode.getParents()` approach. 

### Issue

Relates https://github.com/jenkinsci/opentelemetry-plugin/issues/25

### Tests

Populate the labels attribute from the `Node: allocate` to the `Node: ready`

<details><summary>Expand to view</summary>
<p>

![image](https://user-images.githubusercontent.com/2871786/110946664-1002f000-8337-11eb-86ba-131233575364.png)

</p>
</details>


### Follow up

Implement https://github.com/jenkinsci/opentelemetry-plugin/pull/26#discussion_r593767248 , let's do that in another PR