### PR TITLE
Add shallow clone attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ In addition, if the backends were configured then there will be an environment v
 | git.branch                       | Git branch name | String |
 | git.repository                   | Git repository | String |
 | git.username                     | Git user | String |
+| git.clone.shallow                | Git shallow clone | Boolean |
+| git.clone.depth                  | Git shallow clone depth | Long |
+| git.username                     | Git user | String |
 | jenkins.url                      | Jenkins URL | String |
 | jenkins.computer.name            | Name of the agent | String |
 
@@ -146,8 +149,8 @@ In addition, if the backends were configured then there will be an environment v
 | runtime.jvm.memory.pool          | bytes | type, pool | `used`, `committed`, `max`. <br/> `PS Eden Space`, `G1 Old Gen...` | see [MemoryUsage](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryUsage.html) |
 | system.cpu.load                  | 1     |            |                  | System CPU load. See `com.sun.management.OperatingSystemMXBean.getSystemCpuLoad` |
 | system.cpu.load.average.1m       | 1     |            |                  | System CPU load average 1 minute See `java.lang.management.OperatingSystemMXBean.getSystemLoadAverage` |
-| system.memory.usage              | By    | state      | `used`, `free`   | see `com.sun.management.OperatingSystemMXBean.getTotalPhysicalMemorySize` and `com.sun.management.OperatingSystemMXBean.getFreePhysicalMemorySize` |  
-| system.memory.utilization        | 1     |            |                  | System memory utilization, see `com.sun.management.OperatingSystemMXBean.getTotalPhysicalMemorySize` and `com.sun.management.OperatingSystemMXBean.getFreePhysicalMemorySize`. Report `0%` if no physical memory is discovered by the JVM.| 
+| system.memory.usage              | By    | state      | `used`, `free`   | see `com.sun.management.OperatingSystemMXBean.getTotalPhysicalMemorySize` and `com.sun.management.OperatingSystemMXBean.getFreePhysicalMemorySize` |
+| system.memory.utilization        | 1     |            |                  | System memory utilization, see `com.sun.management.OperatingSystemMXBean.getTotalPhysicalMemorySize` and `com.sun.management.OperatingSystemMXBean.getFreePhysicalMemorySize`. Report `0%` if no physical memory is discovered by the JVM.|
 | system.paging.usage              | By    | state      | `used`, `free`   | see `com.sun.management.OperatingSystemMXBean.getFreeSwapSpaceSize` and `com.sun.management.OperatingSystemMXBean.getTotalSwapSpaceSize` |
 | system.paging.utilization        | 1     |            |                  | see `com.sun.management.OperatingSystemMXBean.getFreeSwapSpaceSize` and `com.sun.management.OperatingSystemMXBean.getTotalSwapSpaceSize`. Report `0%` if no swap memory is discovered by the JVM.|
 | process.cpu.load                 | 1     |            |                  | Process CPU load. See `com.sun.management.OperatingSystemMXBean.getProcessCpuLoad` |

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/GitCheckoutStepHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/GitCheckoutStepHandler.java
@@ -11,7 +11,9 @@ import com.google.common.collect.Iterables;
 import hudson.Extension;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.UserRemoteConfig;
+import hudson.plugins.git.extensions.impl.CloneOption;
 import hudson.scm.SCM;
+import io.jenkins.plugins.opentelemetry.semconv.JenkinsOtelSemanticAttributes;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.Tracer;
 import jenkins.YesNoMaybe;
