### PR TITLE
Add plugin name and version attributes for the called step

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Here are few examples of architecture:
 | jenkins.pipeline.step.name       | Step name (user friendly) | String |
 | jenkins.pipeline.step.type       | Step name | String |
 | jenkins.pipeline.step.id         | Step id   | String |
+| jenkins.pipeline.step.plugin.name | Jenkins plugin for that particular step | String |
+| jenkins.pipeline.step.plugin.version| Jenkins plugin version | String |
 | jenkins.pipeline.step.node.label | Labels attached to the node | String |
 | git.branch                       | Git branch name | String |
 | git.repository                   | Git repository | String |

--- a/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
@@ -234,7 +234,7 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
     }
 
     @Nonnull
-    public StepPlugin findStepPluginOrDefault(@Nonnull String stepName, @Nonnull StepDescriptor descriptor) {
+    public StepPlugin findStepPluginOrDefault(@Nonnull String stepName, @Nullable StepDescriptor descriptor) {
         StepPlugin data = loadedStepsPlugins.get(stepName);
         if (data!=null) {
             LOGGER.log(Level.FINEST, " found the plugin for the step '" + stepName + "' - " + data);
@@ -243,7 +243,7 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
 
         data = new StepPlugin();
         Jenkins jenkins = Jenkins.getInstanceOrNull();
-        if (jenkins!=null) {
+        if (jenkins!=null && descriptor!=null) {
             PluginWrapper wrapper = jenkins.getPluginManager().whichPlugin(descriptor.clazz);
             if (wrapper!=null) {
                 data = new StepPlugin(wrapper.getShortName(), wrapper.getVersion());

--- a/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
@@ -19,6 +19,8 @@ import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepAtomNode;
+import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -223,6 +225,16 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
 
     @Nonnull
     public StepPlugin findStepPluginOrDefault(@Nonnull String stepName, @Nonnull StepAtomNode node) {
+        return findStepPluginOrDefault(stepName, node.getDescriptor());
+    }
+
+    @Nonnull
+    public StepPlugin findStepPluginOrDefault(@Nonnull String stepName, @Nonnull StepStartNode node) {
+        return findStepPluginOrDefault(stepName, node.getDescriptor());
+    }
+
+    @Nonnull
+    public StepPlugin findStepPluginOrDefault(@Nonnull String stepName, @Nonnull StepDescriptor descriptor) {
         StepPlugin data = loadedStepsPlugins.get(stepName);
         if (data!=null) {
             LOGGER.log(Level.FINEST, " found the plugin for the step '" + stepName + "' - " + data);
@@ -232,7 +244,7 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
         data = new StepPlugin();
         Jenkins jenkins = Jenkins.getInstanceOrNull();
         if (jenkins!=null) {
-            PluginWrapper wrapper = jenkins.getPluginManager().whichPlugin(node.getDescriptor().clazz);
+            PluginWrapper wrapper = jenkins.getPluginManager().whichPlugin(descriptor.clazz);
             if (wrapper!=null) {
                 data = new StepPlugin(wrapper.getShortName(), wrapper.getVersion());
                 addStepPlugin(stepName, data);

--- a/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
@@ -18,6 +18,7 @@ import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.workflow.cps.nodes.StepAtomNode;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -221,7 +222,7 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
     }
 
     @Nonnull
-    public StepPlugin findStepPlugin(String stepName, Class c) {
+    public StepPlugin findStepPluginOrDefault(@Nonnull String stepName, @Nonnull StepAtomNode node) {
         StepPlugin data = loadedStepsPlugins.get(stepName);
         if (data!=null) {
             LOGGER.log(Level.FINEST, " found the plugin for the step '" + stepName + "' - " + data);
@@ -231,7 +232,7 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
         data = new StepPlugin();
         Jenkins jenkins = Jenkins.getInstanceOrNull();
         if (jenkins!=null) {
-            PluginWrapper wrapper = jenkins.getPluginManager().whichPlugin(c);
+            PluginWrapper wrapper = jenkins.getPluginManager().whichPlugin(node.getDescriptor().clazz);
             if (wrapper!=null) {
                 data = new StepPlugin(wrapper.getShortName(), wrapper.getVersion());
                 addStepPlugin(stepName, data);

--- a/src/main/java/io/jenkins/plugins/opentelemetry/OpenTelemetryAttributesAction.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/OpenTelemetryAttributesAction.java
@@ -5,12 +5,20 @@
 
 package io.jenkins.plugins.opentelemetry;
 
+import hudson.PluginWrapper;
 import hudson.model.InvisibleAction;
+import io.jenkins.plugins.opentelemetry.job.MonitoringAction;
 import io.opentelemetry.api.common.AttributeKey;
+import jenkins.model.Jenkins;
 
 import javax.annotation.Nonnull;
+import javax.annotation.concurrent.Immutable;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /**
@@ -18,8 +26,10 @@ import java.util.stream.Collectors;
  * @see io.opentelemetry.api.common.AttributeType
  */
 public class OpenTelemetryAttributesAction extends InvisibleAction {
+    private final static Logger LOGGER = Logger.getLogger(MonitoringAction.class.getName());
 
     private transient Map<AttributeKey<?>, Object> attributes;
+    private ConcurrentMap<String, StepPlugin> loadedStepsPlugins = new ConcurrentHashMap<>();
 
     @Nonnull
     public Map<AttributeKey<?>, Object> getAttributes() {
@@ -29,10 +39,72 @@ public class OpenTelemetryAttributesAction extends InvisibleAction {
         return attributes;
     }
 
+    @Nonnull
+    public ConcurrentMap<String, StepPlugin> getLoadedStepsPlugins() {
+        return loadedStepsPlugins;
+    }
+
+    public void addStepPlugin(String stepName, StepPlugin c) {
+        loadedStepsPlugins.put(stepName, c);
+    }
+
+    @Nonnull
+    public StepPlugin findStepPlugin(String stepName, Class c) {
+        StepPlugin data = loadedStepsPlugins.get(stepName);
+        if (data!=null) {
+            LOGGER.log(Level.FINEST, " found the plugin for the step '" + stepName + "' - " + data);
+            return data;
+        }
+
+        data = new StepPlugin();
+        Jenkins jenkins = Jenkins.getInstanceOrNull();
+        if (jenkins!=null) {
+            PluginWrapper wrapper = jenkins.getPluginManager().whichPlugin(c);
+            if (wrapper!=null) {
+                data = new StepPlugin(wrapper.getShortName(), wrapper.getVersion());
+                addStepPlugin(stepName, data);
+            }
+        }
+        return data;
+    }
+
     @Override
     public String toString() {
         return "OpenTelemetryAttributesAction{" +
                 "attributes=" + getAttributes().entrySet().stream().map(e -> e.getKey().getKey() + "-" + e.getKey().getType() + " - " + e.getValue()).collect(Collectors.joining(", ")) +
+                "loadedSteps=" + getLoadedStepsPlugins().entrySet().stream().map(e -> e.getKey() + "-" + e.getValue()).collect(Collectors.joining(", ")) +
                 '}';
+    }
+
+    @Immutable
+    public static class StepPlugin {
+        final String name;
+        final String version;
+
+        public StepPlugin(String name, String version) {
+            this.name = name;
+            this.version = version;
+        }
+
+        public StepPlugin() {
+            this.name = "unknown";
+            this.version = "unknown";
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getVersion() {
+            return version;
+        }
+
+        @Override
+        public String toString() {
+            return "StepPlugin{" +
+                "name=" + name +
+                ", version=" + version +
+            '}';
+        }
     }
 }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/OpenTelemetryAttributesAction.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/OpenTelemetryAttributesAction.java
@@ -5,19 +5,13 @@
 
 package io.jenkins.plugins.opentelemetry;
 
-import hudson.PluginWrapper;
 import hudson.model.InvisibleAction;
 import io.jenkins.plugins.opentelemetry.job.MonitoringAction;
 import io.opentelemetry.api.common.AttributeKey;
-import jenkins.model.Jenkins;
 
 import javax.annotation.Nonnull;
-import javax.annotation.concurrent.Immutable;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -29,7 +23,6 @@ public class OpenTelemetryAttributesAction extends InvisibleAction {
     private final static Logger LOGGER = Logger.getLogger(MonitoringAction.class.getName());
 
     private transient Map<AttributeKey<?>, Object> attributes;
-    private ConcurrentMap<String, StepPlugin> loadedStepsPlugins = new ConcurrentHashMap<>();
 
     @Nonnull
     public Map<AttributeKey<?>, Object> getAttributes() {
@@ -39,72 +32,10 @@ public class OpenTelemetryAttributesAction extends InvisibleAction {
         return attributes;
     }
 
-    @Nonnull
-    public ConcurrentMap<String, StepPlugin> getLoadedStepsPlugins() {
-        return loadedStepsPlugins;
-    }
-
-    public void addStepPlugin(String stepName, StepPlugin c) {
-        loadedStepsPlugins.put(stepName, c);
-    }
-
-    @Nonnull
-    public StepPlugin findStepPlugin(String stepName, Class c) {
-        StepPlugin data = loadedStepsPlugins.get(stepName);
-        if (data!=null) {
-            LOGGER.log(Level.FINEST, " found the plugin for the step '" + stepName + "' - " + data);
-            return data;
-        }
-
-        data = new StepPlugin();
-        Jenkins jenkins = Jenkins.getInstanceOrNull();
-        if (jenkins!=null) {
-            PluginWrapper wrapper = jenkins.getPluginManager().whichPlugin(c);
-            if (wrapper!=null) {
-                data = new StepPlugin(wrapper.getShortName(), wrapper.getVersion());
-                addStepPlugin(stepName, data);
-            }
-        }
-        return data;
-    }
-
     @Override
     public String toString() {
         return "OpenTelemetryAttributesAction{" +
                 "attributes=" + getAttributes().entrySet().stream().map(e -> e.getKey().getKey() + "-" + e.getKey().getType() + " - " + e.getValue()).collect(Collectors.joining(", ")) +
-                "loadedSteps=" + getLoadedStepsPlugins().entrySet().stream().map(e -> e.getKey() + "-" + e.getValue()).collect(Collectors.joining(", ")) +
                 '}';
-    }
-
-    @Immutable
-    public static class StepPlugin {
-        final String name;
-        final String version;
-
-        public StepPlugin(String name, String version) {
-            this.name = name;
-            this.version = version;
-        }
-
-        public StepPlugin() {
-            this.name = "unknown";
-            this.version = "unknown";
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        public String getVersion() {
-            return version;
-        }
-
-        @Override
-        public String toString() {
-            return "StepPlugin{" +
-                "name=" + name +
-                ", version=" + version +
-            '}';
-        }
     }
 }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
@@ -160,12 +160,7 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
             }
 
             String stepName = getStepName(node.getDescriptor(), "step");
-            JenkinsOpenTelemetryPluginConfiguration.StepPlugin stepPlugin = new JenkinsOpenTelemetryPluginConfiguration.StepPlugin();
-            try {
-                stepPlugin = JenkinsOpenTelemetryPluginConfiguration.get().findStepPlugin(stepName, node.getDescriptor().clazz);
-            } catch (Exception e) {
-                LOGGER.log(Level.FINE, () -> " Plugin name and version could not be discovered for the step " + stepName);
-            }
+            JenkinsOpenTelemetryPluginConfiguration.StepPlugin stepPlugin = JenkinsOpenTelemetryPluginConfiguration.get().findStepPluginOrDefault(stepName, node);
 
             spanBuilder
                     .setParent(Context.current())

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
@@ -68,12 +68,6 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
     }
 
     @Override
-    public void onStartPipeline(@Nonnull FlowNode node, @Nonnull WorkflowRun run) {
-        OpenTelemetryAttributesAction openTelemetryAttributesAction = new OpenTelemetryAttributesAction();
-        run.addAction(openTelemetryAttributesAction);
-    }
-
-    @Override
     public void onStartNodeStep(@Nonnull StepStartNode stepStartNode, @Nullable String nodeLabel, @Nonnull WorkflowRun run) {
         try (Scope nodeSpanScope = setupContext(run, stepStartNode)) {
             verifyNotNull(nodeSpanScope, "%s - No span found for node %s", run, stepStartNode);
@@ -165,11 +159,10 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
                 spanBuilder = getTracer().spanBuilder(node.getDisplayFunctionName());
             }
 
-            OpenTelemetryAttributesAction openTelemetryAttributesAction = run.getAction(OpenTelemetryAttributesAction.class);
             String stepName = getStepName(node.getDescriptor(), "step");
-            OpenTelemetryAttributesAction.StepPlugin stepPlugin = new OpenTelemetryAttributesAction.StepPlugin();
+            JenkinsOpenTelemetryPluginConfiguration.StepPlugin stepPlugin = new JenkinsOpenTelemetryPluginConfiguration.StepPlugin();
             try {
-                stepPlugin = openTelemetryAttributesAction.findStepPlugin(stepName, node.getDescriptor().clazz);
+                stepPlugin = JenkinsOpenTelemetryPluginConfiguration.get().findStepPlugin(stepName, node.getDescriptor().clazz);
             } catch (Exception e) {
                 LOGGER.log(Level.FINE, () -> " Plugin name and version could not be discovered for the step " + stepName);
             }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
@@ -168,7 +168,7 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
             try {
                 Jenkins jenkins = Jenkins.getInstanceOrNull();
                 if (jenkins != null) {
-                    PluginWrapper wrapper = jenkins.getPluginManager().whichPlugin(((StepAtomNode) node).getDescriptor().clazz);
+                    PluginWrapper wrapper = jenkins.getPluginManager().whichPlugin(node.getDescriptor().clazz);
                     pluginName = wrapper.getShortName();
                     pluginVersion = wrapper.getVersion();
                 }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
@@ -162,17 +162,18 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
                 spanBuilder = getTracer().spanBuilder(node.getDisplayFunctionName());
             }
 
+            String stepName = getStepName(node.getDescriptor(), "step");
             String pluginName = "unknown";
             String pluginVersion = "unknown";
             try {
                 Jenkins jenkins = Jenkins.getInstanceOrNull();
                 if (jenkins != null) {
-                    PluginWrapper wrapper = jenkins.getPluginManager().whichPlugin(Objects.requireNonNull(((StepAtomNode) node).getDescriptor()).clazz);
+                    PluginWrapper wrapper = jenkins.getPluginManager().whichPlugin(((StepAtomNode) node).getDescriptor().clazz);
                     pluginName = wrapper.getShortName();
                     pluginVersion = wrapper.getVersion();
                 }
             } catch (Exception e) {
-                LOGGER.log(Level.FINE, () -> " Plugin name and version could not be discovered");
+                LOGGER.log(Level.FINE, () -> " Plugin name and version could not be discovered for the step " + stepName);
             }
 
             spanBuilder

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
@@ -110,6 +110,7 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
         try (Scope ignored = setupContext(run, stepStartNode)) {
             verifyNotNull(ignored, "%s - No span found for node %s", run, stepStartNode);
             String spanStageName = "Stage: " + stageName;
+
             Span stageSpan = getTracer().spanBuilder(spanStageName)
                     .setParent(Context.current())
                     .setAttribute(JenkinsOtelSemanticAttributes.JENKINS_STEP_TYPE, getStepType(stepStartNode.getDescriptor(), "stage"))
@@ -159,14 +160,14 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
                 spanBuilder = getTracer().spanBuilder(node.getDisplayFunctionName());
             }
 
-            String stepName = getStepName(node.getDescriptor(), "step");
-            JenkinsOpenTelemetryPluginConfiguration.StepPlugin stepPlugin = JenkinsOpenTelemetryPluginConfiguration.get().findStepPluginOrDefault(stepName, node);
+            String stepType = getStepType(node.getDescriptor(), "step");
+            JenkinsOpenTelemetryPluginConfiguration.StepPlugin stepPlugin = JenkinsOpenTelemetryPluginConfiguration.get().findStepPluginOrDefault(stepType, node);
 
             spanBuilder
                     .setParent(Context.current())
-                    .setAttribute(JenkinsOtelSemanticAttributes.JENKINS_STEP_TYPE, getStepType(node.getDescriptor(), "step"))
+                    .setAttribute(JenkinsOtelSemanticAttributes.JENKINS_STEP_TYPE, stepType)
                     .setAttribute(JenkinsOtelSemanticAttributes.JENKINS_STEP_ID, node.getId())
-                    .setAttribute(JenkinsOtelSemanticAttributes.JENKINS_STEP_NAME, stepName)
+                    .setAttribute(JenkinsOtelSemanticAttributes.JENKINS_STEP_NAME, getStepName(node.getDescriptor(), "step"))
                     .setAttribute(JenkinsOtelSemanticAttributes.CI_PIPELINE_RUN_USER, principal)
                     .setAttribute(JenkinsOtelSemanticAttributes.JENKINS_STEP_PLUGIN_NAME, stepPlugin.getName())
                     .setAttribute(JenkinsOtelSemanticAttributes.JENKINS_STEP_PLUGIN_VERSION, stepPlugin.getVersion());

--- a/src/main/java/io/jenkins/plugins/opentelemetry/semconv/JenkinsOtelSemanticAttributes.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/semconv/JenkinsOtelSemanticAttributes.java
@@ -5,6 +5,7 @@
 
 package io.jenkins.plugins.opentelemetry.semconv;
 
+import hudson.PluginWrapper;
 import hudson.model.Computer;
 import io.opentelemetry.api.common.AttributeKey;
 import jenkins.model.Jenkins;
@@ -60,6 +61,14 @@ public final class JenkinsOtelSemanticAttributes {
      * @see org.jenkinsci.plugins.workflow.graph.FlowNode#getId()
      */
     public static final AttributeKey<String>        JENKINS_STEP_ID = AttributeKey.stringKey("jenkins.pipeline.step.id");
+    /**
+     * @see PluginWrapper#getShortName()
+     */
+    public static final AttributeKey<String>        JENKINS_STEP_PLUGIN_NAME = AttributeKey.stringKey("jenkins.pipeline.step.plugin.name");
+    /**
+     * @see PluginWrapper#getVersion()
+     */
+    public static final AttributeKey<String>        JENKINS_STEP_PLUGIN_VERSION = AttributeKey.stringKey("jenkins.pipeline.step.plugin.version");
     /**
      * @see Computer#getName()
      */

--- a/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginIntegrationTest.java
@@ -325,6 +325,8 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
 
         Attributes attributes = gitNode.get().getData().spanData.getAttributes();
         MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.GIT_USERNAME), CoreMatchers.is(gitUserName));
+        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.JENKINS_STEP_PLUGIN_NAME), CoreMatchers.is("git"));
+        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.JENKINS_STEP_PLUGIN_VERSION), CoreMatchers.is(CoreMatchers.notNullValue()));
     }
 
 }

--- a/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginIntegrationTest.java
@@ -139,11 +139,15 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
 
         Attributes attributes = executorNodeAllocation.get().getData().spanData.getAttributes();
         MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.JENKINS_STEP_NODE_LABEL), CoreMatchers.is("linux"));
+        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.JENKINS_STEP_PLUGIN_NAME), CoreMatchers.is(CoreMatchers.notNullValue()));
+        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.JENKINS_STEP_PLUGIN_VERSION), CoreMatchers.is(CoreMatchers.notNullValue()));
 
         Optional<Tree.Node<SpanDataWrapper>> executorNode = spans.breadthFirstSearchNodes(node -> "Node: linux".equals(node.getData().spanData.getName()));
         MatcherAssert.assertThat(executorNode, CoreMatchers.is(CoreMatchers.notNullValue()));
         attributes = executorNode.get().getData().spanData.getAttributes();
         MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.JENKINS_STEP_NODE_LABEL), CoreMatchers.is("linux"));
+        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.JENKINS_STEP_PLUGIN_NAME), CoreMatchers.is(CoreMatchers.notNullValue()));
+        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.JENKINS_STEP_PLUGIN_VERSION), CoreMatchers.is(CoreMatchers.notNullValue()));
 
         List<SpanDataWrapper> root = spans.byDepth().get(0);
         attributes = root.get(0).spanData.getAttributes();
