### PR TITLE
fix the UTs since they require git version < 2.28 in the CI

### DIFF
--- a/src/test/java/jenkins/plugins/git/ExtendedGitSampleRepoRule.java
+++ b/src/test/java/jenkins/plugins/git/ExtendedGitSampleRepoRule.java
@@ -67,7 +67,7 @@ public final class ExtendedGitSampleRepoRule extends AbstractSampleDVCSRepoRule 
         run(true, tmp.getRoot(), "git", "version");
         checkGlobalConfig();
         git("init");
-        git("checkout -b " + this.initialBranch);
+        git("checkout", "-b", this.initialBranch);
         write("file", "");
         git("add", "file");
         git("config", "user.name", "Git SampleRepoRule");

--- a/src/test/java/jenkins/plugins/git/ExtendedGitSampleRepoRule.java
+++ b/src/test/java/jenkins/plugins/git/ExtendedGitSampleRepoRule.java
@@ -66,7 +66,8 @@ public final class ExtendedGitSampleRepoRule extends AbstractSampleDVCSRepoRule 
     public void init() throws Exception {
         run(true, tmp.getRoot(), "git", "version");
         checkGlobalConfig();
-        git("init", "--initial-branch=" + this.initialBranch);
+        git("init");
+        git("checkout -b " + this.initialBranch);
         write("file", "");
         git("add", "file");
         git("config", "user.name", "Git SampleRepoRule");


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

There are test failures in the CI since the version is not compatible with the flag `--initial-branch`

```
=== Starting io.jenkins.plugins.opentelemetry.JenkinsOtelPluginMBPIntegrationTest
beforeClass()
Wait for jenkins to start...
Jenkins started
[junit1226381304940932694] $ git version
git version 2.25.1
[junit930182219919385916] $ git init --initial-branch=master
error: unknown option `initial-branch=master'
usage: git init [-q | --quiet] [--bare] [--template=<template-directory>] [--shared[=<permissions>]] [<directory>]
```