@@ -29,8 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Customization of the {@code checkout ...} step when configured to access a Git repository.
@@ -81,22 +81,34 @@ public class GitCheckoutStepHandler extends AbstractGitStepHandler {
         final String stepFunctionName = node.getDisplayFunctionName();
         LOGGER.log(Level.FINE, () -> stepFunctionName + " - begin " + rootArguments);
 
+        boolean shallow = false;
+        int depth = 0;
+
         final BranchJobProperty branchJobProperty = run.getParent().getProperty(BranchJobProperty.class);
 
         // TODO better handling of cases where an expected property is not found
         if (branchJobProperty == null) {
             final Map<String, ?> scm = (Map<String, ?>) rootArguments.get("scm");
             if (scm == null) {
-                return tracer.spanBuilder(stepFunctionName);
+                return addCloneAttributes(tracer.spanBuilder(stepFunctionName), shallow, depth);
             }
             final Object clazz = scm.get("$class");
             if (!(Objects.equal(GitSCM.class.getSimpleName(), clazz))) {
-                return tracer.spanBuilder(stepFunctionName);
+                return addCloneAttributes(tracer.spanBuilder(stepFunctionName), shallow, depth);
             }
+
+            List<Map<String, ?>> extensions = (List<Map<String, ?>>) scm.get("extensions");
+            final Map<String, ?> cloneOption = Iterables.getFirst(extensions, null);
+
+            if (cloneOption != null) {
+                shallow = (Boolean) cloneOption.get("shallow");
+                depth = (Integer) cloneOption.get("depth");
+            }
+
             List<Map<String, ?>> userRemoteConfigs = (List<Map<String, ?>>) scm.get("userRemoteConfigs");
             final Map<String, ?> userRemoteConfig = Iterables.getFirst(userRemoteConfigs, null);
             if (userRemoteConfig == null) {
-                return tracer.spanBuilder(stepFunctionName);
+                return addCloneAttributes(tracer.spanBuilder(stepFunctionName), shallow, depth);
             }
             String gitUrl = (String) userRemoteConfig.get("url");
             String credentialsId = (String) userRemoteConfig.get("credentialsId");
@@ -109,8 +121,7 @@ public class GitCheckoutStepHandler extends AbstractGitStepHandler {
                 final Map<String, ?> branch = Iterables.getFirst(branches, null);
                 gitBranch = (String) branch.get("name");
             }
-
-            return super.createSpanBuilder(gitUrl, gitBranch, credentialsId, stepFunctionName, tracer, run);
+            return addCloneAttributes(super.createSpanBuilder(gitUrl, gitBranch, credentialsId, stepFunctionName, tracer, run), shallow, depth);
         } else {
             final Branch branch = branchJobProperty.getBranch();
             String gitBranch = branch.getName();
@@ -118,21 +129,32 @@ public class GitCheckoutStepHandler extends AbstractGitStepHandler {
             final SCM scm = branch.getScm();
             if (scm instanceof GitSCM) {
                 GitSCM gitScm = (GitSCM) scm;
+                CloneOption clone = gitScm.getExtensions().get(CloneOption.class);
+                if (clone != null) {
+                    depth = clone.getDepth();
+                    shallow = clone.isShallow();
+                }
                 final UserRemoteConfig userRemoteConfig = Iterables.getFirst(gitScm.getUserRemoteConfigs(), null);
                 if (userRemoteConfig == null) {
-                    return tracer.spanBuilder(stepFunctionName);
+                    return addCloneAttributes(tracer.spanBuilder(stepFunctionName), shallow, depth);
                 }
                 String gitUrl = userRemoteConfig.getUrl();
                 String credentialsId = userRemoteConfig.getCredentialsId();
 
                 if (Strings.isNullOrEmpty(gitUrl)) {
-                    return tracer.spanBuilder(stepFunctionName);
+                    return addCloneAttributes(tracer.spanBuilder(stepFunctionName), shallow, depth);
                 }
 
-                return super.createSpanBuilder(gitUrl, gitBranch, credentialsId, stepFunctionName, tracer, run);
+                return addCloneAttributes(super.createSpanBuilder(gitUrl, gitBranch, credentialsId, stepFunctionName, tracer, run), shallow, depth);
             } else {
-                return tracer.spanBuilder(stepFunctionName);
+                return addCloneAttributes(tracer.spanBuilder(stepFunctionName), shallow, depth);
             }
         }
+    }
+
+    private SpanBuilder addCloneAttributes(@Nonnull SpanBuilder spanBuilder, @Nonnull boolean shallow, @Nonnull int depth) throws Exception {
+        return spanBuilder
+            .setAttribute(JenkinsOtelSemanticAttributes.GIT_CLONE_DEPTH, (long) depth)
+            .setAttribute(JenkinsOtelSemanticAttributes.GIT_CLONE_SHALLOW, shallow);
     }
 }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/semconv/JenkinsOtelSemanticAttributes.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/semconv/JenkinsOtelSemanticAttributes.java
