### PR TITLE
URLEncode rootSpanName before rendering TraceVisualisationUrl

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/OtelUtils.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/OtelUtils.java
@@ -19,6 +19,9 @@ import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.function.Function;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.io.UnsupportedEncodingException;
 
 public class OtelUtils {
 
@@ -161,5 +164,14 @@ public class OtelUtils {
     @Nonnull
     public static String toDebugString(@Nullable Span span) {
         return spanToDebugString().apply(span);
+    }
+
+    @Nonnull
+    public static String urlEncode(String value) {
+        try {
+            return URLEncoder.encode(value, StandardCharsets.UTF_8.toString());
+        } catch (UnsupportedEncodingException ex) {
+            throw new RuntimeException(ex.getCause());
+        }
     }
 }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringAction.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringAction.java
@@ -11,6 +11,7 @@ import hudson.model.Run;
 import io.jenkins.plugins.opentelemetry.JenkinsOpenTelemetryPluginConfiguration;
 import io.jenkins.plugins.opentelemetry.backend.ObservabilityBackend;
 import io.jenkins.plugins.opentelemetry.semconv.JenkinsOtelSemanticAttributes;
+import io.jenkins.plugins.opentelemetry.OtelUtils;
 import jenkins.model.Jenkins;
 import jenkins.model.RunAction2;
 import jenkins.tasks.SimpleBuildStep;
@@ -89,7 +90,7 @@ public class MonitoringAction implements Action, RunAction2, SimpleBuildStep.Las
         }
         Map<String, Object> binding = new HashMap<>();
         binding.put("serviceName", Objects.requireNonNull(JenkinsOpenTelemetryPluginConfiguration.get().getServiceName()));
-        binding.put("rootSpanName", spanNamingStrategy.getRootSpanName(run));
+        binding.put("rootSpanName", OtelUtils.urlEncode(spanNamingStrategy.getRootSpanName(run)));
         binding.put("traceId", this.traceId);
         binding.put("spanId", this.spanId);
         binding.put("startTime", Instant.ofEpochMilli(run.getStartTimeInMillis()));

--- a/src/test/java/io/jenkins/plugins/opentelemetry/MonitoringActionTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/MonitoringActionTest.java
@@ -6,6 +6,7 @@
 package io.jenkins.plugins.opentelemetry;
 
 import groovy.text.GStringTemplateEngine;
+import io.jenkins.plugins.opentelemetry.OtelUtils;
 import io.jenkins.plugins.opentelemetry.semconv.JenkinsOtelSemanticAttributes;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import org.junit.AfterClass;
@@ -33,7 +34,29 @@ public class MonitoringActionTest {
         Map<String, Object> binding = new HashMap<>();
         binding.put("baseUrl", "https://localhost:9200");
         binding.put("serviceName", JenkinsOtelSemanticAttributes.JENKINS);
-        binding.put("rootSpanName", "my-pipeline");
+        binding.put("rootSpanName", OtelUtils.urlEncode("my-pipeline"));
+        binding.put("traceId", "ef7e4138d38d9e24c494ce123ccbad5d");
+        binding.put("spanId", "a3bab980d6a51ba9");
+        binding.put("startTime", Instant.ofEpochMilli(1613086645141L));
+        String actual = new GStringTemplateEngine().createTemplate(template).make(binding).toString();
+        System.out.println(actual);
+    }
+
+    @Test
+    public void testGenerateVisualisationUrlEncoded() throws IOException, ClassNotFoundException {
+        String template = "${baseUrl}/app/apm/services/${serviceName}/transactions/view" +
+                "?rangeFrom=${startTime.minusSeconds(600)}" +
+                "&rangeTo=${startTime.plusSeconds(600)}" +
+                "&transactionName=${rootSpanName}" +
+                "&transactionType=unknown" +
+                "&latencyAggregationType=avg" +
+                "&traceId=${traceId}" +
+                "&transactionId=${spanId}";
+
+        Map<String, Object> binding = new HashMap<>();
+        binding.put("baseUrl", "https://localhost:9200");
+        binding.put("serviceName", JenkinsOtelSemanticAttributes.JENKINS);
+        binding.put("rootSpanName", OtelUtils.urlEncode("my+job-with+chars+that+need:escaping"));
         binding.put("traceId", "ef7e4138d38d9e24c494ce123ccbad5d");
         binding.put("spanId", "a3bab980d6a51ba9");
         binding.put("startTime", Instant.ofEpochMilli(1613086645141L));


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

When a Jenkins job contains characters that need to be URL encoded, like `+`, the `View pipeline with Elastic Observability` link ends up looking like this:
```
https://$YOUR_BASE_URL/view?
rangeFrom=2021-09-09T02:03:15.426Z&
rangeTo=2021-09-09T02:23:15.426Z&
transactionName=foo+bar-bar+qux+baz&
transactionType=unknown&
latencyAggregationType=avg&
traceId=b13f58669a80ccf236f5850110b74469&
transactionId=50182064eb5ca357
```

Since `+` gets interpreted as a space, when you click the link it gets turned into:
```
https://$YOUR_BASE_URL/view?
rangeFrom=2021-09-09T02:03:15.426Z&
rangeTo=2021-09-09T02:23:15.426Z&
transactionName=foo%20bar-bar%20baz%20qux&
transactionType=unknown&
latencyAggregationType=avg
```
So you don't get the results you were looking for since the transactionName value doesn't match.

Add a `urlEncode` method to `OtelUtils` to handle URL encoding as necessary.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
