### PR TITLE
Environment variables were not accessible with the env map

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ Here are few examples of architecture:
 * Built in integration with [Elastic Observability](https://www.elastic.co/observability), [Jaeger](https://www.jaegertracing.io/), and [Zipkin](https://zipkin.io/).
    Other OpenTelemetry compatible distributed tracing solutions are also supported.
 
+### Environment variables
+
+The current span and trace IDs are exposed as environment variables.
+
+* SPAN_ID
+* TRACE_ID
+
+In addition, if the backends were configured then there will be an environment variable for each of them pointing to the URL with the span/transactions:
+
+* OTEL_CUSTOM_URL
+* OTEL_ELASTIC_URL
+* OTEL_JAEGER_URL
+* OTEL_ZIPKIN_URL
+
 #### Attributes
 
 ##### Transactions

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/EnvironmentContributorUtils.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/EnvironmentContributorUtils.java
@@ -1,0 +1,37 @@
+package io.jenkins.plugins.opentelemetry.job;
+
+import hudson.EnvVars;
+import hudson.model.Run;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.propagation.TextMapSetter;
+
+import javax.annotation.Nonnull;
+
+public class EnvironmentContributorUtils {
+
+    public static final String SPAN_ID = "SPAN_ID";
+    public static final String TRACE_ID = "TRACE_ID";
+
+    public static void setEnvironmentVariables(@Nonnull Run run, @Nonnull EnvVars envs, @Nonnull Span span) {
+        String spanId = span.getSpanContext().getSpanId();
+        String traceId = span.getSpanContext().getTraceId();
+        try (Scope ignored = span.makeCurrent()) {
+            envs.putIfAbsent(TRACE_ID, traceId);
+            envs.put(SPAN_ID, spanId);
+            TextMapSetter<EnvVars> setter = (carrier, key, value) -> carrier.put(key.toUpperCase(), value);
+            W3CTraceContextPropagator.getInstance().inject(Context.current(), envs, setter);
+        }
+
+        MonitoringAction action = new MonitoringAction(traceId, spanId);
+        action.onAttached(run);
+        for (MonitoringAction.ObservabilityBackendLink link : action.getLinks()) {
+            // Default backend link got an empty environment variable.
+            if (link.getEnvironmentVariableName() != null) {
+                envs.put(link.getEnvironmentVariableName(), link.getUrl());
+            }
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/EnvironmentContributorUtils.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/EnvironmentContributorUtils.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.opentelemetry.job;
 
 import hudson.EnvVars;
 import hudson.model.Run;
+import io.jenkins.plugins.opentelemetry.semconv.JenkinsOtelSemanticAttributes;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.Context;
@@ -12,15 +13,12 @@ import javax.annotation.Nonnull;
 
 public class EnvironmentContributorUtils {
 
-    public static final String SPAN_ID = "SPAN_ID";
-    public static final String TRACE_ID = "TRACE_ID";
-
     public static void setEnvironmentVariables(@Nonnull Run run, @Nonnull EnvVars envs, @Nonnull Span span) {
         String spanId = span.getSpanContext().getSpanId();
         String traceId = span.getSpanContext().getTraceId();
         try (Scope ignored = span.makeCurrent()) {
-            envs.putIfAbsent(TRACE_ID, traceId);
-            envs.put(SPAN_ID, spanId);
+            envs.putIfAbsent(JenkinsOtelSemanticAttributes.TRACE_ID, traceId);
+            envs.put(JenkinsOtelSemanticAttributes.SPAN_ID, spanId);
             TextMapSetter<EnvVars> setter = (carrier, key, value) -> carrier.put(key.toUpperCase(), value);
             W3CTraceContextPropagator.getInstance().inject(Context.current(), envs, setter);
         }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelEnvironmentContributor.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelEnvironmentContributor.java
@@ -7,23 +7,12 @@ package io.jenkins.plugins.opentelemetry.job;
 
 import hudson.EnvVars;
 import hudson.Extension;
-import hudson.model.TaskListener;
 import hudson.model.EnvironmentContributor;
 import hudson.model.Run;
-import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
-import io.opentelemetry.context.Context;
-import io.opentelemetry.context.Scope;
-import io.opentelemetry.context.propagation.TextMapPropagator;
-import io.opentelemetry.context.propagation.TextMapSetter;
-import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import hudson.model.TaskListener;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.inject.Inject;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 @Extension
@@ -32,36 +21,10 @@ public class OtelEnvironmentContributor extends EnvironmentContributor {
 
     private OtelTraceService otelTraceService;
 
-    public static final String SPAN_ID = "SPAN_ID";
-    public static final String TRACE_ID = "TRACE_ID";
-
     @Override
     public void buildEnvironmentFor(@Nonnull Run run, @Nonnull EnvVars envs, @Nonnull TaskListener listener) {
-        if (run instanceof WorkflowRun) {
-            // skip, will be handle by OtelStepEnvironmentContributor
-            LOGGER.log(Level.FINER, () -> run.getFullDisplayName() + "buildEnvironmentFor(envs: " + envs + ") : skip, will be handled by OtelStepEnvironmentContributor");
-            return;
-        }
-        Span span = otelTraceService.getSpan(run);
-        String spanId = span.getSpanContext().getSpanId();
-        String traceId = span.getSpanContext().getTraceId();
-        try (Scope ignored = span.makeCurrent()) {
-            envs.put(TRACE_ID, traceId);
-            envs.put(SPAN_ID, spanId);
-            TextMapSetter<EnvVars> setter = (carrier, key, value) -> carrier.put(key.toUpperCase(), value);
-            W3CTraceContextPropagator.getInstance().inject(Context.current(), envs, setter);
-        }
-
-        MonitoringAction action = new MonitoringAction(traceId, spanId);
-        action.onAttached(run);
-        for (MonitoringAction.ObservabilityBackendLink link : action.getLinks()) {
-            // Default backend link got an empty environment variable.
-            if (link.getEnvironmentVariableName() != null) {
-                envs.put(link.getEnvironmentVariableName(), link.getUrl());
-            }
-        }
+        EnvironmentContributorUtils.setEnvironmentVariables(run, envs, otelTraceService.getSpan(run, false));
     }
-
 
     @Inject
     public void setOtelTraceService(OtelTraceService otelTraceService) {

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelStepEnvironmentContributor.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelStepEnvironmentContributor.java
@@ -33,8 +33,6 @@ public class OtelStepEnvironmentContributor extends StepEnvironmentContributor {
         Run run = stepContext.get(Run.class);
         FlowNode flowNode = stepContext.get(FlowNode.class);
 
-        EnvironmentContributorUtils.setEnvironmentVariables(run, envs, otelTraceService.getSpan(run, false));
-
         Span span;
         if (flowNode == null) {
             LOGGER.log(Level.WARNING, () -> run.getFullDisplayName() + "buildEnvironmentFor() NO flowNode found for context " + stepContext);

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelTraceService.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelTraceService.java
@@ -67,10 +67,17 @@ public class OtelTraceService {
 
     @Nonnull
     public Span getSpan(@Nonnull Run run) {
+        return getSpan(run, true);
+    }
+
+    @Nonnull
+    public Span getSpan(@Nonnull Run run, boolean verifyIfRemainingSteps) {
         RunIdentifier runIdentifier = RunIdentifier.fromRun(run);
         RunSpans runSpans = spansByRun.computeIfAbsent(runIdentifier, runIdentifier1 -> new RunSpans()); // absent when Jenkins restarts during build
 
-        verify(runSpans.pipelineStepSpansByFlowNodeId.isEmpty(), run.getFullDisplayName() + " - Can't access run phase span while there are remaining pipeline step spans: " + runSpans);
+        if (verifyIfRemainingSteps) {
+            verify(runSpans.pipelineStepSpansByFlowNodeId.isEmpty(), run.getFullDisplayName() + " - Can't access run phase span while there are remaining pipeline step spans: " + runSpans);
+        }
         LOGGER.log(Level.FINEST, () -> "getSpan(" + run.getFullDisplayName() + ") - " + runSpans);
         final Span span = Iterables.getLast(runSpans.runPhasesSpans, null);
         if (span == null) {

--- a/src/main/java/io/jenkins/plugins/opentelemetry/semconv/JenkinsOtelSemanticAttributes.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/semconv/JenkinsOtelSemanticAttributes.java
@@ -87,6 +87,9 @@ public final class JenkinsOtelSemanticAttributes {
     public static final String JENKINS_JOB_SPAN_PHASE_RUN_NAME = "Phase: Run";
     public static final String JENKINS_JOB_SPAN_PHASE_FINALIZE_NAME = "Phase: Finalise";
 
+    public static final String SPAN_ID = "SPAN_ID";
+    public static final String TRACE_ID = "TRACE_ID";
+
     public static final AttributeKey<String>        ELASTIC_TRANSACTION_TYPE = AttributeKey.stringKey("type");
 
 

--- a/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginIntegrationTest.java
@@ -177,8 +177,8 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
 
         // Environment variables are populated
         EnvVars environment = build.getEnvironment(new LogTaskListener(LOGGER, Level.INFO));
-        MatcherAssert.assertThat(environment.get("SPAN_ID"), CoreMatchers.is(CoreMatchers.notNullValue()));
-        MatcherAssert.assertThat(environment.get("TRACE_ID"), CoreMatchers.is(CoreMatchers.notNullValue()));
+        MatcherAssert.assertThat(environment.get(JenkinsOtelSemanticAttributes.SPAN_ID), CoreMatchers.is(CoreMatchers.notNullValue()));
+        MatcherAssert.assertThat(environment.get(JenkinsOtelSemanticAttributes.TRACE_ID), CoreMatchers.is(CoreMatchers.notNullValue()));
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginMBPIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginMBPIntegrationTest.java
@@ -72,7 +72,7 @@ public class JenkinsOtelPluginMBPIntegrationTest extends BaseIntegrationTest {
 
         // Environment variables are populated
         EnvVars environment = b1.getEnvironment(new LogTaskListener(LOGGER, Level.INFO));
-        MatcherAssert.assertThat(environment.get("SPAN_ID"), CoreMatchers.is(CoreMatchers.notNullValue()));
-        MatcherAssert.assertThat(environment.get("TRACE_ID"), CoreMatchers.is(CoreMatchers.notNullValue()));
+        MatcherAssert.assertThat(environment.get(JenkinsOtelSemanticAttributes.SPAN_ID), CoreMatchers.is(CoreMatchers.notNullValue()));
+        MatcherAssert.assertThat(environment.get(JenkinsOtelSemanticAttributes.TRACE_ID), CoreMatchers.is(CoreMatchers.notNullValue()));
     }
 }

--- a/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginMBPIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginMBPIntegrationTest.java
@@ -6,6 +6,9 @@
 package io.jenkins.plugins.opentelemetry;
 
 import com.github.rutledgepaulv.prune.Tree;
+import hudson.EnvVars;
+import hudson.model.Run;
+import hudson.util.LogTaskListener;
 import io.jenkins.plugins.opentelemetry.semconv.JenkinsOtelSemanticAttributes;
 import io.opentelemetry.api.common.Attributes;
 import jenkins.branch.BranchProperty;
@@ -20,8 +23,11 @@ import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class JenkinsOtelPluginMBPIntegrationTest extends BaseIntegrationTest {
+    private static final Logger LOGGER = Logger.getLogger(Run.class.getName());
 
     @Test
     public void testMultibranchPipelineStep() throws Exception {
@@ -63,5 +69,10 @@ public class JenkinsOtelPluginMBPIntegrationTest extends BaseIntegrationTest {
         MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.CI_PIPELINE_MULTIBRANCH_TYPE), CoreMatchers.is(OtelUtils.BRANCH));
         MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.CI_PIPELINE_TYPE), CoreMatchers.is(OtelUtils.MULTIBRANCH));
         MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.CI_PIPELINE_RUN_DESCRIPTION), CoreMatchers.is("Bar"));
+
+        // Environment variables are populated
+        EnvVars environment = b1.getEnvironment(new LogTaskListener(LOGGER, Level.INFO));
+        MatcherAssert.assertThat(environment.get("SPAN_ID"), CoreMatchers.is(CoreMatchers.notNullValue()));
+        MatcherAssert.assertThat(environment.get("TRACE_ID"), CoreMatchers.is(CoreMatchers.notNullValue()));
     }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->

### What

`env.TRACE_ID` and `env.SPAN_ID` were not accessible within the pipeline context, although it was possible to access them as environment variables in the context of a shell step for instance.

I refactored the common functionality to avoid duplicated code.

I updated the references in the README. Though IIUC, we might change the environment variable names to be OTEL compliance. 

### Tests

I manually tested with a freestyle job and a single pipeline.

#### Pipeline

```
pipeline {
    agent any
    stages {
        stage('Hello') {
            steps {
                echo env.TRACE_ID
                echo env.SPAN_ID
                echo env.OTEL_ELASTIC_URL
            }
        }
    }
}
```

Caused 

![image](https://user-images.githubusercontent.com/2871786/114757877-47a8f180-9d54-11eb-9e79-971251eb446d.png)


#### Freestyle

![image](https://user-images.githubusercontent.com/2871786/114757949-5a232b00-9d54-11eb-9d63-a2d9af116640.png)

Caused

![image](https://user-images.githubusercontent.com/2871786/114758158-8f2f7d80-9d54-11eb-9be9-1fefe8dc135c.png)