@@ -183,7 +187,7 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
                 "    }\n" +
                 "}";
 
-        final Node node = jenkinsRule.createOnlineSlave();
+        final Node agent = jenkinsRule.createOnlineSlave();
 
         WorkflowJob pipeline = jenkinsRule.createProject(WorkflowJob.class, "test-pipeline-with-skipped-tests-" + jobNameSuffix.incrementAndGet());
         pipeline.setDefinition(new CpsFlowDefinition(pipelineScript, true));
@@ -193,6 +197,13 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
         checkChainOfSpans(spans, "shell-1", "Stage: ze-stage1", "Node", "Phase: Run");
         checkChainOfSpans(spans, "shell-2", "Stage: ze-stage2", "Node", "Phase: Run");
         MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(10L));
+
+        Optional<Tree.Node<SpanDataWrapper>> stageNode = spans.breadthFirstSearchNodes(node -> "Stage: ze-stage1".equals(node.getData().spanData.getName()));
+        MatcherAssert.assertThat(stageNode, CoreMatchers.is(CoreMatchers.notNullValue()));
+
+        Attributes attributes = stageNode.get().getData().spanData.getAttributes();
+        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.JENKINS_STEP_PLUGIN_NAME), CoreMatchers.is(CoreMatchers.notNullValue()));
+        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.JENKINS_STEP_PLUGIN_VERSION), CoreMatchers.is(CoreMatchers.notNullValue()));
     }
 
     @Test
