### PR TITLE
Monitor JVM GC and Memory Pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ In addition, if the backends were configured then there will be an environment v
 | runtime.jvm.gc.time{gc="${gc}"} | in milliseconds, `gc: G1 Young Generation, G1 Old Generation...`, see [GarbageCollectorMXBean](https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectorMXBean.html) |
 | runtime.jvm.gc.count{gc="G1 Young Generation"} | `gc: G1 Young Generation, G1 Old Generation...`, see [GarbageCollectorMXBean](https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectorMXBean.html) |
 | runtime.jvm.memory.area{type="${type}"} | in bytes, `type: used, committed`, see [MemoryUsage](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryUsage.html) |
-| runtime.jvm.memory.area{type="committed",area="non_heap"} | in bytes,  `type: used, committed, max`, `area: heap, non_heap`, see [MemoryUsage](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryUsage.html) |
-| runtime.jvm.memory.area{type="used",pool="PS Eden Space"} | in bytes,   `type: used, committed, max`, `pool: PS Eden Space, G1 Old Gen...`, see [MemoryUsage](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryUsage.html) |
+| runtime.jvm.memory.area{type="${type}",area="${area}"} | in bytes, `type: used, committed, max`, `area: heap, non_heap`, see [MemoryUsage](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryUsage.html) |
+| runtime.jvm.memory.area{type="${type}",pool="${pool}"} | in bytes, `type: used, committed, max`, `pool: PS Eden Space, G1 Old Gen...`, see [MemoryUsage](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryUsage.html) |
 
 
 Jenkins metrics can be visualised with any OpenTelemetry compatible metrics solution such as [Prometheus](https://prometheus.io/) or [Elastic Observability](https://www.elastic.co/observability)

--- a/README.md
+++ b/README.md
@@ -111,10 +111,16 @@ In addition, if the backends were configured then there will be an environment v
 | jenkins.agents.online            | Number of online agents |
 | jenkins.agents.offline           | Number of offline agents |
 | jenkins.disk.usage.bytes         | Disk Usage size |
+| runtime.jvm.gc.time{gc="${gc}"} | in milliseconds, `gc: G1 Young Generation, G1 Old Generation...`, see [GarbageCollectorMXBean](https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectorMXBean.html) |
+| runtime.jvm.gc.count{gc="G1 Young Generation"} | `gc: G1 Young Generation, G1 Old Generation...`, see [GarbageCollectorMXBean](https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectorMXBean.html) |
+| runtime.jvm.memory.area{type="${type}"} | in bytes, `type: used, committed`, see [MemoryUsage](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryUsage.html) |
+| runtime.jvm.memory.area{type="committed",area="non_heap"} | in bytes,  `type: used, committed, max`, `area: heap, non_heap`, see [MemoryUsage](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryUsage.html) |
+| runtime.jvm.memory.area{type="used",pool="PS Eden Space"} | in bytes,   `type: used, committed, max`, `pool: PS Eden Space, G1 Old Gen...`, see [MemoryUsage](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryUsage.html) |
 
 
 Jenkins metrics can be visualised with any OpenTelemetry compatible metrics solution such as [Prometheus](https://prometheus.io/) or [Elastic Observability](https://www.elastic.co/observability)
 
+The ``untime.*`metrics are the same as the one collected by the `
 
 ### Standardisation
 

--- a/src/main/java/io/jenkins/plugins/opentelemetry/computer/JvmMonitoringInitializer.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/computer/JvmMonitoringInitializer.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.computer;
+
+import hudson.Extension;
+import hudson.ExtensionPoint;
+import hudson.slaves.ComputerListener;
+import io.jenkins.plugins.opentelemetry.opentelemetry.instrumentation.runtimemetrics.GarbageCollector;
+import io.jenkins.plugins.opentelemetry.opentelemetry.instrumentation.runtimemetrics.MemoryPools;
+import jenkins.YesNoMaybe;
+
+import javax.annotation.PostConstruct;
+import java.util.logging.Logger;
+
+/**
+ * Note: we extend {@link ComputerListener} instead of a plain {@link ExtensionPoint} because simple ExtensionPoint don't get automatically loaded by Jenkins
+ * There may be a better API to do this.
+ */
+@Extension(dynamicLoadable = YesNoMaybe.MAYBE, optional = true)
+public class JvmMonitoringInitializer extends ComputerListener {
+
+    private final static Logger LOGGER = Logger.getLogger(JvmMonitoringInitializer.class.getName());
+
+    public JvmMonitoringInitializer() {
+    }
+
+    @PostConstruct
+    public void postConstruct() {
+        GarbageCollector.registerObservers();
+        MemoryPools.registerObservers();
+    }
+}

--- a/src/main/java/io/jenkins/plugins/opentelemetry/init/JvmMonitoringInitializer.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/init/JvmMonitoringInitializer.java
@@ -3,32 +3,37 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.jenkins.plugins.opentelemetry.computer;
+package io.jenkins.plugins.opentelemetry.init;
 
 import hudson.Extension;
-import hudson.ExtensionPoint;
-import hudson.slaves.ComputerListener;
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
+import io.jenkins.plugins.opentelemetry.OpenTelemetrySdkProvider;
 import io.jenkins.plugins.opentelemetry.opentelemetry.instrumentation.runtimemetrics.GarbageCollector;
 import io.jenkins.plugins.opentelemetry.opentelemetry.instrumentation.runtimemetrics.MemoryPools;
 import jenkins.YesNoMaybe;
 
-import javax.annotation.PostConstruct;
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * Note: we extend {@link ComputerListener} instead of a plain {@link ExtensionPoint} because simple ExtensionPoint don't get automatically loaded by Jenkins
- * There may be a better API to do this.
- */
 @Extension(dynamicLoadable = YesNoMaybe.MAYBE, optional = true)
-public class JvmMonitoringInitializer extends ComputerListener {
+public class JvmMonitoringInitializer extends OpenTelemetryPluginAbstractInitializer {
 
     private final static Logger LOGGER = Logger.getLogger(JvmMonitoringInitializer.class.getName());
 
     public JvmMonitoringInitializer() {
+
     }
 
-    @PostConstruct
-    public void postConstruct() {
+    /**
+     * TODO better dependency handling
+     * Don't start just after `PLUGINS_STARTED` because it creates an initialization problem
+     */
+    @Initializer(after = InitMilestone.JOB_LOADED)
+    public void initialize() {
+        LOGGER.log(Level.INFO, "Start monitoring the JVM...");
         GarbageCollector.registerObservers();
         MemoryPools.registerObservers();
     }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/init/OpenTelemetryPluginAbstractInitializer.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/init/OpenTelemetryPluginAbstractInitializer.java
@@ -6,6 +6,7 @@
 package io.jenkins.plugins.opentelemetry.init;
 
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.jenkins.plugins.opentelemetry.OpenTelemetrySdkProvider;
 
 import javax.annotation.Nonnull;
@@ -13,8 +14,9 @@ import javax.inject.Inject;
 
 public abstract class OpenTelemetryPluginAbstractInitializer {
 
+    @SuppressFBWarnings(value = "URF_UNREAD_FIELD", justification = "will be used once `GlobalMeterProvider#getMeter(String)` is replaced by a getter on `OpenTelemetrySdk`")
     private OpenTelemetrySdkProvider openTelemetrySdkProvider;
-    
+
     /**
      * WARNING do not remove this setter used to surface the dependency to first initialize the OpenTelemetry SDK and then register metrics.
      * Note that once {@link io.opentelemetry.api.metrics.GlobalMeterProvider#getMeter(String)} is replaced by a getter on {@link io.opentelemetry.api.OpenTelemetry},

--- a/src/main/java/io/jenkins/plugins/opentelemetry/init/OpenTelemetryPluginAbstractInitializer.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/init/OpenTelemetryPluginAbstractInitializer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.init;
+
+
+import io.jenkins.plugins.opentelemetry.OpenTelemetrySdkProvider;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+
+public abstract class OpenTelemetryPluginAbstractInitializer {
+
+    private OpenTelemetrySdkProvider openTelemetrySdkProvider;
+    
+    /**
+     * WARNING do not remove this setter used to surface the dependency to first initialize the OpenTelemetry SDK and then register metrics.
+     * Note that once {@link io.opentelemetry.api.metrics.GlobalMeterProvider#getMeter(String)} is replaced by a getter on {@link io.opentelemetry.api.OpenTelemetry},
+     * then the problem dependency will become explicit.
+     *
+     * @param openTelemetrySdkProvider
+     */
+    @Inject
+    public void setOpenTelemetrySdkProvider(@Nonnull OpenTelemetrySdkProvider openTelemetrySdkProvider){
+        this.openTelemetrySdkProvider = openTelemetrySdkProvider;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/opentelemetry/opentelemetry/instrumentation/runtimemetrics/GarbageCollector.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/opentelemetry/instrumentation/runtimemetrics/GarbageCollector.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.opentelemetry.instrumentation.runtimemetrics;
+
+import io.opentelemetry.api.metrics.GlobalMeterProvider;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.common.Labels;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.List;
+
+/*
+ * Copy of https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/v1.2.0/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/GarbageCollector.java
+ */
+/**
+ * Registers observers that generate metrics about JVM garbage collectors.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * GarbageCollector.registerObservers();
+ * }</pre>
+ *
+ * <p>Example metrics being exported:
+ *
+ * <pre>
+ *   runtime.jvm.gc.time{gc="PS1"} 6.7
+ *   runtime.jvm.gc.count{gc="PS1"} 1
+ * </pre>
+ */
+public final class GarbageCollector {
+    private static final String GC_LABEL_KEY = "gc";
+
+    /** Register all observers provided by this module. */
+    public static void registerObservers() {
+        List<GarbageCollectorMXBean> garbageCollectors = ManagementFactory.getGarbageCollectorMXBeans();
+        Meter meter = GlobalMeterProvider.getMeter(GarbageCollector.class.getName());
+        List<Labels> labelSets = new ArrayList<>(garbageCollectors.size());
+        for (final GarbageCollectorMXBean gc : garbageCollectors) {
+            labelSets.add(Labels.of(GC_LABEL_KEY, gc.getName()));
+        }
+        meter
+            .longSumObserverBuilder("runtime.jvm.gc.time")
+            .setDescription("Time spent in a given JVM garbage collector in milliseconds.")
+            .setUnit("ms")
+            .setUpdater(
+                resultLongObserver -> {
+                    for (int i = 0; i < garbageCollectors.size(); i++) {
+                        resultLongObserver.observe(
+                            garbageCollectors.get(i).getCollectionTime(), labelSets.get(i));
+                    }
+                })
+            .build();
+        meter
+            .longSumObserverBuilder("runtime.jvm.gc.count")
+            .setDescription(
+                "The number of collections that have occurred for a given JVM garbage collector.")
+            .setUnit("collections")
+            .setUpdater(
+                resultLongObserver -> {
+                    for (int i = 0; i < garbageCollectors.size(); i++) {
+                        resultLongObserver.observe(
+                            garbageCollectors.get(i).getCollectionCount(), labelSets.get(i));
+                    }
+                })
+            .build();
+    }
+
+    private GarbageCollector() {}
+}

--- a/src/main/java/io/jenkins/plugins/opentelemetry/opentelemetry/instrumentation/runtimemetrics/MemoryPools.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/opentelemetry/instrumentation/runtimemetrics/MemoryPools.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.opentelemetry.instrumentation.runtimemetrics;
+
+import io.opentelemetry.api.metrics.AsynchronousInstrument.LongResult;
+import io.opentelemetry.api.metrics.GlobalMeterProvider;
+import io.opentelemetry.api.metrics.LongUpDownSumObserver;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.common.Labels;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryUsage;
+import java.util.ArrayList;
+import java.util.List;
+
+/*
+ * Copy of https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/v1.2.0/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/MemoryPools.java
+ */
+/**
+ * Registers observers that generate metrics about JVM memory areas.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * MemoryPools.registerObservers();
+ * }</pre>
+ *
+ * <p>Example metrics being exported: Component
+ *
+ * <pre>
+ *   runtime.jvm.memory.area{type="used",area="heap"} 2000000
+ *   runtime.jvm.memory.area{type="committed",area="non_heap"} 200000
+ *   runtime.jvm.memory.area{type="used",pool="PS Eden Space"} 2000
+ * </pre>
+ */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "DLS_DEAD_LOCAL_STORE", justification = "Code copy/pasted from opentelemetry-java-instrumentatio")
+public final class MemoryPools {
+    private static final String TYPE_LABEL_KEY = "type";
+    private static final String AREA_LABEL_KEY = "area";
+    private static final String POOL_LABEL_KEY = "pool";
+    private static final String USED = "used";
+    private static final String COMMITTED = "committed";
+    private static final String MAX = "max";
+    private static final String HEAP = "heap";
+    private static final String NON_HEAP = "non_heap";
+
+    private static final Labels COMMITTED_HEAP =
+        Labels.of(TYPE_LABEL_KEY, COMMITTED, AREA_LABEL_KEY, HEAP);
+    private static final Labels USED_HEAP = Labels.of(TYPE_LABEL_KEY, USED, AREA_LABEL_KEY, HEAP);
+    private static final Labels MAX_HEAP = Labels.of(TYPE_LABEL_KEY, MAX, AREA_LABEL_KEY, HEAP);
+
+    private static final Labels COMMITTED_NON_HEAP =
+        Labels.of(TYPE_LABEL_KEY, COMMITTED, AREA_LABEL_KEY, NON_HEAP);
+    private static final Labels USED_NON_HEAP =
+        Labels.of(TYPE_LABEL_KEY, USED, AREA_LABEL_KEY, NON_HEAP);
+    private static final Labels MAX_NON_HEAP =
+        Labels.of(TYPE_LABEL_KEY, MAX, AREA_LABEL_KEY, NON_HEAP);
+
+    /** Register only the "area" observers. */
+    public static void registerMemoryAreaObservers() {
+        MemoryMXBean memoryBean = ManagementFactory.getMemoryMXBean();
+        Meter meter = GlobalMeterProvider.getMeter(MemoryPools.class.getName());
+        final LongUpDownSumObserver areaMetric =
+            meter
+                .longUpDownSumObserverBuilder("runtime.jvm.memory.area")
+                .setDescription("Bytes of a given JVM memory area.")
+                .setUnit("By")
+                .setUpdater(
+                    resultLongObserver -> {
+                        observeHeap(resultLongObserver, memoryBean.getHeapMemoryUsage());
+                        observeNonHeap(resultLongObserver, memoryBean.getNonHeapMemoryUsage());
+                    })
+                .build();
+    }
+
+    /** Register only the "pool" observers. */
+    public static void registerMemoryPoolObservers() {
+        List<MemoryPoolMXBean> poolBeans = ManagementFactory.getMemoryPoolMXBeans();
+        Meter meter = GlobalMeterProvider.getMeter(MemoryPools.class.getName());
+        List<Labels> usedLabelSets = new ArrayList<>(poolBeans.size());
+        List<Labels> committedLabelSets = new ArrayList<>(poolBeans.size());
+        List<Labels> maxLabelSets = new ArrayList<>(poolBeans.size());
+        for (MemoryPoolMXBean pool : poolBeans) {
+            usedLabelSets.add(Labels.of(TYPE_LABEL_KEY, USED, POOL_LABEL_KEY, pool.getName()));
+            committedLabelSets.add(Labels.of(TYPE_LABEL_KEY, COMMITTED, POOL_LABEL_KEY, pool.getName()));
+            maxLabelSets.add(Labels.of(TYPE_LABEL_KEY, MAX, POOL_LABEL_KEY, pool.getName()));
+        }
+        meter
+            .longUpDownSumObserverBuilder("runtime.jvm.memory.pool")
+            .setDescription("Bytes of a given JVM memory pool.")
+            .setUnit("By")
+            .setUpdater(
+                resultLongObserver -> {
+                    for (int i = 0; i < poolBeans.size(); i++) {
+                        MemoryUsage poolUsage = poolBeans.get(i).getUsage();
+                        if (poolUsage != null) {
+                            observe(
+                                resultLongObserver,
+                                poolUsage,
+                                usedLabelSets.get(i),
+                                committedLabelSets.get(i),
+                                maxLabelSets.get(i));
+                        }
+                    }
+                })
+            .build();
+    }
+
+    /** Register all observers provided by this module. */
+    public static void registerObservers() {
+        registerMemoryAreaObservers();
+        registerMemoryPoolObservers();
+    }
+
+    static void observeHeap(LongResult observer, MemoryUsage usage) {
+        observe(observer, usage, USED_HEAP, COMMITTED_HEAP, MAX_HEAP);
+    }
+
+    static void observeNonHeap(LongResult observer, MemoryUsage usage) {
+        observe(observer, usage, USED_NON_HEAP, COMMITTED_NON_HEAP, MAX_NON_HEAP);
+    }
+
+    private static void observe(
+        LongResult observer,
+        MemoryUsage usage,
+        Labels usedLabels,
+        Labels committedLabels,
+        Labels maxLabels) {
+        // TODO: Decide if init is needed or not. It is a constant that can be queried once on startup.
+        // if (usage.getInit() != -1) {
+        //  observer.observe(usage.getInit(), ...);
+        // }
+        observer.observe(usage.getUsed(), usedLabels);
+        observer.observe(usage.getCommitted(), committedLabels);
+        // TODO: Decide if max is needed or not. It is a constant that can be queried once on startup.
+        if (usage.getMax() != -1) {
+            observer.observe(usage.getMax(), maxLabels);
+        }
+    }
+
+    private MemoryPools() {}
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Monitor JVM GC and Memory Pools.

Example metrics being exported:

```
runtime.jvm.gc.time{gc="G1 Young Generation"} 6.7
runtime.jvm.gc.count{gc="G1 Young Generation"} 1

runtime.jvm.memory.area{type="used",area="heap"} 2000000
runtime.jvm.memory.area{type="committed",area="non_heap"} 200000
runtime.jvm.memory.area{type="used",pool="PS Eden Space"} 2000
```

Reuse Otel's Java Instrumentation 
* [instrumentation/runtimemetrics/GarbageCollector.java](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/v1.2.0/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/GarbageCollector.java) 
* [instrumentation/runtimemetrics/MemoryPools.java](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/v1.2.0/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics/MemoryPools.java)