@@ -44,6 +44,8 @@ public final class JenkinsOtelSemanticAttributes {
     public static final AttributeKey<String>        GIT_REPOSITORY = AttributeKey.stringKey("git.repository");
     public static final AttributeKey<String>        GIT_BRANCH = AttributeKey.stringKey("git.branch");
     public static final AttributeKey<String>        GIT_USERNAME = AttributeKey.stringKey("git.username");
+    public static final AttributeKey<Long>          GIT_CLONE_DEPTH = AttributeKey.longKey("git.clone.depth");
+    public static final AttributeKey<Boolean>       GIT_CLONE_SHALLOW = AttributeKey.booleanKey("git.clone.shallow");
 
     /**
      * @see Jenkins#getRootUrl()

--- a/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginIntegrationTest.java
@@ -380,4 +380,32 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
         MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.JENKINS_STEP_PLUGIN_VERSION), CoreMatchers.is(CoreMatchers.notNullValue()));
     }
 
+    @Test
+    public void testPipelineWithCheckoutShallowSteps() throws Exception {
+        final String jobName = "test-pipeline-with-checkout-" + jobNameSuffix.incrementAndGet();
+
+        String pipelineScript = "node() {\n" +
+            "  stage('foo') {\n" +
+            "    checkout([$class: 'GitSCM', branches: [[name: '*/master']], extensions: [[$class: 'CloneOption', depth: 2, noTags: true, reference: '', shallow: true]], userRemoteConfigs: [[url: 'https://github.com/jenkinsci/opentelemetry-plugin']]]) \n" +
+            "  }\n" +
+            "}";
+        final Node agent = jenkinsRule.createOnlineSlave();
+        WorkflowJob pipeline = jenkinsRule.createProject(WorkflowJob.class, jobName);
+        pipeline.setDefinition(new CpsFlowDefinition(pipelineScript, true));
+        WorkflowRun build = jenkinsRule.assertBuildStatus(Result.SUCCESS, pipeline.scheduleBuild2(0));
+
+        final Tree<SpanDataWrapper> spans = getGeneratedSpans();
+        checkChainOfSpans(spans, "checkout: github.com/jenkinsci/opentelemetry-plugin", "Stage: foo", JenkinsOtelSemanticAttributes.AGENT_UI, "Phase: Run");
+        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(8L));
+
+        Optional<Tree.Node<SpanDataWrapper>> checkoutNode = spans.breadthFirstSearchNodes(node -> "checkout: github.com/jenkinsci/opentelemetry-plugin".equals(node.getData().spanData.getName()));
+        MatcherAssert.assertThat(checkoutNode, CoreMatchers.is(CoreMatchers.notNullValue()));
+
+        Attributes attributes = checkoutNode.get().getData().spanData.getAttributes();
+        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.JENKINS_STEP_PLUGIN_NAME), CoreMatchers.is(CoreMatchers.notNullValue()));
+        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.JENKINS_STEP_PLUGIN_VERSION), CoreMatchers.is(CoreMatchers.notNullValue()));
+        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.GIT_CLONE_SHALLOW), CoreMatchers.is(true));
+        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.GIT_CLONE_DEPTH), CoreMatchers.is(2L));
+    }
+
 }

--- a/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginMBPIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginMBPIntegrationTest.java
@@ -23,6 +23,7 @@ import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -69,6 +70,15 @@ public class JenkinsOtelPluginMBPIntegrationTest extends BaseIntegrationTest {
         MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.CI_PIPELINE_MULTIBRANCH_TYPE), CoreMatchers.is(OtelUtils.BRANCH));
         MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.CI_PIPELINE_TYPE), CoreMatchers.is(OtelUtils.MULTIBRANCH));
         MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.CI_PIPELINE_RUN_DESCRIPTION), CoreMatchers.is("Bar"));
+
+        // TODO: support the chain of spans for the checkout step (it uses some random folder name in the tests
+        // It returns the first checkout, aka the one without any shallow cloning, depth shallow.
+        Optional<Tree.Node<SpanDataWrapper>> checkoutNode = spans.breadthFirstSearchNodes(node -> node.getData().spanData.getName().startsWith("checkout:"));
+        MatcherAssert.assertThat(checkoutNode, CoreMatchers.is(CoreMatchers.notNullValue()));
+
+        attributes = checkoutNode.get().getData().spanData.getAttributes();
+        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.GIT_CLONE_SHALLOW), CoreMatchers.is(false));
+        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.GIT_CLONE_DEPTH), CoreMatchers.is(0L));
 
         // Environment variables are populated
         EnvVars environment = b1.getEnvironment(new LogTaskListener(LOGGER, Level.INFO));


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

### What

Add the git attributes for the shallow clone.

### Why

While working on some demos about advantages for using the opentelemetry, I realise, there were some attributes for the git checkout that could help with understanding without much context if the shallow cloning best practice has been implemented in any git checkout step


### For instance

Given a big massive git repository then

![image](https://user-images.githubusercontent.com/2871786/123102494-03f5f680-d42d-11eb-85d8-c2cfaf4ac164.png)

It means the checkout took 4 minutes, while if adding shallow clone options in the git checkout step the checkout time will be shorter.

While using the `checkout step` with some shallow cloning then

![image](https://user-images.githubusercontent.com/2871786/123110126-b630bc80-d433-11eb-8873-3bec7102e607.png)

Unfortunately, those attributes were not exposed in the existing metadata therefore I could not easily identify if the long checkout could be related to some misconfiguration in the git step, a third party issue, networking or so.