### PR TITLE
Add line on resource requirements

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -24,7 +24,7 @@ This is an example of distributed tracing with Jenkins based on:
 
 ## System Requirements
 
-- Docker >= 19.x.x
+- Docker >= 19.x.x (make sure you have greater than 2gb memory allocated to Docker)
 - Docker Compose >= 1.25.0
 - Java >= 8
 - *nix based (preferably x86_64)


### PR DESCRIPTION
I'm running on docker for mac which defaulted to 4 CPUs and 2gb memory allocated to docker.

The elasticsearch container wouldn't start with the amount allocated.

I increased it to 4gb and it worked

Not 100% sure on where this should go but I think it should be mentioned