### PR TITLE
Remove UseAVX from elasticsearch jvm opts

### DIFF
--- a/demos/docker-compose.yml
+++ b/demos/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       - cluster.name=docker-cluster
       - cluster.routing.allocation.disk.threshold_enabled=false
       - discovery.type=single-node
-      - ES_JAVA_OPTS=-XX:UseAVX=2 -Xms1g -Xmx1g
+      - ES_JAVA_OPTS=-Xms1g -Xmx1g
     ulimits:
       memlock:
         hard: -1


### PR DESCRIPTION
This change was reverted in https://github.com/elastic/elasticsearch/pull/40828

It works fine on Java 11+

It prevents the demo from working on arm64 such as mac m1