### PR TITLE
Ignore ITs on Windows

### DIFF
--- a/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginIntegrationTest.java
@@ -5,6 +5,8 @@
 
 package io.jenkins.plugins.opentelemetry;
 
+import static org.junit.Assume.assumeFalse;
+
 import com.github.rutledgepaulv.prune.Tree;
 import com.google.common.collect.Iterables;
 import hudson.EnvVars;
@@ -22,6 +24,7 @@ import io.opentelemetry.sdk.metrics.data.LongPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricDataType;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricExporter;
+import org.apache.commons.lang3.SystemUtils;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
@@ -46,6 +49,7 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
 
     @Test
     public void testSimplePipeline() throws Exception {
+        assumeFalse(SystemUtils.IS_OS_WINDOWS);
         // BEFORE
 
         String pipelineScript = "def xsh(cmd) {if (isUnix()) {sh cmd} else {bat cmd}};\n" +
@@ -202,6 +206,7 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
 
     @Test
     public void testPipelineWithSkippedSteps() throws Exception {
+        assumeFalse(SystemUtils.IS_OS_WINDOWS);
         String pipelineScript = "def xsh(cmd) {if (isUnix()) {sh cmd} else {bat cmd}};\n" +
                 "node() {\n" +
                 "    stage('ze-stage1') {\n" +
@@ -292,6 +297,7 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
 
     @Test
     public void testPipelineWithParallelStep() throws Exception {
+        assumeFalse(SystemUtils.IS_OS_WINDOWS);
         String pipelineScript = "def xsh(cmd) {if (isUnix()) {sh cmd} else {bat cmd}};\n" +
                 "node() {\n" +
                 "    stage('ze-parallel-stage') {\n" +
@@ -326,6 +332,7 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
 
     @Test
     public void testPipelineWithGitCredentialsSteps() throws Exception {
+        assumeFalse(SystemUtils.IS_OS_WINDOWS);
         // Details defined in the JCasC file -> io/jenkins/plugins/opentelemetry/jcasc-elastic-backend.yml
         final String userName = "my-user-2";
         final String globalCredentialId = "user-and-password";
@@ -337,6 +344,7 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
 
     @Test
     public void testPipelineWithSshCredentialsSteps() throws Exception {
+        assumeFalse(SystemUtils.IS_OS_WINDOWS);
         // Details defined in the JCasC file -> io/jenkins/plugins/opentelemetry/jcasc-elastic-backend.yml
         final String userName = "my-user-1";
         final String globalCredentialId = "ssh-private-key";
@@ -348,6 +356,7 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
 
     @Test
     public void testPipelineWithoutGitCredentialsSteps() throws Exception {
+        assumeFalse(SystemUtils.IS_OS_WINDOWS);
         String credentialId = "unknown";
         final String jobName = "git-credentials-" + jobNameSuffix.incrementAndGet();
 
@@ -381,6 +390,7 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
 
     @Test
     public void testPipelineWithCheckoutShallowSteps() throws Exception {
+        assumeFalse(SystemUtils.IS_OS_WINDOWS);
         final String jobName = "with-checkout-" + jobNameSuffix.incrementAndGet();
 
         String pipelineScript = "node() {\n" +

--- a/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginMBPIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginMBPIntegrationTest.java
@@ -5,6 +5,8 @@
 
 package io.jenkins.plugins.opentelemetry;
 
+import static org.junit.Assume.assumeFalse;
+
 import com.github.rutledgepaulv.prune.Tree;
 import hudson.EnvVars;
 import hudson.model.Run;
@@ -15,6 +17,7 @@ import jenkins.branch.BranchProperty;
 import jenkins.branch.BranchSource;
 import jenkins.branch.DefaultBranchPropertyStrategy;
 import jenkins.plugins.git.GitSCMSource;
+import org.apache.commons.lang3.SystemUtils;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -32,6 +35,7 @@ public class JenkinsOtelPluginMBPIntegrationTest extends BaseIntegrationTest {
 
     @Test
     public void testMultibranchPipelineStep() throws Exception {
+        assumeFalse(SystemUtils.IS_OS_WINDOWS);
         String pipelineScript = "pipeline {\n" +
                 "  agent any\n" +
                 "  stages {\n" +

--- a/src/test/java/io/jenkins/plugins/opentelemetry/OtelUtilsTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/OtelUtilsTest.java
@@ -5,6 +5,8 @@
 
 package io.jenkins.plugins.opentelemetry;
 
+import static org.junit.Assume.assumeFalse;
+
 import hudson.matrix.AxisList;
 import hudson.matrix.MatrixBuild;
 import hudson.matrix.MatrixProject;
@@ -18,6 +20,7 @@ import jenkins.branch.BranchProperty;
 import jenkins.branch.BranchSource;
 import jenkins.branch.DefaultBranchPropertyStrategy;
 import jenkins.plugins.git.GitSCMSource;
+import org.apache.commons.lang3.SystemUtils;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
@@ -110,6 +113,7 @@ public class OtelUtilsTest extends BaseIntegrationTest {
 
     @Test
     public void test_multibranch() throws Exception {
+        assumeFalse(SystemUtils.IS_OS_WINDOWS);
         sampleRepo.init();
         sampleRepo.write("Jenkinsfile", "echo 'hi'");
         sampleRepo.write("file", "initial content");


### PR DESCRIPTION
Supersedes https://github.com/jenkinsci/opentelemetry-plugin/pull/167

Asked in the [jenkins-dev](https://groups.google.com/g/jenkinsci-dev/c/TfENbStxWIc) and might require some changes in the Windows CI workers to support the filename too long. 

Ignore those tests on windows for the time being.