### PR TITLE
Revert "Bump OpenTelemetry to v1.3.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <jenkins.version>2.235.5</jenkins.version>
         <java.level>8</java.level>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <opentelemetry.version>1.3.0</opentelemetry.version>
+        <opentelemetry.version>1.2.0</opentelemetry.version>
     </properties>
     <name>OpenTelemetry Plugin</name>
     <description>Publish Jenkins metrics to an OpenTelemetry endpoint, including distributed traces of job executions and health metrics of the controller.</description>


### PR DESCRIPTION
Reverts jenkinsci/opentelemetry-plugin#126

### Why


Metric values are always `0`

```
StartTimestamp: 2021-06-22 14:41:00.372 +0000 UTC
Timestamp: 2021-06-22 14:49:57.646 +0000 UTC
Value: 0.000000
Metric #11
Descriptor:
     -> Name: jenkins.queue.buildable
     -> Description: Number of buildable items in queue
     -> Unit: 1
     -> DataType: DoubleGauge
```

While using `1.2.0` then the output is:

```
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2021-06-22 14:53:32.892 +0000 UTC
Value: 1
Metric #5
Descriptor:
     -> Name: jenkins.queue.buildable
     -> Description: Number of buildable items in queue
     -> Unit: 1
     -> DataType: IntGauge
IntDataPoints #0
```


### Screenshots


With agent `1.2.0`

![image](https://user-images.githubusercontent.com/2871786/122949593-b2d5fc00-d373-11eb-8904-10638aaae4e3.png)


With agent `1.3.0`

![image](https://user-images.githubusercontent.com/2871786/122949712-ca14e980-d373-11eb-9d2b-4d3125a73967.png)


### Issues

Closes https://github.com/jenkinsci/opentelemetry-plugin/issues/132