### PR TITLE
Prevent StackOverflowError in `FlowNode#getParents()`

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelTraceService.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelTraceService.java
@@ -154,7 +154,7 @@ public class OtelTraceService {
             if (flowNode.equals(parentNode)) {
                 LOGGER.log(Level.INFO, "buildListOfAncestors(" + flowNode + "): skip parentFlowNode as it is the current node"); // TODO change message to Level.FINE once the cause is understood
             } else if (parents.contains(parentNode)) {
-                LOGGER.log(Level.INFO, "buildListOfAncestors(" + flowNode + "): skip already added " + flowNode);  // TODO can we remove this check once the cause is understood?
+                LOGGER.log(Level.INFO, "buildListOfAncestors(" + flowNode + "): skip already added " + parentNode);  // TODO can we remove this check once the cause is understood?
             } else {
                 buildListOfAncestors(parentNode, parents);
             }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelTraceService.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelTraceService.java
@@ -31,7 +31,11 @@ import org.jenkinsci.plugins.workflow.support.steps.ExecutorStep;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 import javax.inject.Inject;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
@@ -147,7 +151,13 @@ public class OtelTraceService {
             flowNode = startNode;
         }
         for (FlowNode parentNode : flowNode.getParents()) {
-            buildListOfAncestors(parentNode, parents);
+            if (flowNode.equals(parentNode)) {
+                LOGGER.log(Level.INFO, "buildListOfAncestors(" + flowNode + "): skip parentFlowNode as it is the current node"); // TODO change message to Level.FINE once the cause is understood
+            } else if (parents.contains(parentNode)) {
+                LOGGER.log(Level.INFO, "buildListOfAncestors(" + flowNode + "): skip already added " + flowNode);  // TODO can we remove this check once the cause is understood?
+            } else {
+                buildListOfAncestors(parentNode, parents);
+            }
         }
     }
 


### PR DESCRIPTION
Prevent StackOverflowError when `o.j.p.workflow.graph.FlowNode#getParents()` returns a node that is the current node or a child node. Fix 
- https://github.com/jenkinsci/opentelemetry-plugin/issues/197

ℹ️ contains some verbose log message to understand better the problem working with @bulanovk. These log messages will have to be cleaned up.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

