### PR TITLE
Low cardinality root span name for MultiBranchPipeline change requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,18 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>github-branch-source</artifactId>
+            <version>2.9.7</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
             <classifier>tests</classifier>
             <scope>test</scope>

--- a/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
@@ -12,6 +12,7 @@ import hudson.util.FormValidation;
 import io.jenkins.plugins.opentelemetry.authentication.NoAuthentication;
 import io.jenkins.plugins.opentelemetry.backend.ObservabilityBackend;
 import io.jenkins.plugins.opentelemetry.authentication.OtlpAuthentication;
+import io.jenkins.plugins.opentelemetry.job.SpanNamingStrategy;
 import jenkins.model.GlobalConfiguration;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
@@ -53,6 +54,8 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
     private String ignoredSteps = "dir,echo,isUnix,pwd,properties";
 
     private transient OpenTelemetrySdkProvider openTelemetrySdkProvider;
+
+    private transient SpanNamingStrategy spanNamingStrategy;
 
     /**
      * The previously used configuration. Kept in memory to prevent unneeded reconfigurations.
@@ -190,6 +193,15 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
     @Nonnull
     public String getVisualisationObservabilityBackendsString(){
         return "Visualisation observability backends: " + ObservabilityBackend.allDescriptors().stream().sorted().map(d-> d.getDisplayName()).collect(Collectors.joining(", "));
+    }
+
+    @Inject
+    public void setSpanNamingStrategy(SpanNamingStrategy spanNamingStrategy) {
+        this.spanNamingStrategy = spanNamingStrategy;
+    }
+
+    public SpanNamingStrategy getSpanNamingStrategy() {
+        return spanNamingStrategy;
     }
 
     public static JenkinsOpenTelemetryPluginConfiguration get() {

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/SpanNamingStrategy.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/SpanNamingStrategy.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.job;
+
+import com.google.common.annotations.VisibleForTesting;
+import hudson.Extension;
+import hudson.model.Run;
+import jenkins.YesNoMaybe;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
+import jenkins.scm.api.mixin.ChangeRequestSCMHead;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Use same root span name for all pull change request pipelines (pull request, merge request)
+ * Use different span names for different branches.
+ */
+@Extension(dynamicLoadable = YesNoMaybe.YES)
+@Symbol("basicSpanNamingStrategy")
+public class SpanNamingStrategy {
+
+    private final static List<String> CHANGE_REQUEST_JOB_NAME_SUFFIXES = Collections.unmodifiableList(Arrays.asList(
+            "-" + ChangeRequestCheckoutStrategy.HEAD.name().toLowerCase(Locale.ENGLISH),
+            "-" + ChangeRequestCheckoutStrategy.MERGE.name().toLowerCase(Locale.ENGLISH)));
+
+    @DataBoundConstructor
+    public SpanNamingStrategy() {
+
+    }
+
+    @Nonnull
+    public String getRootSpanName(@Nonnull Run run) {
+        final SCMHead head = SCMHead.HeadByItem.findHead(run.getParent());
+        final String fullName = run.getParent().getFullName();
+        if (head instanceof ChangeRequestSCMHead) {
+            return getChangeRequestRootSpanName(fullName);
+        } else {
+            return fullName;
+        }
+    }
+
+    @Nonnull
+    public String getRootSpanNameForRecoveredSpan(@Nonnull Run run) {
+        return getRootSpanName(run) + "_recovered-after-restart";
+    }
+
+    @VisibleForTesting
+    @Nonnull
+    protected String getChangeRequestRootSpanName(@Nonnull String jobFullName) {
+        // org.jenkinsci.plugins.github_branch_source.PullRequestGHEventSubscriber
+        // com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource
+        // jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy
+        // e.g. "my-war/PR-2", "my-war/PR-2-merge", "my-war/PR-2-head"
+        // io.jenkins.plugins.gitlabbranchsource.GitLabSCMSource
+        // e.g. "my-war/MR-2", "my-war/MR-2-merge", "my-war/MR-2-head"
+        String rootSpanName = jobFullName;
+        for (String changeRequestJobNameSuffix : CHANGE_REQUEST_JOB_NAME_SUFFIXES) {
+            if (rootSpanName.endsWith(changeRequestJobNameSuffix)) {
+                rootSpanName = rootSpanName.substring(0, rootSpanName.length() - changeRequestJobNameSuffix.length());
+                break;
+            }
+        }
+
+        // remove digits
+        while (Character.isDigit(rootSpanName.charAt(rootSpanName.length() - 1))) {
+            rootSpanName = rootSpanName.substring(0, rootSpanName.length() - 1);
+        }
+        if ('-' == rootSpanName.charAt(rootSpanName.length() - 1)) {
+            return rootSpanName + "{number}";
+        }
+        return jobFullName;
+    }
+}

--- a/src/test/java/io/jenkins/plugins/opentelemetry/job/SpanNamingStrategyTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/job/SpanNamingStrategyTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.job;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SpanNamingStrategyTest {
+
+    // org.jenkinsci.plugins.github_branch_source.PullRequestGHEventSubscriber
+    // jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy
+    // e.g. "my-war/PR-2", "my-war/PR-2-merge", "my-war/PR-2-head"
+    // io.jenkins.plugins.gitlabbranchsource.GitLabSCMSource
+    // e.g. "my-war/MR-2", "my-war/MR-2-merge", "my-war/MR-2-head"
+
+    SpanNamingStrategy spanNamingStrategy = new SpanNamingStrategy();
+
+    /**
+     * GitHub and BitBucket Pull Requests
+     */
+    @Test
+    public void test_pull_request() {
+        verifyRootSpanName("my-war/PR-2", "my-war/PR-{number}");
+    }
+
+    /**
+     * GitHub and BitBucket Pull Requests
+     */
+    @Test
+    public void test_pull_request_with_head_checkout_strategy() {
+        verifyRootSpanName("my-war/PR-2-head", "my-war/PR-{number}");
+    }
+
+    /**
+     * GitHub and BitBucket Pull Requests
+     */
+    @Test
+    public void test_pull_request_with_merge_checkout_strategy() {
+        verifyRootSpanName("my-war/PR-2-merge", "my-war/PR-{number}");
+    }
+
+    /**
+     * GitLab Merge Requests
+     */
+    @Test
+    public void test_merge_request() {
+        verifyRootSpanName("my-war/MR-2", "my-war/MR-{number}");
+    }
+
+    /**
+     * GitLab Merge Requests
+     */
+    @Test
+    public void test_merge_request_with_head_checkout_strategy() {
+        verifyRootSpanName("my-war/MR-2-head", "my-war/MR-{number}");
+    }
+
+    /**
+     * GitLab Merge Requests
+     */
+    @Test
+    public void test_merge_request_with_merge_checkout_strategy() {
+        verifyRootSpanName("my-war/MR-2-merge", "my-war/MR-{number}");
+    }
+
+    private void verifyRootSpanName(String jobFullName, String expected) {
+        final String actual = spanNamingStrategy.getChangeRequestRootSpanName(jobFullName);
+        Assert.assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
Low cardinality root span name for MultiBranchPipeline change requests jobs: `<<repo-name>>/PR-{number}` instead of `<<repo-name>>/PR-<<number>>`.
The root span name for regular branches remains the full name of the job (ie `<<repo-name>>/<<my-branch>>`).

Later, we could handle additional conventions such as conflating `<<repo-name>>/feature/xxx` branches in one single root span name...

Example: the root span name for PR jobs  `my-war/PR-1`, `my-war/PR-2`... is `my-war/PR-{number}`