@@ -267,7 +278,7 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
                 "        }\n" +
                 "    }\n" +
                 "}";
-        final Node node = jenkinsRule.createOnlineSlave();
+        final Node agent = jenkinsRule.createOnlineSlave();
 
         WorkflowJob pipeline = jenkinsRule.createProject(WorkflowJob.class, "test-pipeline-with-parallel-step" + jobNameSuffix.incrementAndGet());
         pipeline.setDefinition(new CpsFlowDefinition(pipelineScript, true));
@@ -279,6 +290,12 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
         checkChainOfSpans(spans, "shell-3", "Parallel branch: parallelBranch3", "Stage: ze-parallel-stage", "Node", "Phase: Run");
         MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(13L));
 
+        Optional<Tree.Node<SpanDataWrapper>> branchNode = spans.breadthFirstSearchNodes(node -> "Parallel branch: parallelBranch1".equals(node.getData().spanData.getName()));
+        MatcherAssert.assertThat(branchNode, CoreMatchers.is(CoreMatchers.notNullValue()));
+
+        Attributes attributes = branchNode.get().getData().spanData.getAttributes();
+        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.JENKINS_STEP_PLUGIN_NAME), CoreMatchers.is(CoreMatchers.notNullValue()));
+        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.JENKINS_STEP_PLUGIN_VERSION), CoreMatchers.is(CoreMatchers.notNullValue()));
     }
 
     @Test


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->

