### PR TITLE
Add metrics for `system.cpu`, `system.memory`, `system.paging`, and `process.cpu`

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,27 +95,34 @@ In addition, if the backends were configured then there will be an environment v
 
 ### Metrics on Jenkins health indicators
 
-| Metrics                          | Description  |
-|----------------------------------|--------------|
-| ci.pipeline.run.active           | Gauge of active jobs |
-| ci.pipeline.run.launched         | Job launched |
-| ci.pipeline.run.started          | Job started |
-| ci.pipeline.run.completed        | Job completed |
-| ci.pipeline.run.aborted          | Job aborted |
-| jenkins.queue.waiting            | Number of waiting items in queue |
-| jenkins.queue.blocked            | Number of blocked items in queue |
-| jenkins.queue.buildable          | Number of buildable items in queue |
-| jenkins.queue.left               | Total count of left items |
-| jenkins.queue.time_spent_millis  | Total time spent in queue by items |
-| jenkins.agents.total             | Number of agents|
-| jenkins.agents.online            | Number of online agents |
-| jenkins.agents.offline           | Number of offline agents |
-| jenkins.disk.usage.bytes         | Disk Usage size |
-| runtime.jvm.gc.time{gc="${gc}"} | in milliseconds, `gc: G1 Young Generation, G1 Old Generation...`, see [GarbageCollectorMXBean](https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectorMXBean.html) |
-| runtime.jvm.gc.count{gc="G1 Young Generation"} | `gc: G1 Young Generation, G1 Old Generation...`, see [GarbageCollectorMXBean](https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectorMXBean.html) |
-| runtime.jvm.memory.area{type="${type}"} | in bytes, `type: used, committed`, see [MemoryUsage](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryUsage.html) |
-| runtime.jvm.memory.area{type="${type}",area="${area}"} | in bytes, `type: used, committed, max`, `area: heap, non_heap`, see [MemoryUsage](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryUsage.html) |
-| runtime.jvm.memory.area{type="${type}",pool="${pool}"} | in bytes, `type: used, committed, max`, `pool: PS Eden Space, G1 Old Gen...`, see [MemoryUsage](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryUsage.html) |
+| Metrics                          | Unit  | Label key  | Label Value       |            Description  |
+|----------------------------------|-------|------------|-------------------|-------------|
+| ci.pipeline.run.active           | 1     |            |                   | Gauge of active jobs |
+| ci.pipeline.run.launched         | 1     |            |                   | Job launched |
+| ci.pipeline.run.started          | 1     |            |                   | Job started |
+| ci.pipeline.run.completed        | 1     |            |                   | Job completed |
+| ci.pipeline.run.aborted          | 1     |            |                   | Job aborted |
+| jenkins.queue.waiting            | 1     |            |                   | Number of waiting items in queue |
+| jenkins.queue.blocked            | 1     |            |                   | Number of blocked items in queue |
+| jenkins.queue.buildable          | 1     |            |                   | Number of buildable items in queue |
+| jenkins.queue.left               | 1     |            |                   | Total count of left items |
+| jenkins.queue.time_spent_millis  | ms    |            |                   | Total time spent in queue by items |
+| jenkins.agents.total             | 1     |            |                   | Number of agents|
+| jenkins.agents.online            | 1     |            |                   | Number of online agents |
+| jenkins.agents.offline           | 1     |            |                   | Number of offline agents |
+| jenkins.disk.usage.bytes         | By    |            |                   | Disk Usage size |
+| runtime.jvm.gc.time              | ms    |  gc        | `G1 Young Generation`, `G1 Old Generation...` | see [GarbageCollectorMXBean](https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectorMXBean.html) |
+| runtime.jvm.gc.count             | 1     |  gc        | `G1 Young Generation`, `G1 Old Generation...` | see [GarbageCollectorMXBean](https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectorMXBean.html) |
+| runtime.jvm.memory.area          | bytes | type, area | `used`, `committed`, `max` <br/> `heap`, `non_heap` | see [MemoryUsage](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryUsage.html) |
+| runtime.jvm.memory.pool          | bytes | type, pool | `used`, `committed`, `max` <br/> `PS Eden Space`, `G1 Old Gen...` | see [MemoryUsage](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryUsage.html) |
+| system.cpu.load                  | 1     |            |                  | System CPU load. See `com.sun.management.OperatingSystemMXBean.getSystemCpuLoad` |
+| system.cpu.load.average.1m       | 1     |            |                  | System CPU load average 1 minute See `java.lang.management.OperatingSystemMXBean.getSystemLoadAverage` |
+| system.memory.usage              | By    | state      | `used`, `free`   | see `com.sun.management.OperatingSystemMXBean.getTotalPhysicalMemorySize` and `com.sun.management.OperatingSystemMXBean.getFreePhysicalMemorySize` |  
+| system.memory.utilization        | 1     |            |                  | System memory utilization, see `com.sun.management.OperatingSystemMXBean.getTotalPhysicalMemorySize` and `com.sun.management.OperatingSystemMXBean.getFreePhysicalMemorySize` | 
+| system.paging.usage              | By    | state      | `used`, `free`   | see `com.sun.management.OperatingSystemMXBean.getFreeSwapSpaceSize` and `com.sun.management.OperatingSystemMXBean.getTotalSwapSpaceSize` |
+| system.paging.utilization        | 1     |            |                  | see `com.sun.management.OperatingSystemMXBean.getFreeSwapSpaceSize` and `com.sun.management.OperatingSystemMXBean.getTotalSwapSpaceSize` |
+| process.cpu.load                 | 1     |            |                  | Process CPU load. See `com.sun.management.OperatingSystemMXBean.getProcessCpuLoad` |
+| process.cpu.time                 | ns    |            |                  | Process CPU time. See `com.sun.management.OperatingSystemMXBean.getProcessCpuTime` |
 
 
 Jenkins metrics can be visualised with any OpenTelemetry compatible metrics solution such as [Prometheus](https://prometheus.io/) or [Elastic Observability](https://www.elastic.co/observability)

--- a/src/main/java/io/jenkins/plugins/opentelemetry/OpenTelemetrySdkProvider.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/OpenTelemetrySdkProvider.java
@@ -81,6 +81,7 @@ public class OpenTelemetrySdkProvider {
     public void postConstruct() {
         this.tracer = new TracerDelegate(OpenTelemetry.noop().getTracer("jenkins"));
         Resource resource = buildResource();
+        LOGGER.log(Level.INFO, () ->"OpenTelemetry SdkMeterProvider resources: " + resource.getAttributes().asMap().entrySet().stream().map( e -> e.getKey() + ": " + e.getValue()).collect(Collectors.joining(", ")));
         this.sdkMeterProvider = SdkMeterProvider.builder().setResource(resource).buildAndRegisterGlobal();
         this.meter = GlobalMeterProvider.getMeter("jenkins");
     }
@@ -166,7 +167,7 @@ public class OpenTelemetrySdkProvider {
 
         // TRACES
         Resource resource = buildResource();
-        LOGGER.log(Level.FINE, () ->"OpenTelemetry SDK resources: " + resource.getAttributes().asMap().entrySet().stream().map( e -> e.getKey() + ": " + e.getValue()).collect(Collectors.joining(", ")));
+        LOGGER.log(Level.FINE, () ->"OpenTelemetry SdkTracerProvider resources: " + resource.getAttributes().asMap().entrySet().stream().map( e -> e.getKey() + ": " + e.getValue()).collect(Collectors.joining(", ")));
         SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder().setResource(resource).addSpanProcessor(SimpleSpanProcessor.create(spanExporter)).build();
 
         this.openTelemetry = OpenTelemetrySdk.builder()

--- a/src/main/java/io/jenkins/plugins/opentelemetry/init/JvmMonitoringInitializer.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/init/JvmMonitoringInitializer.java
@@ -5,16 +5,23 @@
 
 package io.jenkins.plugins.opentelemetry.init;
 
+import static io.jenkins.plugins.opentelemetry.semconv.OpenTelemetryMetricsSemanticConventions.*;
+
 import hudson.Extension;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
-import io.jenkins.plugins.opentelemetry.OpenTelemetrySdkProvider;
 import io.jenkins.plugins.opentelemetry.opentelemetry.instrumentation.runtimemetrics.GarbageCollector;
 import io.jenkins.plugins.opentelemetry.opentelemetry.instrumentation.runtimemetrics.MemoryPools;
+import io.jenkins.plugins.opentelemetry.semconv.OpenTelemetryMetricsSemanticConventions;
+import io.opentelemetry.api.metrics.GlobalMeterProvider;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.common.Labels;
 import jenkins.YesNoMaybe;
 
-import javax.annotation.Nonnull;
-import javax.inject.Inject;
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
+import java.math.BigDecimal;
+import java.math.MathContext;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -36,5 +43,114 @@ public class JvmMonitoringInitializer extends OpenTelemetryPluginAbstractInitial
         LOGGER.log(Level.INFO, "Start monitoring the JVM...");
         GarbageCollector.registerObservers();
         MemoryPools.registerObservers();
+
+        final OperatingSystemMXBean operatingSystemMXBean = ManagementFactory.getOperatingSystemMXBean();
+
+        Meter meter = GlobalMeterProvider.getMeter(OperatingSystemMXBean.class.getName());
+
+        meter
+            .doubleValueObserverBuilder(OpenTelemetryMetricsSemanticConventions.SYSTEM_CPU_LOAD_AVERAGE_1M)
+            .setDescription("System CPU load average 1 minute")
+            .setUnit("%")
+            .setUpdater(valueObserver ->
+                valueObserver.observe(operatingSystemMXBean.getSystemLoadAverage(), Labels.empty())
+            )
+            .build();
+
+        if (operatingSystemMXBean instanceof com.sun.management.OperatingSystemMXBean) {
+            com.sun.management.OperatingSystemMXBean osBean = (com.sun.management.OperatingSystemMXBean) operatingSystemMXBean;
+
+            // PROCESS CPU
+            meter
+                .doubleValueObserverBuilder(OpenTelemetryMetricsSemanticConventions.PROCESS_CPU_LOAD)
+                .setDescription("Process CPU load")
+                .setUnit("%")
+                .setUpdater(valueObserver ->
+                    valueObserver.observe(osBean.getProcessCpuLoad(), Labels.empty())
+                )
+                .build();
+            meter
+                .longSumObserverBuilder(OpenTelemetryMetricsSemanticConventions.PROCESS_CPU_TIME)
+                .setDescription("Process CPU time")
+                .setUnit("ns")
+                .setUpdater(valueObserver ->
+                    valueObserver.observe(osBean.getProcessCpuTime(), Labels.empty())
+                )
+                .build();
+
+            // SYSTEM CPU
+            meter
+                .doubleValueObserverBuilder(OpenTelemetryMetricsSemanticConventions.SYSTEM_CPU_LOAD)
+                .setDescription("System CPU load")
+                .setUnit("%")
+                .setUpdater(valueObserver ->
+                    valueObserver.observe(osBean.getSystemCpuLoad(), Labels.empty())
+                )
+                .build();
+
+            // SYSTEM MEMORY
+            /*
+            Extract from the Otel Collector Host Metrics
+            system_memory_usage{state="free"} 3.06987008e+08
+            system_memory_usage{state="inactive"} 4.968194048e+09
+            system_memory_usage{state="used"} 1.1904688128e+10
+            */
+            meter
+                .longUpDownSumObserverBuilder(OpenTelemetryMetricsSemanticConventions.SYSTEM_MEMORY_USAGE)
+                .setDescription("System memory usage")
+                .setUnit("bytes")
+                .setUpdater(valueObserver -> {
+                        final long totalSize = osBean.getTotalPhysicalMemorySize();
+                        final long freeSize = osBean.getFreePhysicalMemorySize();
+                        valueObserver.observe((totalSize - freeSize), STATE_USED);
+                        valueObserver.observe(freeSize, STATE_FREE);
+                    }
+                )
+                .build();
+            meter
+                .doubleValueObserverBuilder(OpenTelemetryMetricsSemanticConventions.SYSTEM_MEMORY_UTILIZATION)
+                .setDescription("System memory utilization (0.0 to 1.0)")
+                .setUnit("1")
+                .setUpdater(valueObserver ->
+                    {
+                        final long totalSize = osBean.getTotalPhysicalMemorySize();
+                        final long freeSize = osBean.getFreePhysicalMemorySize();
+                        final long usedSize = totalSize - freeSize;
+                        final BigDecimal utilization = new BigDecimal(usedSize).divide(new BigDecimal(totalSize), MathContext.DECIMAL64);
+                        LOGGER.log(Level.FINER, () -> "Memory utilization: " + utilization + ", used: " + usedSize + " bytes, free: " + freeSize + " bytes, total: " + totalSize + " bytes");
+                        valueObserver.observe(utilization.doubleValue(), Labels.empty());
+                    }
+                )
+                .build();
+
+            // SYSTEM SWAP
+            meter
+                .longUpDownSumObserverBuilder(SYSTEM_PAGING_USAGE)
+                .setDescription("System swap usage")
+                .setUnit("bytes")
+                .setUpdater(valueObserver -> {
+                        final long freeSize = osBean.getFreeSwapSpaceSize();
+                        final long totalSize = osBean.getTotalSwapSpaceSize();
+                        valueObserver.observe((totalSize - freeSize), STATE_USED);
+                        valueObserver.observe(freeSize, STATE_FREE);
+                    }
+                )
+                .build();
+            meter
+                .doubleValueObserverBuilder(SYSTEM_PAGING_UTILIZATION)
+                .setDescription("System swap utilization (0.0 to 1.0)")
+                .setUnit("bytes")
+                .setUpdater(valueObserver ->
+                    {
+                        final long totalSize = osBean.getTotalSwapSpaceSize();
+                        final long freeSize = osBean.getFreeSwapSpaceSize();
+                        final long usedSize = totalSize - freeSize;
+                        final BigDecimal utilization = new BigDecimal(usedSize).divide(new BigDecimal(totalSize), MathContext.DECIMAL64);
+                        LOGGER.log(Level.FINER, () -> "Swap utilization: " + utilization + ", used: " + usedSize + " bytes, free: " + freeSize + " bytes, total: " + totalSize + " bytes");
+                        valueObserver.observe(utilization.doubleValue(), Labels.empty());
+                    }
+                )
+                .build();
+        }
     }
 }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/semconv/OpenTelemetryMetricsSemanticConventions.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/semconv/OpenTelemetryMetricsSemanticConventions.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.semconv;
+
+import io.opentelemetry.api.metrics.common.Labels;
+
+/**
+ * Java constants for the
+ * [OpenTelemetry System Metrics Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/system-metrics.md)
+ * [OpenTelemetry Process Metrics Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/process-metrics.md)
+ */
+public class OpenTelemetryMetricsSemanticConventions {
+
+    public final static String SYSTEM_CPU_LOAD = "system.cpu.load";
+    public final static String SYSTEM_CPU_LOAD_AVERAGE_1M = "system.cpu.load.average.1m";
+    public final static String SYSTEM_MEMORY_USAGE = "system.memory.usage";
+    public final static String SYSTEM_MEMORY_UTILIZATION = "system.memory.utilization";
+    public final static String SYSTEM_PAGING_USAGE = "system.paging.usage";
+    public final static String SYSTEM_PAGING_UTILIZATION = "system.paging.utilization";
+
+    public final static Labels STATE_FREE = Labels.of("state", "free");
+    public final static Labels STATE_USED = Labels.of("state", "used");
+
+    public final static String PROCESS_CPU_LOAD = "process.cpu.load";
+    public final static String PROCESS_CPU_TIME = "process.cpu.time";
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->

Add metrics for `system.cpu`, `system.memory`, `system.paging`, and `process.cpu`


| Metrics                          | Unit  | Label key  | Label Value       |            Description  |
|----------------------------------|-------|------------|-------------------|-------------|
| system.cpu.load                  | 1     |            |                  | System CPU load. See `com.sun.management.OperatingSystemMXBean.getSystemCpuLoad` |
| system.cpu.load.average.1m       | 1     |            |                  | System CPU load average 1 minute See `java.lang.management.OperatingSystemMXBean.getSystemLoadAverage` |
| system.memory.usage              | By    | state      | `used`, `free`   | see `com.sun.management.OperatingSystemMXBean.getTotalPhysicalMemorySize` and `com.sun.management.OperatingSystemMXBean.getFreePhysicalMemorySize` |  
| system.memory.utilization        | 1     |            |                  | System memory utilization, see `com.sun.management.OperatingSystemMXBean.getTotalPhysicalMemorySize` and `com.sun.management.OperatingSystemMXBean.getFreePhysicalMemorySize` | 
| system.paging.usage              | By    | state      | `used`, `free`   | see `com.sun.management.OperatingSystemMXBean.getFreeSwapSpaceSize` and `com.sun.management.OperatingSystemMXBean.getTotalSwapSpaceSize` |
| system.paging.utilization        | 1     |            |                  | see `com.sun.management.OperatingSystemMXBean.getFreeSwapSpaceSize` and `com.sun.management.OperatingSystemMXBean.getTotalSwapSpaceSize` |
| process.cpu.load                 | 1     |            |                  | Process CPU load. See `com.sun.management.OperatingSystemMXBean.getProcessCpuLoad` |
| process.cpu.time                 | ns    |            |                  | Process CPU time. See `com.sun.management.OperatingSystemMXBean.getProcessCpuTime` |
