### PR TITLE
Add support for Jaeger and Prometheus exporters via Otel SDK Auto Configuration Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ service:
       ...
 ```
 
+### Configuring the Jenkins OpenTelemetry Plugin using OpenTelemetry standard environment variables and system properties
+
+The configuration of the Jenkins OpenTelemetry plugin that relate to the export of the signals can be set up using the standard OpenTelemetry configuration environment variables and system properties.
+The Jenkins OpenTelemetry plugin supports the following exporters: OTLP, Jaeger, Prometheus, and Logging.
+
+When specifying configuration parameters mixing environment variables, system properties, and Jenkins Otel plugin config, the order of precedence is: Jenkins Plugin Config > JVM System Properties > Environment Variable.
+Note that the key-value pairs of the `OTEL_RESOURCE_ATTRIBUTES` attributes are merged across all the layers of settings.
+
+All the system properties and environment variables of the [OpenTelemetry SDK Auto Configuration Extension](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md) are supported at the exception of the settings of Zipkin exporter which is not included.
+
 
 ## Features
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,13 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
+                <groupId>io.prometheus</groupId>
+                <artifactId>simpleclient_bom</artifactId>
+                <version>0.12.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>io.grpc</groupId>
                 <artifactId>grpc-bom</artifactId>
                 <version>1.41.0</version>
@@ -95,6 +102,10 @@
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-metrics</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk-extension-autoconfigure-spi</artifactId>
         </dependency>
         <dependency>
@@ -129,16 +140,6 @@
             <artifactId>opentelemetry-exporter-otlp-metrics</artifactId>
         </dependency>
         <dependency>
-            <!-- authentication header... -->
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-stub</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-netty-shaded</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-otlp-trace</artifactId>
         </dependency>
@@ -146,11 +147,16 @@
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-logging</artifactId>
         </dependency>
+
         <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-sdk-metrics</artifactId>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_httpserver</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+        </dependency>
 
         <dependency> <!-- see maskClasses config -->
             <groupId>com.google.guava</groupId>

--- a/src/main/java/io/jenkins/plugins/opentelemetry/OpenTelemetryConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/OpenTelemetryConfiguration.java
@@ -5,15 +5,26 @@
 
 package io.jenkins.plugins.opentelemetry;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.jenkins.plugins.opentelemetry.authentication.NoAuthentication;
 import io.jenkins.plugins.opentelemetry.authentication.OtlpAuthentication;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import org.apache.commons.lang.StringUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 public class OpenTelemetryConfiguration {
+
+    @SuppressFBWarnings
+    @VisibleForTesting
+    public static boolean TESTING_INMEMORY_MODE = false;
 
     private final String endpoint;
     private final String trustedCertificatesPem;
@@ -79,6 +90,49 @@ public class OpenTelemetryConfiguration {
         return exporterIntervalMillis;
     }
 
+    public Map<String, String> toOpenTelemetryAutoConfigurationProperties() {
+        Map<String, String> configuration = new HashMap<>();
+        Map<String, String> resourceAttributes = new HashMap<>();
+
+        if (StringUtils.isNotBlank(endpoint)){
+            Preconditions.checkArgument(
+                endpoint.startsWith("http://") ||
+                    endpoint.startsWith("https://"),
+                "endpoint must be prefixed by 'http://' or 'https://': %s", endpoint);
+
+            configuration.put("otel.traces.exporter", "otlp");
+            configuration.put("otel.metrics.exporter", "otlp");
+            configuration.put("otel.exporter.otlp.endpoint", endpoint);
+        }
+        if (StringUtils.isNotBlank(serviceName)) {
+            configuration.put("otel.service.name", serviceName);
+        }
+        if (StringUtils.isNotBlank(serviceNamespace)) {
+            resourceAttributes.put(ResourceAttributes.SERVICE_NAMESPACE.getKey(), serviceNamespace);
+        }
+        if (StringUtils.isNotBlank(trustedCertificatesPem)) {
+            configuration.put("otel.exporter.otlp.certificate", trustedCertificatesPem);
+        }
+        if (authentication != null) {
+            authentication.enrichOpenTelemetryAutoConfigureConfigProperties(configuration);
+        }
+        if (exporterTimeoutMillis != null) {
+            configuration.put("otel.exporter.otlp.timeout", Integer.toString(exporterTimeoutMillis));
+        }
+        if (exporterIntervalMillis != null) {
+            configuration.put("otel.imr.export.interval", Integer.toString(exporterIntervalMillis));
+        }
+
+        configuration.put("otel.resource.attributes", OtelUtils.getComaSeparatedString(resourceAttributes));
+
+        if (OpenTelemetryConfiguration.TESTING_INMEMORY_MODE) {
+            configuration.put("otel.traces.exporter", "testing");
+            configuration.put("otel.metrics.exporter", "testing");
+            configuration.put("otel.imr.export.interval", "10");
+        }
+
+        return  configuration;
+    }
     @Nullable
     public String getIgnoredSteps() {
         return ignoredSteps;

--- a/src/main/java/io/jenkins/plugins/opentelemetry/OtelUtils.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/OtelUtils.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 import java.net.URLEncoder;
@@ -47,17 +48,9 @@ public class OtelUtils {
     public static final String TAG = "tag";
     public static final String JENKINS_CORE = "jenkins-core";
 
-    public static String getConfiguration(
-        @Nullable String pluginConfigurationValue, @Nonnull String systemPropertyName, @Nonnull String environmentVariableName) {
-        if (StringUtils.isNotBlank(pluginConfigurationValue)) {
-            return pluginConfigurationValue;
-        }
-       return getSystemPropertyOrEnvironmentVariable(systemPropertyName, environmentVariableName);
-    }
-
     @CheckForNull
-    public static String getSystemPropertyOrEnvironmentVariable(
-        String systemPropertyName, String environmentVariableName) {
+    public static String getSystemPropertyOrEnvironmentVariable(String environmentVariableName) {
+        String systemPropertyName = environmentVariableName.replace('_', '.').toLowerCase(Locale.ROOT);
         String systemProperty = System.getProperty(systemPropertyName);
         if (StringUtils.isNotBlank(systemProperty)) {
             return systemProperty;
@@ -75,6 +68,7 @@ public class OtelUtils {
             .collect(Collectors.joining(","));
     }
 
+    @Nonnull
     public static Map<String, String> getCommaSeparatedMap(@Nullable String comaSeparatedKeyValuePairs) {
         if (StringUtils.isBlank(comaSeparatedKeyValuePairs)) {
             return new HashMap<>();

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelEnvironmentContributorService.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelEnvironmentContributorService.java
@@ -52,9 +52,15 @@ public class OtelEnvironmentContributorService {
         if (this.jenkinsOpenTelemetryPluginConfiguration.isExportOtelConfigurationAsEnvironmentVariables()) {
             Map<String, String> otelConfiguration = jenkinsOpenTelemetryPluginConfiguration.getOtelConfigurationAsEnvironmentVariables();
             for (Map.Entry<String, String> otelEnvironmentVariable : otelConfiguration.entrySet()) {
-                String previousValue = envs.put(otelEnvironmentVariable.getKey(), otelEnvironmentVariable.getValue());
-                if (previousValue != null) {
-                    LOGGER.log(Level.FINE, "Overwrite environment variable '" + otelEnvironmentVariable.getKey() + "'");
+                String envVarValue = otelEnvironmentVariable.getValue();
+                String envVarName = otelEnvironmentVariable.getKey();
+                if (envVarValue == null) {
+                    LOGGER.log(Level.FINE, () -> "No value found for environment variable '" + envVarName + "'");
+                } else {
+                    String previousValue = envs.put(envVarName, envVarValue);
+                    if (previousValue != null) {
+                        LOGGER.log(Level.FINE, () -> "Overwrite environment variable '" + envVarName + "'");
+                    }
                 }
             }
         } else {

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelTraceService.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelTraceService.java
@@ -13,7 +13,6 @@ import com.google.common.collect.Multimap;
 import com.google.errorprone.annotations.MustBeClosed;
 import hudson.Extension;
 import hudson.model.AbstractBuild;
-import hudson.model.BuildListener;
 import hudson.model.Run;
 import hudson.tasks.BuildStep;
 import io.jenkins.plugins.opentelemetry.OpenTelemetrySdkProvider;

--- a/src/main/java/io/jenkins/plugins/opentelemetry/opentelemetry/autoconfigure/ConfigPropertiesUtils.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/opentelemetry/autoconfigure/ConfigPropertiesUtils.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.opentelemetry.autoconfigure;
+
+import com.google.common.collect.Lists;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class ConfigPropertiesUtils {
+    public static String prettyPrintConfiguration(ConfigProperties config) {
+        List<String> attributeNames = Lists.newArrayList(
+            "otel.resource.attributes", "otel.service.name",
+            "otel.traces.exporter", "otel.metrics.exporter", "otel.exporter.otlp.endpoint"
+            , "otel.exporter.otlp.traces.endpoint", "otel.exporter.otlp.metrics.endpoint",
+            "otel.exporter.jaeger.endpoint",
+            "otel.exporter.prometheus.port");
+
+        Map<String, String> message = new LinkedHashMap<>();
+        for (String attributeName: attributeNames) {
+            final String attributeValue = config.getString(attributeName);
+            if (attributeValue != null) {
+                message.put(attributeName, attributeValue);
+            }
+        }
+        return message.entrySet().stream().map(entry -> entry.getKey() + "=" + entry.getValue()).collect(Collectors.joining(", "));
+    }
+}

--- a/src/test/java/io/jenkins/plugins/opentelemetry/BaseIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/BaseIntegrationTest.java
@@ -60,7 +60,7 @@ public class BaseIntegrationTest {
     private static final Logger LOGGER = Logger.getLogger(Run.class.getName());
 
     static {
-        OpenTelemetrySdkProvider.TESTING_INMEMORY_MODE = true;
+        OpenTelemetryConfiguration.TESTING_INMEMORY_MODE = true;
     }
 
     final static AtomicInteger jobNameSuffix = new AtomicInteger();
@@ -100,7 +100,7 @@ public class BaseIntegrationTest {
         openTelemetrySdkProvider = openTelemetrySdkProviders.get(0);
 
         // verify(openTelemetrySdkProvider.openTelemetry == null, "OpenTelemetrySdkProvider has already been configured");
-        OpenTelemetrySdkProvider.TESTING_INMEMORY_MODE = true;
+        OpenTelemetryConfiguration.TESTING_INMEMORY_MODE = true;
         openTelemetrySdkProvider.initialize(new OpenTelemetryConfiguration());
 
         // openTelemetrySdkProvider.tracer.setDelegate(openTelemetrySdkProvider.openTelemetry.getTracer("jenkins"));

--- a/src/test/java/io/jenkins/plugins/opentelemetry/opentelemetry/autoconfigure/DefaultConfigPropertiesTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/opentelemetry/autoconfigure/DefaultConfigPropertiesTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.opentelemetry.autoconfigure;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+public class DefaultConfigPropertiesTest {
+
+    @Test
+    public void createFromConfiguration() {
+
+        Map<String, String> defaultCfg = new HashMap<>();
+        Map<String, String> envVars = new HashMap<>();
+        Properties systemProperties = new Properties();
+        Map<String, String> overwrites = new HashMap<>();
+
+
+        // SETUP
+        defaultCfg.put("otel.service.name", "jenkins");
+        defaultCfg.put("otel.resource.attributes", "service.namespace=jenkins");
+
+        envVars.put("OTEL_EXPORTER_OTLP_ENDPOINT", "https://otel-endpoint.example.com");
+        envVars.put("OTEL_EXPORTER_OTLP_HEADERS", "Authorization=Bearer my-token");
+
+        overwrites.put("otel.service.name", "jenkins-123");
+        overwrites.put("otel.resource.attributes", "jenkins.url=https://jenkins-123.example.com");
+
+
+        // VERIFY
+        DefaultConfigProperties configProperties = DefaultConfigProperties.createFromConfiguration(overwrites, systemProperties, envVars, defaultCfg);
+        MatcherAssert.assertThat(configProperties.getString("otel.service.name"), CoreMatchers.is("jenkins-123"));
+        MatcherAssert.assertThat(configProperties.getString("otel.exporter.otlp.endpoint"), CoreMatchers.is("https://otel-endpoint.example.com"));
+        final Map<String, String> otlpExporterHeaders = configProperties.getMap("otel.exporter.otlp.headers");
+        MatcherAssert.assertThat(otlpExporterHeaders.get("Authorization"), CoreMatchers.is("Bearer my-token"));
+
+
+        Map<String, String> resourceAttributes = configProperties.getMap("otel.resource.attributes");
+        MatcherAssert.assertThat(resourceAttributes.get("service.namespace"), CoreMatchers.is("jenkins"));
+        MatcherAssert.assertThat(resourceAttributes.get("jenkins.url"), CoreMatchers.is("https://jenkins-123.example.com"));
+    }
+}


### PR DESCRIPTION
Add support for Jaeger and Prometheus exporters via Otel SDK Auto Configuration Extension.

The list of supported configuration attributes is available on https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md 

Note that Zipkin exporter is not supported to not add too many dependencies with the Jenkins Otel Plugin.

You can activate the  Jaeger or Prometheus exporters just like:

```shell
export OTEL_TRACES_EXPORTER=jaeger
export OTEL_METRICS_EXPORTER=prometheus
# assuming that the Otel Jenkins Plugin is installed ,just start Jenkins
java -jar jenkins.war 
```


<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
