### PR TITLE
Better `ci.pipeline.run.cause` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,7 @@ In addition, if the backends were configured then there will be an environment v
 | ci.pipeline.run.result           | Build result | Enum (`aborted`, `success`, `failure`, `not_build` and `unstable`) |
 | ci.pipeline.run.url              | Build URL | String |
 | ci.pipeline.run.user             | Who triggered the build | String |
-| ci.pipeline.run.cause.xxx        | List of machine readable build causes | String |
-| ci.pipeline.run.cause.description| List of human readable description of build causes | String |
+| ci.pipeline.run.cause            | List of machine readable build causes like `UserIdCause:anonymous` or `BranchIndexingCause`. Pattern : `${cause.class.simpleName}[:details]` | String |
 | ci.pipeline.parameter.sensitive  | Whether the information contained in this parameter is sensitive or security related. | Boolean |
 | ci.pipeline.parameter.name       | Name of the parameter | String |
 | ci.pipeline.parameter.value      | Value of the parameter. "Sensitive" values are redacted | String |

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringRunListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringRunListener.java
@@ -137,21 +137,18 @@ public class MonitoringRunListener extends OtelContextAwareAbstractRunListener {
 
         // CAUSES
         if (!run.getCauses().isEmpty()) {
-            List<String> causeXxx = new ArrayList<>();
-            List<String> causeDescriptions = new ArrayList<>();
+            List<String> causesDescriptions = new ArrayList<>();
 
             run.getCauses()
                 .stream()
                 .forEach( cause -> {
                     for (CauseHandler stepHandler : ExtensionList.lookup(CauseHandler.class)) {
                         if (stepHandler.canAddAttributes((Cause) cause)) {
-                            causeDescriptions.add(stepHandler.getDescription());
-                            causeXxx.add(stepHandler.getXxx());
+                            causesDescriptions.add(stepHandler.getStructuredDescription());
                         }
                     }
                 });
-            rootSpanBuilder.setAttribute(JenkinsOtelSemanticAttributes.CI_PIPELINE_RUN_CAUSE_XXX, causeXxx);
-            rootSpanBuilder.setAttribute(JenkinsOtelSemanticAttributes.CI_PIPELINE_RUN_CAUSE_DESCRIPTION, causeDescriptions);
+            rootSpanBuilder.setAttribute(JenkinsOtelSemanticAttributes.CI_PIPELINE_RUN_CAUSE, causesDescriptions);
         }
 
         // START ROOT SPAN

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/cause/AbstractCauseHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/cause/AbstractCauseHandler.java
@@ -14,14 +14,12 @@ import javax.annotation.Nonnull;
 @Extension(optional = true, dynamicLoadable = YesNoMaybe.YES)
 public class AbstractCauseHandler implements CauseHandler {
 
-    private String description;
-    private String xxx;
+    private String structuredDescription;
 
     @Override
     public boolean canAddAttributes(@Nonnull Cause cause) {
         if (isSupported(cause)) {
-            setDescription(cause.getShortDescription());
-            setXxx(cause.getClass().getSimpleName() + getDetails(cause));
+            setStructuredDescription(cause.getClass().getSimpleName() + getDetails(cause));
             return true;
         }
         return false;
@@ -34,26 +32,20 @@ public class AbstractCauseHandler implements CauseHandler {
 
     @Nonnull
     @Override
-    public String getDescription() {
-        return this.description;
+    public String getStructuredDescription() {
+        return this.structuredDescription;
     }
 
+    /**
+     * @return Empty or prefixed by ":"
+     */
     @Nonnull
-    @Override
-    public String getXxx() {
-        return this.xxx;
-    }
-
     public String getDetails(@Nonnull Cause cause) {
         return "";
     }
 
-    protected void setDescription(String description) {
-        this.description = description;
-    }
-
-    protected void setXxx(String xxx) {
-        this.xxx = xxx;
+    protected void setStructuredDescription(String xxx) {
+        this.structuredDescription = xxx;
     }
 
     protected boolean isGitHubPushCause(Cause cause) {

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/cause/CauseHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/cause/CauseHandler.java
@@ -15,9 +15,9 @@ public interface CauseHandler {
 
     boolean canAddAttributes(@Nonnull Cause cause);
 
+    /**
+     * Machine-readable description of the cause like "UserIdCause:anonymous"...
+     */
     @Nonnull
-    String getDescription();
-
-    @Nonnull
-    String getXxx();
+    String getStructuredDescription();
 }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/semconv/JenkinsOtelSemanticAttributes.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/semconv/JenkinsOtelSemanticAttributes.java
@@ -30,8 +30,7 @@ public final class JenkinsOtelSemanticAttributes {
      * @see hudson.model.Node#getDisplayName() ()
      */
     public static final AttributeKey<String>        CI_PIPELINE_AGENT_NAME = AttributeKey.stringKey("ci.pipeline.agent.name");
-    public static final AttributeKey<List<String>>  CI_PIPELINE_RUN_CAUSE_DESCRIPTION = AttributeKey.stringArrayKey("ci.pipeline.run.cause.description");
-    public static final AttributeKey<List<String>>  CI_PIPELINE_RUN_CAUSE_XXX = AttributeKey.stringArrayKey("ci.pipeline.run.cause.xxx");
+    public static final AttributeKey<List<String>>  CI_PIPELINE_RUN_CAUSE = AttributeKey.stringArrayKey("ci.pipeline.run.cause");
     public static final AttributeKey<Boolean>       CI_PIPELINE_RUN_COMPLETED = AttributeKey.booleanKey("ci.pipeline.run.completed");
     public static final AttributeKey<Long>          CI_PIPELINE_RUN_DURATION_MILLIS = AttributeKey.longKey("ci.pipeline.run.durationMillis");
     public static final AttributeKey<String>        CI_PIPELINE_RUN_DESCRIPTION = AttributeKey.stringKey("ci.pipeline.run.description");

--- a/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginFreestyleIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginFreestyleIntegrationTest.java
@@ -29,6 +29,7 @@ import org.jvnet.hudson.test.SingleFileSCM;
 import org.jvnet.hudson.test.ToolInstallations;
 import org.jvnet.hudson.test.recipes.WithPlugin;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static io.jenkins.plugins.opentelemetry.OtelUtils.JENKINS_CORE;
@@ -156,8 +157,7 @@ public class JenkinsOtelPluginFreestyleIntegrationTest extends BaseIntegrationTe
         Tree<SpanDataWrapper> spans = getGeneratedSpans();
         List<SpanDataWrapper> root = spans.byDepth().get(0);
         Attributes attributes = root.get(0).spanData.getAttributes();
-        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.CI_PIPELINE_RUN_CAUSE_XXX), CoreMatchers.is(CoreMatchers.notNullValue()));
-        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.CI_PIPELINE_RUN_CAUSE_DESCRIPTION), CoreMatchers.is(CoreMatchers.notNullValue()));
+        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.CI_PIPELINE_RUN_CAUSE), CoreMatchers.is(Arrays.asList("UserIdCause:SYSTEM")));
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginMBPIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginMBPIntegrationTest.java
@@ -25,6 +25,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
@@ -74,8 +75,7 @@ public class JenkinsOtelPluginMBPIntegrationTest extends BaseIntegrationTest {
         MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.CI_PIPELINE_MULTIBRANCH_TYPE), CoreMatchers.is(OtelUtils.BRANCH));
         MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.CI_PIPELINE_TYPE), CoreMatchers.is(OtelUtils.MULTIBRANCH));
         MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.CI_PIPELINE_RUN_DESCRIPTION), CoreMatchers.is("Bar"));
-        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.CI_PIPELINE_RUN_CAUSE_XXX), CoreMatchers.is(CoreMatchers.notNullValue()));
-        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.CI_PIPELINE_RUN_CAUSE_DESCRIPTION), CoreMatchers.is(CoreMatchers.notNullValue()));
+        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.CI_PIPELINE_RUN_CAUSE), CoreMatchers.is(Arrays.asList("BranchIndexingCause")));
 
         // TODO: support the chain of spans for the checkout step (it uses some random folder name in the tests
         // It returns the first checkout, aka the one without any shallow cloning, depth shallow.


### PR DESCRIPTION
Better `ci.pipeline.run.cause` attribute, finish the work started on 
- https://github.com/jenkinsci/opentelemetry-plugin/pull/187  .

Replace `ci.pipeline.run.cause.description` and `ci.pipeline.run.cause.xxx` to just keep `ci.pipeline.run.cause`with a machine readable value like `UserIdCause:anonymous` or `BranchIndexingCause `

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
