### PR TITLE
Support span labels with the plugin details for the SimpleBuildStep implementations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -286,10 +285,6 @@
             <artifactId>prune</artifactId>
             <version>1.3</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-basic-steps</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -287,6 +287,10 @@
             <version>1.3</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-basic-steps</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
@@ -240,7 +240,7 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
         // Support for https://javadoc.jenkins.io/jenkins/tasks/SimpleBuildStep.html
         if (descriptor instanceof CoreStep.DescriptorImpl) {
             Map<String, Object> arguments = ArgumentsAction.getFilteredArguments(node);
-            if (arguments.get("delegate") instanceOf UninstantiatedDescribable) {
+            if (arguments.get("delegate") instanceof UninstantiatedDescribable) {
               UninstantiatedDescribable describable = (UninstantiatedDescribable) arguments.get("delegate");
               if (describable != null) {
                   return SymbolLookup.get().findDescriptor(Describable.class, describable.getSymbol());

--- a/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
@@ -240,7 +240,7 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
         // Support for https://javadoc.jenkins.io/jenkins/tasks/SimpleBuildStep.html
         if (descriptor instanceof CoreStep.DescriptorImpl) {
             Map<String, Object> arguments = ArgumentsAction.getFilteredArguments(node);
-            if(arguments.get("delegate") instanceOf UninstantiatedDescribable){
+            if (arguments.get("delegate") instanceOf UninstantiatedDescribable) {
               UninstantiatedDescribable describable = (UninstantiatedDescribable) arguments.get("delegate");
               if (describable != null) {
                   return SymbolLookup.get().findDescriptor(Describable.class, describable.getSymbol());

--- a/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
@@ -240,9 +240,11 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
         // Support for https://javadoc.jenkins.io/jenkins/tasks/SimpleBuildStep.html
         if (descriptor instanceof CoreStep.DescriptorImpl) {
             Map<String, Object> arguments = ArgumentsAction.getFilteredArguments(node);
-            UninstantiatedDescribable describable = (UninstantiatedDescribable) arguments.get("delegate");
-            if (describable != null) {
-                return SymbolLookup.get().findDescriptor(Describable.class, describable.getSymbol());
+            if(arguments.get("delegate") instanceOf UninstantiatedDescribable){
+              UninstantiatedDescribable describable = (UninstantiatedDescribable) arguments.get("delegate");
+              if (describable != null) {
+                  return SymbolLookup.get().findDescriptor(Describable.class, describable.getSymbol());
+              }
             }
         }
         return descriptor;

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
@@ -244,7 +244,7 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
         // Support for https://javadoc.jenkins.io/jenkins/tasks/SimpleBuildStep.html
         if (stepDescriptor instanceof CoreStep.DescriptorImpl) {
             Map<String, Object> arguments = ArgumentsAction.getFilteredArguments(node);
-            if(arguments.get("delegate") instanceOf UninstantiatedDescribable){
+            if (arguments.get("delegate") instanceof UninstantiatedDescribable) {
               return (UninstantiatedDescribable) arguments.get("delegate");
             }
         }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
@@ -243,7 +243,9 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
         // Support for https://javadoc.jenkins.io/jenkins/tasks/SimpleBuildStep.html
         if (stepDescriptor instanceof CoreStep.DescriptorImpl) {
             Map<String, Object> arguments = ArgumentsAction.getFilteredArguments(node);
-            return (UninstantiatedDescribable) arguments.get("delegate");
+            if(arguments.get("delegate") instanceOf UninstantiatedDescribable){
+              return (UninstantiatedDescribable) arguments.get("delegate");
+            }
         }
         return null;
     }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
@@ -178,14 +178,14 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
                 spanBuilder = getTracer().spanBuilder(node.getDisplayFunctionName());
             }
 
-            String stepType = getStepType(node, node.getDescriptor(), "step");
+            String stepType = getStepType(node, node.getDescriptor(), JenkinsOtelSemanticAttributes.STEP_NAME);
             JenkinsOpenTelemetryPluginConfiguration.StepPlugin stepPlugin = JenkinsOpenTelemetryPluginConfiguration.get().findStepPluginOrDefault(stepType, node);
 
             spanBuilder
                     .setParent(Context.current())
                     .setAttribute(JenkinsOtelSemanticAttributes.JENKINS_STEP_TYPE, stepType)
                     .setAttribute(JenkinsOtelSemanticAttributes.JENKINS_STEP_ID, node.getId())
-                    .setAttribute(JenkinsOtelSemanticAttributes.JENKINS_STEP_NAME, getStepName(node, node.getDescriptor(), "step"))
+                    .setAttribute(JenkinsOtelSemanticAttributes.JENKINS_STEP_NAME, getStepName(node, JenkinsOtelSemanticAttributes.STEP_NAME))
                     .setAttribute(JenkinsOtelSemanticAttributes.CI_PIPELINE_RUN_USER, principal)
                     .setAttribute(JenkinsOtelSemanticAttributes.JENKINS_STEP_PLUGIN_NAME, stepPlugin.getName())
                     .setAttribute(JenkinsOtelSemanticAttributes.JENKINS_STEP_PLUGIN_VERSION, stepPlugin.getVersion());
@@ -215,13 +215,14 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
         return ignoreStep;
     }
 
-    private String getStepName(@Nonnull FlowNode node, @Nullable StepDescriptor stepDescriptor, @Nonnull String name) {
+    private String getStepName(@Nonnull StepAtomNode node, @Nonnull String name) {
+        StepDescriptor stepDescriptor = node.getDescriptor();
         if (stepDescriptor == null) {
             return name;
         }
         UninstantiatedDescribable describable = getUninstantiatedDescribableOrNull(node, stepDescriptor);
         if (describable != null) {
-            Descriptor<? extends Describable> d  = SymbolLookup.get().findDescriptor(Describable.class, describable.getSymbol());
+            Descriptor<? extends Describable> d = SymbolLookup.get().findDescriptor(Describable.class, describable.getSymbol());
             return d.getDisplayName();
         }
         return stepDescriptor.getDisplayName();

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
@@ -10,6 +10,8 @@ import com.google.errorprone.annotations.MustBeClosed;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.model.Computer;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
 import hudson.model.Run;
 import io.jenkins.plugins.opentelemetry.JenkinsOpenTelemetryPluginConfiguration;
 import io.jenkins.plugins.opentelemetry.OpenTelemetryAttributesAction;
@@ -28,6 +30,9 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import org.apache.commons.compress.utils.Sets;
+import org.jenkinsci.plugins.structs.SymbolLookup;
+import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable;
+import org.jenkinsci.plugins.workflow.actions.ArgumentsAction;
 import org.jenkinsci.plugins.workflow.actions.ErrorAction;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepAtomNode;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepEndNode;
@@ -35,6 +40,7 @@ import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode;
 import org.jenkinsci.plugins.workflow.flow.StepListener;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.steps.CoreStep;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
@@ -72,7 +78,7 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
         try (Scope nodeSpanScope = setupContext(run, stepStartNode)) {
             verifyNotNull(nodeSpanScope, "%s - No span found for node %s", run, stepStartNode);
             String agentSpanName = Strings.isNullOrEmpty(agentLabel) ? JenkinsOtelSemanticAttributes.AGENT_UI : JenkinsOtelSemanticAttributes.AGENT_UI + ": " + agentLabel;
-            String stepType = getStepType(stepStartNode.getDescriptor(), JenkinsOtelSemanticAttributes.STEP_NODE);
+            String stepType = getStepType(stepStartNode, stepStartNode.getDescriptor(), JenkinsOtelSemanticAttributes.STEP_NODE);
             JenkinsOpenTelemetryPluginConfiguration.StepPlugin stepPlugin = JenkinsOpenTelemetryPluginConfiguration.get().findStepPluginOrDefault(stepType, stepStartNode);
 
             Span agentSpan = getTracer().spanBuilder(agentSpanName)
@@ -92,7 +98,7 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
                 String allocateAgentSpanName = Strings.isNullOrEmpty(agentLabel) ? JenkinsOtelSemanticAttributes.AGENT_ALLOCATION_UI : JenkinsOtelSemanticAttributes.AGENT_ALLOCATION_UI + ": " + agentLabel;
                 Span allocateAgentSpan = getTracer().spanBuilder(allocateAgentSpanName)
                         .setParent(Context.current())
-                        .setAttribute(JenkinsOtelSemanticAttributes.JENKINS_STEP_TYPE, getStepType(stepStartNode.getDescriptor(), JenkinsOtelSemanticAttributes.STEP_NODE))
+                        .setAttribute(JenkinsOtelSemanticAttributes.JENKINS_STEP_TYPE, getStepType(stepStartNode, stepStartNode.getDescriptor(), JenkinsOtelSemanticAttributes.STEP_NODE))
                         .setAttribute(JenkinsOtelSemanticAttributes.JENKINS_STEP_ID, stepStartNode.getId())
                         .setAttribute(JenkinsOtelSemanticAttributes.JENKINS_STEP_NAME, JenkinsOtelSemanticAttributes.AGENT_ALLOCATE) // FIXME verify it's the right semantic and value
                         .setAttribute(JenkinsOtelSemanticAttributes.JENKINS_STEP_AGENT_LABEL, Strings.emptyToNull(agentLabel))
@@ -118,7 +124,7 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
             verifyNotNull(ignored, "%s - No span found for node %s", run, stepStartNode);
             String spanStageName = "Stage: " + stageName;
 
-            String stepType = getStepType(stepStartNode.getDescriptor(), "stage");
+            String stepType = getStepType(stepStartNode, stepStartNode.getDescriptor(),"stage");
             JenkinsOpenTelemetryPluginConfiguration.StepPlugin stepPlugin = JenkinsOpenTelemetryPluginConfiguration.get().findStepPluginOrDefault(stepType, stepStartNode);
 
             Span stageSpan = getTracer().spanBuilder(spanStageName)
@@ -172,14 +178,14 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
                 spanBuilder = getTracer().spanBuilder(node.getDisplayFunctionName());
             }
 
-            String stepType = getStepType(node.getDescriptor(), "step");
+            String stepType = getStepType(node, node.getDescriptor(), "step");
             JenkinsOpenTelemetryPluginConfiguration.StepPlugin stepPlugin = JenkinsOpenTelemetryPluginConfiguration.get().findStepPluginOrDefault(stepType, node);
 
             spanBuilder
                     .setParent(Context.current())
                     .setAttribute(JenkinsOtelSemanticAttributes.JENKINS_STEP_TYPE, stepType)
                     .setAttribute(JenkinsOtelSemanticAttributes.JENKINS_STEP_ID, node.getId())
-                    .setAttribute(JenkinsOtelSemanticAttributes.JENKINS_STEP_NAME, getStepName(node.getDescriptor(), "step"))
+                    .setAttribute(JenkinsOtelSemanticAttributes.JENKINS_STEP_NAME, getStepName(node, node.getDescriptor(), "step"))
                     .setAttribute(JenkinsOtelSemanticAttributes.CI_PIPELINE_RUN_USER, principal)
                     .setAttribute(JenkinsOtelSemanticAttributes.JENKINS_STEP_PLUGIN_NAME, stepPlugin.getName())
                     .setAttribute(JenkinsOtelSemanticAttributes.JENKINS_STEP_PLUGIN_VERSION, stepPlugin.getVersion());
@@ -209,16 +215,35 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
         return ignoreStep;
     }
 
-    private String getStepName(@Nullable StepDescriptor stepDescriptor, @Nonnull String name) {
+    private String getStepName(@Nonnull FlowNode node, @Nullable StepDescriptor stepDescriptor, @Nonnull String name) {
         if (stepDescriptor == null) {
             return name;
+        }
+
+        // Support for https://javadoc.jenkins.io/jenkins/tasks/SimpleBuildStep.html
+        if (stepDescriptor instanceof CoreStep.DescriptorImpl) {
+            Map<String, Object> arguments = ArgumentsAction.getFilteredArguments(node);
+            UninstantiatedDescribable describable = (UninstantiatedDescribable) arguments.get("delegate");
+            if (describable != null) {
+                Descriptor<? extends Describable> d  = SymbolLookup.get().findDescriptor(Describable.class, describable.getSymbol());
+                return d.getDisplayName();
+            }
         }
         return stepDescriptor.getDisplayName();
     }
 
-    private String getStepType(@Nullable StepDescriptor stepDescriptor, @Nonnull String type) {
+    private String getStepType(@Nonnull FlowNode node, @Nullable StepDescriptor stepDescriptor, @Nonnull String type) {
         if (stepDescriptor == null) {
             return type;
+        }
+
+        // Support for https://javadoc.jenkins.io/jenkins/tasks/SimpleBuildStep.html
+        if (stepDescriptor instanceof CoreStep.DescriptorImpl) {
+            Map<String, Object> arguments = ArgumentsAction.getFilteredArguments(node);
+            UninstantiatedDescribable describable = (UninstantiatedDescribable) arguments.get("delegate");
+            if (describable != null) {
+                return describable.getSymbol();
+            }
         }
         return stepDescriptor.getFunctionName();
     }
@@ -228,7 +253,7 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
         try (Scope ignored = setupContext(run, stepStartNode)) {
             verifyNotNull(ignored, "%s - No span found for node %s", run, stepStartNode);
 
-            String stepType = getStepType(stepStartNode.getDescriptor(), "branch");
+            String stepType = getStepType(stepStartNode, stepStartNode.getDescriptor(),"branch");
             JenkinsOpenTelemetryPluginConfiguration.StepPlugin stepPlugin = JenkinsOpenTelemetryPluginConfiguration.get().findStepPluginOrDefault(stepType, stepStartNode);
 
             Span atomicStepSpan = getTracer().spanBuilder("Parallel branch: " + branchName)

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
@@ -219,15 +219,10 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
         if (stepDescriptor == null) {
             return name;
         }
-
-        // Support for https://javadoc.jenkins.io/jenkins/tasks/SimpleBuildStep.html
-        if (stepDescriptor instanceof CoreStep.DescriptorImpl) {
-            Map<String, Object> arguments = ArgumentsAction.getFilteredArguments(node);
-            UninstantiatedDescribable describable = (UninstantiatedDescribable) arguments.get("delegate");
-            if (describable != null) {
-                Descriptor<? extends Describable> d  = SymbolLookup.get().findDescriptor(Describable.class, describable.getSymbol());
-                return d.getDisplayName();
-            }
+        UninstantiatedDescribable describable = getUninstantiatedDescribableOrNull(node, stepDescriptor);
+        if (describable != null) {
+            Descriptor<? extends Describable> d  = SymbolLookup.get().findDescriptor(Describable.class, describable.getSymbol());
+            return d.getDisplayName();
         }
         return stepDescriptor.getDisplayName();
     }
@@ -236,16 +231,21 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
         if (stepDescriptor == null) {
             return type;
         }
+        UninstantiatedDescribable describable = getUninstantiatedDescribableOrNull(node, stepDescriptor);
+        if (describable != null) {
+            return describable.getSymbol();
+        }
+        return stepDescriptor.getFunctionName();
+    }
 
+    @Nullable
+    private UninstantiatedDescribable getUninstantiatedDescribableOrNull(@Nonnull FlowNode node, @Nullable StepDescriptor stepDescriptor) {
         // Support for https://javadoc.jenkins.io/jenkins/tasks/SimpleBuildStep.html
         if (stepDescriptor instanceof CoreStep.DescriptorImpl) {
             Map<String, Object> arguments = ArgumentsAction.getFilteredArguments(node);
-            UninstantiatedDescribable describable = (UninstantiatedDescribable) arguments.get("delegate");
-            if (describable != null) {
-                return describable.getSymbol();
-            }
+            return (UninstantiatedDescribable) arguments.get("delegate");
         }
-        return stepDescriptor.getFunctionName();
+        return null;
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/opentelemetry/semconv/JenkinsOtelSemanticAttributes.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/semconv/JenkinsOtelSemanticAttributes.java
@@ -105,6 +105,10 @@ public final class JenkinsOtelSemanticAttributes {
      * The pipeline step node
      */
     public static final String STEP_NODE = "node";
+    /**
+     * The pipeline step name
+     */
+    public static final String STEP_NAME = "step";
 
 
     public static final AttributeKey<String>        ELASTIC_TRANSACTION_TYPE = AttributeKey.stringKey("type");


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

### What

Some plugins implement the [SimpleBuildStep](https://javadoc.jenkins.io/jenkins/tasks/SimpleBuildStep.html) and therefore there is no way to access directly to the pluginwrapper context for the step itself.

Those steps use the description class https://javadoc.jenkins.io/plugin/workflow-basic-steps/org/jenkinsci/plugins/workflow/steps/CoreStep.html and their `symbol`, aka their step syntax, can be accessed through the `ArgumentsAction` class, and more precisely the `delegate` key.  See [mailing-list](https://groups.google.com/g/jenkinsci-dev/c/UbJAeh8UZnE/m/KE5UIECOAAAJ)


### Test

For instance see the execution for the `googleStorageUpload` step provided by https://github.com/jenkinsci/google-storage-plugin/blob/6618c8ef7c4a0eaf2f2bc8a0b48383667e2478e3/src/main/java/com/google/jenkins/plugins/storage/ClassicUploadStep.java


![image](https://user-images.githubusercontent.com/2871786/123175824-590c2980-d47a-11eb-9a38-fa743054e381.png)


### Issue

Fixes https://github.com/jenkinsci/opentelemetry-plugin/issues/133