### PR TITLE
JCasC reload changes when a setter call

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ This plugin supports configuration as code. Add to your yaml file:
 ```yaml
 unclassified:
   openTelemetry:
+    authentication: "noAuthentication"
     endpoint: "otel-collector-contrib:4317"
     observabilityBackends:
       - elastic:
@@ -203,7 +204,6 @@ unclassified:
           traceVisualisationUrlTemplate: "http://example.com"
       - zipkin:
           zipkinBaseUrl: "http://localhost:9411/"
-    useTls: false
 ```
 
 For more details see the configuration as code plugin documentation:

--- a/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
@@ -104,6 +104,7 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
     @DataBoundSetter
     public void setEndpoint(String endpoint) {
         this.endpoint = sanitizeOtlpEndpoint(endpoint);
+        initializeOpenTelemetry();
     }
 
     @Nonnull
@@ -114,6 +115,7 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
     @DataBoundSetter
     public void setAuthentication(OtlpAuthentication authentication) {
         this.authentication = authentication;
+        initializeOpenTelemetry();
     }
 
     @CheckForNull
@@ -124,11 +126,13 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
     @DataBoundSetter
     public void setTrustedCertificatesPem(String trustedCertificatesPem) {
         this.trustedCertificatesPem = trustedCertificatesPem;
+        initializeOpenTelemetry();
     }
 
     @DataBoundSetter
     public void setObservabilityBackends(List<ObservabilityBackend> observabilityBackends) {
         this.observabilityBackends = Optional.of(observabilityBackends).orElse(Collections.emptyList());
+        initializeOpenTelemetry();
     }
 
     @Nonnull

--- a/src/test/java/io/jenkins/plugins/opentelemetry/jcasc/ConfigurationAsCodeTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/jcasc/ConfigurationAsCodeTest.java
@@ -11,6 +11,8 @@ import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.opentelemetry.JenkinsOpenTelemetryPluginConfiguration;
+import io.jenkins.plugins.opentelemetry.authentication.NoAuthentication;
+import io.jenkins.plugins.opentelemetry.authentication.OtlpAuthentication;
 import io.jenkins.plugins.opentelemetry.backend.CustomObservabilityBackend;
 import io.jenkins.plugins.opentelemetry.backend.ElasticBackend;
 import io.jenkins.plugins.opentelemetry.backend.JaegerBackend;
@@ -24,6 +26,7 @@ import org.junit.*;
 import static io.jenkins.plugins.casc.misc.Util.getUnclassifiedRoot;
 import static io.jenkins.plugins.casc.misc.Util.toStringFromYamlFile;
 import static io.jenkins.plugins.casc.misc.Util.toYamlString;
+import static org.hamcrest.CoreMatchers.instanceOf;
 
 public class ConfigurationAsCodeTest {
 
@@ -50,7 +53,10 @@ public class ConfigurationAsCodeTest {
 
         ZipkinBackend zipkin = (ZipkinBackend) configuration.getObservabilityBackends().get(3);
         MatcherAssert.assertThat(zipkin.getZipkinBaseUrl(), CoreMatchers.is("http://localhost:9411/"));
-	}
+
+        OtlpAuthentication authentication = configuration.getAuthentication();
+        MatcherAssert.assertThat(authentication, CoreMatchers.is(instanceOf(NoAuthentication.class)));
+    }
 
     @Test
     public void should_support_configuration_export() throws Exception {

--- a/src/test/resources/io/jenkins/plugins/opentelemetry/jcasc-elastic-backend.yml
+++ b/src/test/resources/io/jenkins/plugins/opentelemetry/jcasc-elastic-backend.yml
@@ -1,5 +1,6 @@
 unclassified:
   openTelemetry:
+    authentication: "noAuthentication"
     endpoint: "http://otel-collector-contrib:4317"
     observabilityBackends:
       - elasticBackend:


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->

### What

The `configure(StaplerRequest req, JSONObject json)` method is not call when the JCasC run, so I found the only way to reload the configuration is by adding in the `DataBoundSetter` methods the `initializeOpenTelemetry` call.

I also updated the README with the new authentication and added a JCasC validation for the UTs.

### Why

Otherwise, JCasC won't change the existing configuration.

### Tests

Manually a new vanilla installation when reloading with JCasC produces an entry like:

```
[INFO] Started Jetty Server
[INFO] Console reloading is ENABLED. Hit ENTER on the console to restart the context.
2021-03-15 19:26:04.106+0000 [id=57]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
2021-03-15 19:26:04.883+0000 [id=78]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /Users/vmartinez/work/src/github.com/v1v/opentelemetry-plugin/work/plugins/command-launcher.jpi
2021-03-15 19:26:04.896+0000 [id=78]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /Users/vmartinez/work/src/github.com/v1v/opentelemetry-plugin/work/plugins/jdk-tool.jpi
2021-03-15 19:26:06.610+0000 [id=77]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /Users/vmartinez/work/src/github.com/v1v/opentelemetry-plugin/work/plugins/bouncycastle-api.jpi
2021-03-15 19:26:06.764+0000 [id=77]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
2021-03-15 19:26:06.844+0000 [id=77]	INFO	j.b.a.SecurityProviderInitializer#addSecurityProvider: Initializing Bouncy Castle security provider.
2021-03-15 19:26:06.963+0000 [id=77]	INFO	j.b.a.SecurityProviderInitializer#addSecurityProvider: Bouncy Castle security provider initialized.
2021-03-15 19:26:10.043+0000 [id=71]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
2021-03-15 19:26:10.055+0000 [id=71]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
2021-03-15 19:26:11.073+0000 [id=55]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
2021-03-15 19:26:11.121+0000 [id=64]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
2021-03-15 19:26:11.456+0000 [id=59]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
2021-03-15 19:26:11.456+0000 [id=69]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
2021-03-15 19:26:11.456+0000 [id=75]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
2021-03-15 19:26:11.477+0000 [id=93]	INFO	hudson.model.AsyncPeriodicWork#lambda$doRun$0: Started Download metadata
2021-03-15 19:26:11.486+0000 [id=93]	INFO	hudson.util.Retrier#start: Attempt #1 to do the action check updates server
2021-03-15 19:26:11.509+0000 [id=64]	INFO	jenkins.model.Jenkins#setInstallState: Install state transitioning from: null to : DEVELOPMENT
2021-03-15 19:26:11.513+0000 [id=73]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
2021-03-15 19:26:11.546+0000 [id=50]	INFO	hudson.WebAppMain$3#run: Jenkins is fully up and running
2021-03-15 19:26:18.812+0000 [id=93]	INFO	h.m.DownloadService$Downloadable#load: Obtained the updated data file for hudson.tasks.Maven.MavenInstaller
2021-03-15 19:26:19.618+0000 [id=93]	INFO	h.m.DownloadService$Downloadable#load: Obtained the updated data file for hudson.tools.JDKInstaller
2021-03-15 19:26:19.619+0000 [id=93]	INFO	hudson.util.Retrier#start: Performed the action check updates server successfully at the attempt #1
2021-03-15 19:26:19.621+0000 [id=93]	INFO	hudson.model.AsyncPeriodicWork#lambda$doRun$0: Finished Download metadata. 8,144 ms
2021-03-15 19:26:54.304+0000 [id=45]	INFO	i.j.p.o.OpenTelemetrySdkProvider#initializeForGrpc: OpenTelemetry initialized with GRPC endpoint http://localhost:4317, authenticationHeader: NoAuthentication{}
```