### PR TITLE
Enforce default observability backend name if empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,13 +271,17 @@ unclassified:
     observabilityBackends:
       - elastic:
           kibanaBaseUrl: "http://localhost:5601"
+          name: "Elastic Observability"
       - jaeger:
           jaegerBaseUrl: "http://localhost:16686"
+          name: "Jaeger"
       - customObservabilityBackend:
           metricsVisualisationUrlTemplate: "foo"
           traceVisualisationUrlTemplate: "http://example.com"
+          name: "Custom Observability"
       - zipkin:
           zipkinBaseUrl: "http://localhost:9411/"
+          name: "Zipkin"
     serviceName: "jenkins"
     serviceNamespace: "jenkins"
 ```

--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/CustomObservabilityBackend.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/CustomObservabilityBackend.java
@@ -65,6 +65,12 @@ public class CustomObservabilityBackend extends ObservabilityBackend {
         return OTEL_CUSTOM_URL;
     }
 
+    @CheckForNull
+    @Override
+    public String getDefaultName() {
+        return "Custom Observability Backend";
+    }
+
     @Override
     public String toString() {
         return "CustomBackend{" +

--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/CustomObservabilityBackend.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/CustomObservabilityBackend.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 public class CustomObservabilityBackend extends ObservabilityBackend {
 
     public static final String OTEL_CUSTOM_URL = "OTEL_CUSTOM_URL";
+    public static final String DEFAULT_NAME = "Custom Observability Backend";
     private String traceVisualisationUrlTemplate;
     private String metricsVisualisationUrlTemplate;
 
@@ -68,7 +69,7 @@ public class CustomObservabilityBackend extends ObservabilityBackend {
     @CheckForNull
     @Override
     public String getDefaultName() {
-        return "Custom Observability Backend";
+        return DEFAULT_NAME;
     }
 
     @Override
@@ -97,7 +98,7 @@ public class CustomObservabilityBackend extends ObservabilityBackend {
     public static class DescriptorImpl extends ObservabilityBackendDescriptor {
         @Override
         public String getDisplayName() {
-            return "Custom Observability Backend";
+            return DEFAULT_NAME;
         }
 
         /**

--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/ElasticBackend.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/ElasticBackend.java
@@ -68,6 +68,12 @@ public class ElasticBackend extends ObservabilityBackend {
 
     @CheckForNull
     @Override
+    public String getDefaultName() {
+        return "Elastic Observability";
+    }
+
+    @CheckForNull
+    @Override
     public String getMetricsVisualisationUrlTemplate() {
         return null;
     }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/ElasticBackend.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/ElasticBackend.java
@@ -18,6 +18,7 @@ import java.util.Map;
 public class ElasticBackend extends ObservabilityBackend {
 
     public static final String OTEL_ELASTIC_URL = "OTEL_ELASTIC_URL";
+    public static final String DEFAULT_NAME = "Elastic Observability";
     private String kibanaBaseUrl;
 
     @DataBoundConstructor
@@ -69,7 +70,7 @@ public class ElasticBackend extends ObservabilityBackend {
     @CheckForNull
     @Override
     public String getDefaultName() {
-        return "Elastic Observability";
+        return DEFAULT_NAME;
     }
 
     @CheckForNull
@@ -93,8 +94,7 @@ public class ElasticBackend extends ObservabilityBackend {
     public static class DescriptorImpl extends ObservabilityBackendDescriptor {
         @Override
         public String getDisplayName() {
-            return "Elastic Observability";
+            return DEFAULT_NAME;
         }
     }
-
 }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/JaegerBackend.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/JaegerBackend.java
@@ -61,6 +61,12 @@ public class JaegerBackend extends ObservabilityBackend {
 
     @CheckForNull
     @Override
+    public String getDefaultName() {
+        return "Jaeger";
+    }
+
+    @CheckForNull
+    @Override
     public String getMetricsVisualisationUrlTemplate() {
         return null;
     }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/JaegerBackend.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/JaegerBackend.java
@@ -18,6 +18,8 @@ import java.util.Map;
 public class JaegerBackend extends ObservabilityBackend {
 
     public static final String OTEL_JAEGER_URL = "OTEL_JAEGER_URL";
+    public static final String DEFAULT_NAME = "Jaeger";
+
 	private String jaegerBaseUrl;
 
     @DataBoundConstructor
@@ -62,7 +64,7 @@ public class JaegerBackend extends ObservabilityBackend {
     @CheckForNull
     @Override
     public String getDefaultName() {
-        return "Jaeger";
+        return DEFAULT_NAME;
     }
 
     @CheckForNull
@@ -86,7 +88,7 @@ public class JaegerBackend extends ObservabilityBackend {
     public static class DescriptorImpl extends ObservabilityBackendDescriptor {
         @Override
         public String getDisplayName() {
-            return "Jaeger";
+            return DEFAULT_NAME;
         }
     }
 }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/ObservabilityBackend.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/ObservabilityBackend.java
@@ -42,6 +42,9 @@ public abstract class ObservabilityBackend implements Describable<ObservabilityB
     @CheckForNull
     public abstract String getEnvVariableName();
 
+    @CheckForNull
+    public abstract String getDefaultName();
+
     @Override
     public abstract boolean equals(Object obj);
 
@@ -51,7 +54,7 @@ public abstract class ObservabilityBackend implements Describable<ObservabilityB
     public abstract Map<String, Object> mergeBindings(Map<String, Object> bindings);
 
     public String getName() {
-        return name;
+        return Strings.isNullOrEmpty(name) ? getDefaultName() : name;
     }
 
     @DataBoundSetter

--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/ZipkinBackend.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/ZipkinBackend.java
@@ -65,6 +65,12 @@ public class ZipkinBackend extends ObservabilityBackend {
 
     @CheckForNull
     @Override
+    public String getDefaultName() {
+        return "Zipkin";
+    }
+
+    @CheckForNull
+    @Override
     public String getMetricsVisualisationUrlTemplate() {
         return null;
     }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/ZipkinBackend.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/ZipkinBackend.java
@@ -18,6 +18,7 @@ import java.util.Map;
 public class ZipkinBackend extends ObservabilityBackend {
 
     public static final String OTEL_ZIPKIN_URL = "OTEL_ZIPKIN_URL";
+    public static final String DEFAULT_NAME = "Zipkin";
 	private String zipkinBaseUrl;
 
     @DataBoundConstructor
@@ -66,7 +67,7 @@ public class ZipkinBackend extends ObservabilityBackend {
     @CheckForNull
     @Override
     public String getDefaultName() {
-        return "Zipkin";
+        return DEFAULT_NAME;
     }
 
     @CheckForNull
@@ -90,7 +91,7 @@ public class ZipkinBackend extends ObservabilityBackend {
     public static class DescriptorImpl extends ObservabilityBackendDescriptor {
         @Override
         public String getDisplayName() {
-            return "Zipkin";
+            return DEFAULT_NAME;
         }
     }
 }

--- a/src/test/java/io/jenkins/plugins/opentelemetry/jcasc/ConfigurationAsCodeDefaultTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/jcasc/ConfigurationAsCodeDefaultTest.java
@@ -13,6 +13,7 @@ import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.opentelemetry.JenkinsOpenTelemetryPluginConfiguration;
 import io.jenkins.plugins.opentelemetry.authentication.NoAuthentication;
 import io.jenkins.plugins.opentelemetry.authentication.OtlpAuthentication;
+import io.jenkins.plugins.opentelemetry.backend.CustomObservabilityBackend;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import jenkins.model.GlobalConfiguration;
 import org.hamcrest.CoreMatchers;
@@ -38,6 +39,11 @@ public class ConfigurationAsCodeDefaultTest {
         final JenkinsOpenTelemetryPluginConfiguration configuration = GlobalConfiguration.all().get(JenkinsOpenTelemetryPluginConfiguration.class);
 
         MatcherAssert.assertThat(configuration.getEndpoint(), CoreMatchers.is("http://otel-collector-contrib:4317"));
+
+        CustomObservabilityBackend custom = (CustomObservabilityBackend) configuration.getObservabilityBackends().get(0);
+        MatcherAssert.assertThat(custom.getMetricsVisualisationUrlTemplate(), CoreMatchers.is("foo"));
+        MatcherAssert.assertThat(custom.getTraceVisualisationUrlTemplate(), CoreMatchers.is("http://example.com"));
+        MatcherAssert.assertThat(custom.getName(), CoreMatchers.is("Custom Observability Backend"));
 
         OtlpAuthentication authentication = configuration.getAuthentication();
         MatcherAssert.assertThat(authentication, CoreMatchers.is(instanceOf(NoAuthentication.class)));

--- a/src/test/java/io/jenkins/plugins/opentelemetry/jcasc/ConfigurationAsCodeDefaultTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/jcasc/ConfigurationAsCodeDefaultTest.java
@@ -43,7 +43,7 @@ public class ConfigurationAsCodeDefaultTest {
         CustomObservabilityBackend custom = (CustomObservabilityBackend) configuration.getObservabilityBackends().get(0);
         MatcherAssert.assertThat(custom.getMetricsVisualisationUrlTemplate(), CoreMatchers.is("foo"));
         MatcherAssert.assertThat(custom.getTraceVisualisationUrlTemplate(), CoreMatchers.is("http://example.com"));
-        MatcherAssert.assertThat(custom.getName(), CoreMatchers.is("Custom Observability Backend"));
+        MatcherAssert.assertThat(custom.getName(), CoreMatchers.is(CustomObservabilityBackend.DEFAULT_NAME));
 
         OtlpAuthentication authentication = configuration.getAuthentication();
         MatcherAssert.assertThat(authentication, CoreMatchers.is(instanceOf(NoAuthentication.class)));

--- a/src/test/java/io/jenkins/plugins/opentelemetry/jcasc/ConfigurationAsCodeTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/jcasc/ConfigurationAsCodeTest.java
@@ -43,16 +43,20 @@ public class ConfigurationAsCodeTest {
 
         ElasticBackend elastic = (ElasticBackend) configuration.getObservabilityBackends().get(0);
         MatcherAssert.assertThat(elastic.getKibanaBaseUrl(), CoreMatchers.is("http://localhost:5601"));
+        MatcherAssert.assertThat(elastic.getName(), CoreMatchers.is("My Elastic"));
 
         JaegerBackend jaeger = (JaegerBackend) configuration.getObservabilityBackends().get(1);
         MatcherAssert.assertThat(jaeger.getJaegerBaseUrl(), CoreMatchers.is("http://localhost:16686"));
+        MatcherAssert.assertThat(jaeger.getName(), CoreMatchers.is("My Jaeger"));
 
         CustomObservabilityBackend custom = (CustomObservabilityBackend) configuration.getObservabilityBackends().get(2);
         MatcherAssert.assertThat(custom.getMetricsVisualisationUrlTemplate(), CoreMatchers.is("foo"));
         MatcherAssert.assertThat(custom.getTraceVisualisationUrlTemplate(), CoreMatchers.is("http://example.com"));
+        MatcherAssert.assertThat(custom.getName(), CoreMatchers.is("My Custom"));
 
         ZipkinBackend zipkin = (ZipkinBackend) configuration.getObservabilityBackends().get(3);
         MatcherAssert.assertThat(zipkin.getZipkinBaseUrl(), CoreMatchers.is("http://localhost:9411/"));
+        MatcherAssert.assertThat(zipkin.getName(), CoreMatchers.is("My Zipkin"));
 
         OtlpAuthentication authentication = configuration.getAuthentication();
         MatcherAssert.assertThat(authentication, CoreMatchers.is(instanceOf(NoAuthentication.class)));

--- a/src/test/resources/io/jenkins/plugins/opentelemetry/jcasc/configuration-as-code-default-expected.yml
+++ b/src/test/resources/io/jenkins/plugins/opentelemetry/jcasc/configuration-as-code-default-expected.yml
@@ -3,5 +3,9 @@ endpoint: "http://otel-collector-contrib:4317"
 exporterIntervalMillis: 60000
 exporterTimeoutMillis: 30000
 ignoredSteps: "dir,echo,isUnix,pwd,properties"
+observabilityBackends:
+- customObservabilityBackend:
+    metricsVisualisationUrlTemplate: "foo"
+    traceVisualisationUrlTemplate: "http://example.com"
 serviceName: "jenkins"
 serviceNamespace: "jenkins"

--- a/src/test/resources/io/jenkins/plugins/opentelemetry/jcasc/configuration-as-code-default.yml
+++ b/src/test/resources/io/jenkins/plugins/opentelemetry/jcasc/configuration-as-code-default.yml
@@ -1,3 +1,7 @@
 unclassified:
   openTelemetry:
     endpoint: "http://otel-collector-contrib:4317"
+    observabilityBackends:
+      - customObservabilityBackend:
+          metricsVisualisationUrlTemplate: "foo"
+          traceVisualisationUrlTemplate: "http://example.com"

--- a/src/test/resources/io/jenkins/plugins/opentelemetry/jcasc/configuration-as-code-expected.yml
+++ b/src/test/resources/io/jenkins/plugins/opentelemetry/jcasc/configuration-as-code-expected.yml
@@ -6,12 +6,16 @@ ignoredSteps: "dir,echo,isUnix,pwd,properties"
 observabilityBackends:
 - elastic:
     kibanaBaseUrl: "http://localhost:5601"
+    name: "My Elastic"
 - jaeger:
     jaegerBaseUrl: "http://localhost:16686"
+    name: "My Jaeger"
 - customObservabilityBackend:
     metricsVisualisationUrlTemplate: "foo"
+    name: "My Custom"
     traceVisualisationUrlTemplate: "http://example.com"
 - zipkin:
+    name: "My Zipkin"
     zipkinBaseUrl: "http://localhost:9411/"
 serviceName: "my-jenkins"
 serviceNamespace: "ci"

--- a/src/test/resources/io/jenkins/plugins/opentelemetry/jcasc/configuration-as-code.yml
+++ b/src/test/resources/io/jenkins/plugins/opentelemetry/jcasc/configuration-as-code.yml
@@ -3,13 +3,17 @@ unclassified:
     endpoint: "http://otel-collector-contrib:4317"
     observabilityBackends:
       - elastic:
+          name: "My Elastic"
           kibanaBaseUrl: "http://localhost:5601"
       - jaeger:
           jaegerBaseUrl: "http://localhost:16686"
+          name: "My Jaeger"
       - customObservabilityBackend:
           metricsVisualisationUrlTemplate: "foo"
+          name: "My Custom"
           traceVisualisationUrlTemplate: "http://example.com"
       - zipkin:
+          name: "My Zipkin"
           zipkinBaseUrl: "http://localhost:9411/"
     serviceName: "my-jenkins"
     serviceNamespace: "ci"


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->

### What

Enforce a default value in case the name for the observability backend was set to 'empty'

### Why

<img width="529" alt="Screenshot 2021-05-07 at 11 53 06" src="https://user-images.githubusercontent.com/2871786/117440504-0909ef80-af2c-11eb-84e2-377c3b845455.png">