### What

Add plugin and version span attributes for the called step with some caching.

### Issue

Closes https://github.com/jenkinsci/opentelemetry-plugin/issues/70


### Tasks

- [x] Cache the existing steps/plugin matches for the current Run. See https://github.com/jenkinsci/opentelemetry-plugin/pull/72/commits/f6cdd4560464c076915f320c22f02e086a9e9f58
- [x] Cache the steps/plugin globally.

### Test

#### Git step

<details><summary>Expand to view</summary>
<p>

![image](https://user-images.githubusercontent.com/2871786/114761758-d586db80-9d58-11eb-9f14-0e1b29975770.png)

</p>
</details>

#### Node step

<details><summary>Expand to view</summary>
<p>

![image](https://user-images.githubusercontent.com/2871786/115146204-6b6a8100-a04d-11eb-9db4-09d98e49c141.png)

</p>
</details>

#### Branch step

<details><summary>Expand to view</summary>
<p>

![image](https://user-images.githubusercontent.com/2871786/115146224-78877000-a04d-11eb-803d-a55c48e9e893.png)

</p>
</details>

#### Archive step

<details><summary>Expand to view</summary>
<p>

![image](https://user-images.githubusercontent.com/2871786/114767347-6cef2d00-9d5f-11eb-8506-b601eff15541.png)

</p>
</details>

#### Global caching

If I run the same pipeline twice:

```
pipeline {
    agent any
    stages {
        stage('Build') {
            steps {
                git 'https://github.com/jglick/simple-maven-project-with-tests.git'
                echo 'hi'
                sh "touch file.1"
                sh "touch file.2"
            }
            post {
                success {
                    archiveArtifacts 'file.1'
                    archiveArtifacts 'file.2'
                }
            }
        }
    }
}
```

![image](https://user-images.githubusercontent.com/2871786/115009016-b9438580-9ea3-11eb-9fec-615a006e9eb4.png)


I run some parallel builds from different jobs and it looks good and stable with the caching:

![image](https://user-images.githubusercontent.com/2871786/115009778-8a79df00-9ea4-11eb-9f28-30db5a28f68f.png)
