### PR TITLE
missing tls key for insecure configuration

### DIFF
--- a/demos/config/otel-collector-config.yaml
+++ b/demos/config/otel-collector-config.yaml
@@ -17,11 +17,13 @@ exporters:
 
   jaeger:
     endpoint: jaeger-all-in-one:14250
-    insecure: true
+    tls:
+      insecure: true
 
   otlp/elastic:
     endpoint: "apm-server:8200"
-    insecure: true
+    tls:
+      insecure: true
 
 processors:
   batch:


### PR DESCRIPTION
Missing the "tls" section for jaeger and elastic in otel-configuration.yaml demo file.