### PR TITLE
Introduce a span for the allocation duration of the build node on `node(){...}` blocks

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/jenkins/AbstractPipelineListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/jenkins/AbstractPipelineListener.java
@@ -12,6 +12,7 @@ import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public class AbstractPipelineListener implements PipelineListener {
     @Override
@@ -20,7 +21,7 @@ public class AbstractPipelineListener implements PipelineListener {
     }
 
     @Override
-    public void onStartNodeStep(@Nonnull StepStartNode stepStartNode, @Nonnull String nodeName, @Nonnull WorkflowRun run) {
+    public void onStartNodeStep(@Nonnull StepStartNode stepStartNode, @Nullable String nodeLabel, @Nonnull WorkflowRun run) {
 
     }
 
@@ -30,7 +31,7 @@ public class AbstractPipelineListener implements PipelineListener {
     }
 
     @Override
-    public void onAfterStartNodeStep(@Nonnull StepStartNode stepStartNode, @Nonnull String stageName, @Nonnull WorkflowRun run) {
+    public void onAfterStartNodeStep(@Nonnull StepStartNode stepStartNode, @Nullable String nodeLabel, @Nonnull WorkflowRun run) {
 
     }
 

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/jenkins/PipelineListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/jenkins/PipelineListener.java
@@ -13,6 +13,7 @@ import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.List;
 
 public interface PipelineListener {
@@ -30,12 +31,12 @@ public interface PipelineListener {
     /**
      * Just before the `node` step starts.
      */
-    void onStartNodeStep(@Nonnull StepStartNode stepStartNode, @Nonnull String nodeName, @Nonnull WorkflowRun run);
+    void onStartNodeStep(@Nonnull StepStartNode stepStartNode, @Nullable String nodeLabel, @Nonnull WorkflowRun run);
 
     /**
      * Just after the `node` step starts.
      */
-    void onAfterStartNodeStep(@Nonnull StepStartNode stepStartNode, @Nonnull String nodeName, @Nonnull WorkflowRun run);
+    void onAfterStartNodeStep(@Nonnull StepStartNode stepStartNode, @Nullable String nodeLabel, @Nonnull WorkflowRun run);
 
     /**
      * Just after the `node` step ends

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/jenkins/PipelineNodeUtil.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/jenkins/PipelineNodeUtil.java
@@ -156,7 +156,7 @@ public class PipelineNodeUtil {
         return true;
     }
 
-    public static boolean isStartNode(@Nullable FlowNode node) {
+    public static boolean isStartExecutorNode(@Nullable FlowNode node) {
         if (node == null) {
             return false;
         }
@@ -168,7 +168,14 @@ public class PipelineNodeUtil {
             return false;
         }
 
-        LOGGER.log(Level.FINER, ()-> "isStartNode():" + getDetailedDebugString(node));
+        BodyInvocationAction bodyInvocationAction = node.getAction(BodyInvocationAction.class);
+        if (bodyInvocationAction != null) {
+            // it's the second StepStartNode of the ExecutorStep, the StepStartNode for the actual invocation
+            LOGGER.log(Level.INFO, ()-> "isStartNode(): false - " + getDetailedDebugString(node));
+            return false;
+        }
+
+        LOGGER.log(Level.INFO, ()-> "isStartNode(): true - " + getDetailedDebugString(node));
         return true;
     }
 
@@ -205,22 +212,20 @@ public class PipelineNodeUtil {
         return isStartParallelBlock(stepEndNode.getStartNode());
     }
 
-    public static boolean isNodeReady(@Nonnull FlowNode node) {
-        if (!isStartNode(node)) {
+    public static boolean isStartExecutorNodeExecution(@Nonnull FlowNode node) {
+        if (node == null) {
+            return false;
+        }
+        if (!(node instanceof StepStartNode)) {
+            return false;
+        }
+        StepStartNode stepStartNode = (StepStartNode) node;
+        if (!(stepStartNode.getDescriptor() instanceof ExecutorStep.DescriptorImpl)) {
             return false;
         }
 
         BodyInvocationAction bodyInvocationAction = node.getAction(BodyInvocationAction.class);
         return bodyInvocationAction != null;
-    }
-
-    public static boolean isNodeAllocate(@Nonnull FlowNode node) {
-        if (!isStartNode(node)) {
-            return false;
-        }
-
-        BodyInvocationAction bodyInvocationAction = node.getAction(BodyInvocationAction.class);
-        return bodyInvocationAction == null;
     }
 
     /**


### PR DESCRIPTION



### Node with a label (e.g. 'linux')

```
test-pipeline-with-node-steps-4
   |
   |- Phase: Start
   |
   |- Phase: Run
   |   |
   |   |- Stage: foo, function: stage, name: foo, node.id: 4
   |       |
   |       |- Node: linux, function: node, name: node, node.id: 5
   |           |
   |           |- Node Allocation: linux, function: node, name: node.allocate, node.id: 5
   |
   |- Phase: Finalise
```

### Node without label

```
test-pipeline-with-wrapping-step-3
   |
   |- Phase: Start
   |
   |- Phase: Run
   |   |
   |   |- Node, function: node, name: node, node.id: 3
   |       |
   |       |- Node Allocation, function: node, name: node.allocate, node.id: 3
   |       |
   |       |- Stage: ze-stage1, function: stage, name: ze-stage1, node.id: 6
   |       |   |
   |       |   |- shell-1, function: sh, name: Shell Script, node.id: 10
   |       |   |
   |       |   |- sh, function: sh, name: Shell Script, node.id: 14
   |       |
   |       |- Stage: ze-stage2, function: stage, name: ze-stage2, node.id: 18
   |           |
   |           |- shell-2, function: sh, name: Shell Script, node.id: 20
   |
   |- Phase: Finalise
```