### PR TITLE
No serialisation for the loadedStepsPlugins data structure

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
@@ -66,7 +66,7 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
 
     private transient SpanNamingStrategy spanNamingStrategy;
 
-    private ConcurrentMap<String, StepPlugin> loadedStepsPlugins = new ConcurrentHashMap<>();
+    private transient ConcurrentMap<String, StepPlugin> loadedStepsPlugins = new ConcurrentHashMap<>();
 
     private String serviceName;
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->


### What

`loadedStepsPlugins` field should not be serialised.


### Why

Otherwise the config XML file will contain those details:

```xml
<io.jenkins.plugins.opentelemetry.JenkinsOpenTelemetryPluginConfiguration plugin="opentelemetry@0.13-beta-rc324.f99bfc237ccd">
  <endpoint>*****</endpoint>
  <trustedCertificatesPem></trustedCertificatesPem>
  <authentication class="io.jenkins.plugins.opentelemetry.authentication.NoAuthentication"/>
  <observabilityBackends>
    <io.jenkins.plugins.opentelemetry.backend.ElasticBackend>
      <name>Elastic Observability</name>
      <kibanaBaseUrl>******</kibanaBaseUrl>
    </io.jenkins.plugins.opentelemetry.backend.ElasticBackend>
  </observabilityBackends>
  <exporterTimeoutMillis>30000</exporterTimeoutMillis>
  <exporterIntervalMillis>60000</exporterIntervalMillis>
  <ignoredSteps>dir,echo,isUnix,pwd,properties</ignoredSteps>
  <loadedStepsPlugins class="concurrent-hash-map">
    <entry>
      <string>junit</string>
      <io.jenkins.plugins.opentelemetry.JenkinsOpenTelemetryPluginConfiguration_-StepPlugin>
        <name>junit</name>
        <version>1.49</version>
      </io.jenkins.plugins.opentelemetry.JenkinsOpenTelemetryPluginConfiguration_-StepPlugin>
    </entry>
    ...

```