### PR TITLE
Enrich opentelemetry attributes explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   - [Monitoring and troubleshooting Jenkins jobs using distributed tracing](#monitoring-and-troubleshooting-jenkins-jobs-using-distributed-tracing)
   - [Metrics on Jenkins health indicators](#metrics-on-jenkins-health-indicators)
 - [Getting Started](#getting-started)
+- [Pipeline syntax](#Pipeline-syntax)
 - [Examples](#screenshots)
 - [Configuration as Code](#configuration-as-code)
 - [Demos](#demos)
@@ -356,6 +357,37 @@ See the [jcasc](src/test/resources/io/jenkins/plugins/opentelemetry/jcasc) folde
 For more details see the configuration as code plugin documentation:
 <https://github.com/jenkinsci/configuration-as-code-plugin#getting-started>
 
+
+## Pipeline syntax
+
+**Available since `opentelemetry-0.20`**
+
+You can enrich your distributed traces with some attributes that are stored as properties or options, in your pipelines.
+
+### Declarative pipeline:
+
+```groovy
+pipeline {
+    ...
+    options {
+        opentelemetry('your-org=acme,team=your-team,project=your-project')
+    }
+    stages{...}
+}
+```
+
+### Scripted pipeline:
+
+```groovy
+properties([
+    opentelemetry('your-org=acme,team=your-team,project=your-project')
+])
+node {
+    ...
+}
+```
+
+You can specify multiple attributes separated by commas.
 
 ## Demos
 

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/OpentelemetryJobProperty.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/OpentelemetryJobProperty.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.job;
+
+import hudson.Extension;
+import hudson.model.Job;
+import hudson.model.JobProperty;
+import hudson.model.JobPropertyDescriptor;
+import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
+
+import javax.annotation.Nonnull;
+
+public class OpentelemetryJobProperty extends JobProperty<Job<?,?>> {
+
+    private final String metadata;
+
+    @DataBoundConstructor
+    public OpentelemetryJobProperty(@Nonnull String metadata) {
+        this.metadata = metadata;
+    }
+
+    public String getMetadata() {
+        return metadata;
+    }
+
+    @Extension
+    @Symbol("opentelemetry")
+    public static class DescriptorImpl extends JobPropertyDescriptor {
+        @Override
+        public String getDisplayName() {
+            return "Add OpenTelemetry attributes to the job";
+        }
+
+        public String getPropertyName() {
+            return "opentelemetry-property";
+        }
+
+        @Override
+        public OpentelemetryJobProperty newInstance(StaplerRequest req, JSONObject formData)
+            throws hudson.model.Descriptor.FormException {
+            if (formData == null || formData.isNullObject()) {
+                return null;
+            }
+            JSONObject form = formData.getJSONObject(getPropertyName());
+            if (form == null || form.isNullObject()) {
+                return null;
+            }
+            return (OpentelemetryJobProperty) super.newInstance(req, form);
+        }
+    }
+}

--- a/src/main/resources/io/jenkins/plugins/opentelemetry/job/OpentelemetryJobProperty/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/opentelemetry/job/OpentelemetryJobProperty/config.jelly
@@ -1,0 +1,8 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:optionalBlock name="${descriptor.propertyName}" title="${descriptor.displayName}" checked="${instance != null}">
+    <f:entry title="${%Opentelemetry metadata}" field="metadata">
+      <f:textbox />
+    </f:entry>
+  </f:optionalBlock>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/opentelemetry/job/OpentelemetryJobProperty/help.html
+++ b/src/main/resources/io/jenkins/plugins/opentelemetry/job/OpentelemetryJobProperty/help.html
@@ -1,0 +1,3 @@
+<div>
+    Define the metadata to be populated to the distributed trace of that particular build.
+</div>

--- a/src/test/java/io/jenkins/plugins/opentelemetry/job/OpentelemetryJobPropertyTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/job/OpentelemetryJobPropertyTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.job;
+
+import hudson.model.FreeStyleProject;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class OpentelemetryJobPropertyTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testFreestyle() throws Exception {
+        JenkinsRule.WebClient wc = j.createWebClient();
+        // not configured
+        {
+            FreeStyleProject p = j.createFreeStyleProject();
+            assertNull(p.getProperty(OpentelemetryJobProperty.class));
+
+            j.submit(wc.getPage(p, "configure").getFormByName("config"));
+
+            p = j.jenkins.getItemByFullName(p.getFullName(), FreeStyleProject.class);
+            assertNotNull(p);
+            assertNull(p.getProperty(OpentelemetryJobProperty.class));
+        }
+
+        // configured
+        {
+            FreeStyleProject p = j.createFreeStyleProject();
+            p.addProperty(new OpentelemetryJobProperty("my-metadata=123"));
+
+            j.submit(wc.getPage(p, "configure").getFormByName("config"));
+
+            p = j.jenkins.getItemByFullName(p.getFullName(), FreeStyleProject.class);
+            assertNotNull(p);
+            OpentelemetryJobProperty prop = p.getProperty(OpentelemetryJobProperty.class);
+            assertNotNull(prop);
+            assertEquals("my-metadata=123", prop.getMetadata());
+        }
+    }
+
+    @Test
+    public void testPipeline() throws Exception {
+        WorkflowJob upstream = j.createProject(WorkflowJob.class, "upstream");
+        upstream.setDefinition(new CpsFlowDefinition("properties([opentelemetry('my-metadata=123')]); echo 'hi'", true));
+        j.buildAndAssertSuccess(upstream);
+        OpentelemetryJobProperty prop = upstream.getProperty(OpentelemetryJobProperty.class);
+        assertNotNull(prop);
+        assertEquals("my-metadata=123", prop.getMetadata());
+    }
+}


### PR DESCRIPTION
🚧 
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

### What

Support opentelemetry option/property to define attributes/properties that are added to all the spans of the pipeline execution.

### Question

- Do we want to apply those attributes to all the spans for the given trace, or only top-level transaction?
- Do we want to allow fine granularity:
  - for all the spans option
  - for the top level transaction?

### Action

- [ ] Read properties and apply them to the trace.
- [ ] Support for traditional jobs.
- [ ] Test MBP

### Issue

- https://github.com/jenkinsci/opentelemetry-plugin/issues/173

### UI

#### Declarative directive generator

![image](https://user-images.githubusercontent.com/2871786/136437154-555c5102-5e1d-4651-b7ce-0a57344ae8db.png)
