### PR TITLE
Monitor disk usage metrics for the JENKINS_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ In addition, if the backends were configured then there will be an environment v
 | jenkins.agents.total             | Number of agents|
 | jenkins.agents.online            | Number of online agents |
 | jenkins.agents.offline           | Number of offline agents |
-| jenkins.disk.usage               | Disk Usage size in bytes |
+| jenkins.disk.usage.bytes         | Disk Usage size |
 
 
 Jenkins metrics can be visualised with any OpenTelemetry compatible metrics solution such as [Prometheus](https://prometheus.io/) or [Elastic Observability](https://www.elastic.co/observability)

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ In addition, if the backends were configured then there will be an environment v
 | jenkins.agents.total             | Number of agents|
 | jenkins.agents.online            | Number of online agents |
 | jenkins.agents.offline           | Number of offline agents |
+| jenkins.disk.usage               | Disk Usage size in bytes |
 
 
 Jenkins metrics can be visualised with any OpenTelemetry compatible metrics solution such as [Prometheus](https://prometheus.io/) or [Elastic Observability](https://www.elastic.co/observability)

--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,12 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>cloudbees-disk-usage-simple</artifactId>
+            <version>0.10</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-stage-step</artifactId>
         </dependency>
         <dependency>

--- a/src/main/java/io/jenkins/plugins/opentelemetry/computer/MonitoringComputerListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/computer/MonitoringComputerListener.java
@@ -83,16 +83,16 @@ public class MonitoringComputerListener extends ComputerListener {
         if (jenkins != null) {
             QuickDiskUsagePlugin diskUsagePlugin = jenkins.getPlugin(QuickDiskUsagePlugin.class);
             if (diskUsagePlugin != null) {
-                meter.longValueObserverBuilder(JenkinsSemanticMetrics.JENKINS_DISK_USAGE)
+                meter.longValueObserverBuilder(JenkinsSemanticMetrics.JENKINS_DISK_USAGE_BYTES)
                         .setDescription("Disk usage of first level folder in JENKINS_HOME.")
                         .setUnit("byte")
-                        .setUpdater(result -> result.observe(calculateDiskUsage(diskUsagePlugin), Labels.empty()))
+                        .setUpdater(result -> result.observe(calculateDiskUsageInBytes(diskUsagePlugin), Labels.empty()))
                         .build();
             }
         }
     }
 
-    private long calculateDiskUsage(QuickDiskUsagePlugin diskUsagePlugin) {
+    private long calculateDiskUsageInBytes(QuickDiskUsagePlugin diskUsagePlugin) {
         try {
             DiskItem disk = diskUsagePlugin.getDirectoriesUsages()
                     .stream()

--- a/src/main/java/io/jenkins/plugins/opentelemetry/queue/MonitoringQueueListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/queue/MonitoringQueueListener.java
@@ -5,12 +5,15 @@
 
 package io.jenkins.plugins.opentelemetry.queue;
 
+import com.cloudbees.simplediskusage.DiskItem;
+import com.cloudbees.simplediskusage.QuickDiskUsagePlugin;
 import hudson.Extension;
 import hudson.model.Queue;
 import hudson.model.queue.QueueListener;
 import io.jenkins.plugins.opentelemetry.OpenTelemetrySdkProvider;
 import io.jenkins.plugins.opentelemetry.semconv.JenkinsSemanticMetrics;
 import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongValueObserver;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.common.Labels;
 import jenkins.model.Jenkins;
@@ -18,7 +21,7 @@ import jenkins.model.Jenkins;
 import javax.annotation.Nonnull;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
-import java.util.Arrays;
+import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -38,6 +41,7 @@ public class MonitoringQueueListener extends QueueListener {
     private final AtomicInteger buildableItemGauge = new AtomicInteger();
     private LongCounter leftItemCounter;
     private LongCounter timeInQueueInMillisCounter;
+    private LongValueObserver diskObserver;
 
     @PostConstruct
     public void postConstruct() {
@@ -64,6 +68,33 @@ public class MonitoringQueueListener extends QueueListener {
                 .setDescription("Total time spent in queue by items")
                 .setUnit("ms")
                 .build();
+        Jenkins jenkins = Jenkins.getInstanceOrNull();
+        if (jenkins != null) {
+            QuickDiskUsagePlugin diskUsagePlugin = jenkins.getPlugin(QuickDiskUsagePlugin.class);
+            if (diskUsagePlugin != null) {
+                diskObserver = meter.longValueObserverBuilder(JenkinsSemanticMetrics.JENKINS_DISK_USAGE)
+                        .setDescription("Disk usage of first level folder in JENKINS_HOME.")
+                        .setUnit("byte")
+                        .setUpdater(result -> result.observe(calculateDiskUsage(diskUsagePlugin), Labels.empty()))
+                        .build();
+            }
+        }
+    }
+
+    private long calculateDiskUsage(QuickDiskUsagePlugin diskUsagePlugin) {
+        try {
+            DiskItem disk = diskUsagePlugin.getDirectoriesUsages()
+                    .stream()
+                    .filter(x -> x.getDisplayName().equals("JENKINS_HOME"))
+                    .findFirst()
+                    .orElse(null);
+            if (disk != null) {
+                return disk.getUsage() * 1024;
+            }
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, e, () -> "Exception invoking `diskUsagePlugin.getDirectoriesUsages()`");
+        }
+        return 0;
     }
 
     private long getUnblockedItemsSize() {

--- a/src/main/java/io/jenkins/plugins/opentelemetry/semconv/JenkinsSemanticMetrics.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/semconv/JenkinsSemanticMetrics.java
@@ -19,7 +19,7 @@ public class JenkinsSemanticMetrics {
     public static final String JENKINS_AGENTS_TOTAL =               "jenkins.agents.total";
     public static final String JENKINS_AGENTS_ONLINE =              "jenkins.agents.online";
     public static final String JENKINS_AGENTS_OFFLINE =             "jenkins.agents.offline";
-    public static final String JENKINS_DISK_USAGE =                 "jenkins.disk.usage";
+    public static final String JENKINS_DISK_USAGE_BYTES =           "jenkins.disk.usage.bytes";
 
     private JenkinsSemanticMetrics(){}
 }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/semconv/JenkinsSemanticMetrics.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/semconv/JenkinsSemanticMetrics.java
@@ -19,6 +19,7 @@ public class JenkinsSemanticMetrics {
     public static final String JENKINS_AGENTS_TOTAL =               "jenkins.agents.total";
     public static final String JENKINS_AGENTS_ONLINE =              "jenkins.agents.online";
     public static final String JENKINS_AGENTS_OFFLINE =             "jenkins.agents.offline";
+    public static final String JENKINS_DISK_USAGE =                 "jenkins.disk.usage";
 
     private JenkinsSemanticMetrics(){}
 }

--- a/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginIntegrationTest.java
@@ -85,9 +85,6 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
 
     @Test
     public void testMetricsWithoutDiskUsagePlugin() throws Exception {
-        FreeStyleProject project = jenkinsRule.createFreeStyleProject();
-
-        FreeStyleBuild build = jenkinsRule.buildAndAssertSuccess(project);
         // WORKAROUND because we don't know how to force the IntervalMetricReader to collect metrics
         Thread.sleep(600);
         Map<String, MetricData> exportedMetrics = ((InMemoryMetricExporter) OpenTelemetrySdkProvider.TESTING_METRICS_EXPORTER).getLastExportedMetricByMetricName();

--- a/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginIntegrationTest.java
@@ -81,7 +81,18 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
         MatcherAssert.assertThat(runCompletedCounterData.getType(), CoreMatchers.is(MetricDataType.LONG_SUM));
         Collection<LongPointData> metricPoints = runCompletedCounterData.getLongSumData().getPoints();
         //MatcherAssert.assertThat(Iterables.getLast(metricPoints).getValue(), CoreMatchers.is(1L));
+    }
 
+    @Test
+    public void testMetricsWithoutDiskUsagePlugin() throws Exception {
+        FreeStyleProject project = jenkinsRule.createFreeStyleProject();
+
+        FreeStyleBuild build = jenkinsRule.buildAndAssertSuccess(project);
+        // WORKAROUND because we don't know how to force the IntervalMetricReader to collect metrics
+        Thread.sleep(600);
+        Map<String, MetricData> exportedMetrics = ((InMemoryMetricExporter) OpenTelemetrySdkProvider.TESTING_METRICS_EXPORTER).getLastExportedMetricByMetricName();
+        dumpMetrics(exportedMetrics);
+        MatcherAssert.assertThat(exportedMetrics.get(JenkinsSemanticMetrics.JENKINS_DISK_USAGE), CoreMatchers.nullValue());
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginIntegrationTest.java
@@ -92,7 +92,7 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
         Thread.sleep(600);
         Map<String, MetricData> exportedMetrics = ((InMemoryMetricExporter) OpenTelemetrySdkProvider.TESTING_METRICS_EXPORTER).getLastExportedMetricByMetricName();
         dumpMetrics(exportedMetrics);
-        MetricData diskUsageData = exportedMetrics.get(JenkinsSemanticMetrics.JENKINS_DISK_USAGE);
+        MetricData diskUsageData = exportedMetrics.get(JenkinsSemanticMetrics.JENKINS_DISK_USAGE_BYTES);
         MatcherAssert.assertThat(diskUsageData, CoreMatchers.notNullValue());
         // TODO TEST METRICS WITH PROPER RESET BETWEEN TESTS
         MatcherAssert.assertThat(diskUsageData.getType(), CoreMatchers.is(MetricDataType.LONG_GAUGE));


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

## What

Add disk usage metrics for the JENKINS_HOME. 

Metric id `jenkins.disk.usage`

I've decided to use the `MonitoringComputerListener` instead creating it somewhere else or using any Periodic Jenkins task since `setUpdater` was something useful for this particular context.

## Manual Tests

![image](https://user-images.githubusercontent.com/2871786/116621150-a6689080-a93a-11eb-9649-55bcc49e3a1c.png)

## Issues

Closes https://github.com/jenkinsci/opentelemetry-plugin/issues/74
