### PR TITLE
Add troubleshooting details on `OtelTraceService#buildListOfAncestors()`

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelTraceService.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelTraceService.java
@@ -115,7 +115,7 @@ public class OtelTraceService {
             LOGGER.log(Level.FINE, () -> "No span found for run " + run.getFullDisplayName() + ", Jenkins server may have restarted");
             return noOpTracer.spanBuilder("noop-recovery-run-span-for-" + run.getFullDisplayName()).startSpan();
         }
-        LOGGER.log(Level.FINEST, () -> "span: " + span.getSpanContext().getSpanId());
+        LOGGER.log(Level.FINEST, () -> "getSpan(): " + span.getSpanContext().getSpanId());
         return span;
     }
 
@@ -137,12 +137,22 @@ public class OtelTraceService {
 
     @Nonnull
     private Iterable<FlowNode> getAncestors(FlowNode flowNode) {
+        // troubleshoot https://github.com/jenkinsci/opentelemetry-plugin/issues/197
+        LOGGER.log(Level.FINEST, () -> "> getAncestors([" + flowNode.getClass().getSimpleName() + ", " + flowNode.getId() + "," + flowNode.getDisplayFunctionName() + "])");
         List<FlowNode> ancestors = new ArrayList<>();
         buildListOfAncestors(flowNode, ancestors);
+        // troubleshoot https://github.com/jenkinsci/opentelemetry-plugin/issues/197
+        LOGGER.log(Level.FINEST, () -> "< getAncestors([" +  flowNode.getClass().getSimpleName() + ", " + flowNode.getId() + "," + flowNode.getDisplayFunctionName() + "]): " + ancestors.stream().map(fn -> "[" + fn.getId() + ", " + fn.getDisplayFunctionName() + "]").collect(Collectors.joining(", ")));
         return ancestors;
     }
 
     public void buildListOfAncestors(@Nonnull FlowNode flowNode, @Nonnull List<FlowNode> parents) {
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            // troubleshoot https://github.com/jenkinsci/opentelemetry-plugin/issues/197
+            LOGGER.log(Level.FINEST, "buildListOfAncestors: [" + flowNode.getClass().getSimpleName() + ", " +
+                flowNode.getId() + ", " + flowNode.getDisplayFunctionName() + "]   -   " +
+                parents.stream().map(fn -> "[" + fn.getId() + ", " + fn.getDisplayFunctionName() + "]").collect(Collectors.joining(", ")));
+        }
         parents.add(flowNode);
         if (flowNode instanceof StepEndNode) {
             StepEndNode endNode = (StepEndNode) flowNode;

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelTraceService.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelTraceService.java
@@ -136,7 +136,7 @@ public class OtelTraceService {
     }
 
     @Nonnull
-    private Iterable<FlowNode> getAncestors(FlowNode flowNode) {
+    private Iterable<FlowNode> getAncestors(@Nonnull FlowNode flowNode) {
         // troubleshoot https://github.com/jenkinsci/opentelemetry-plugin/issues/197
         LOGGER.log(Level.FINEST, () -> "> getAncestors([" + flowNode.getClass().getSimpleName() + ", " + flowNode.getId() + ", '" + flowNode.getDisplayFunctionName() + "'])");
         List<FlowNode> ancestors = new ArrayList<>();

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelTraceService.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelTraceService.java
@@ -138,11 +138,11 @@ public class OtelTraceService {
     @Nonnull
     private Iterable<FlowNode> getAncestors(FlowNode flowNode) {
         // troubleshoot https://github.com/jenkinsci/opentelemetry-plugin/issues/197
-        LOGGER.log(Level.FINEST, () -> "> getAncestors([" + flowNode.getClass().getSimpleName() + ", " + flowNode.getId() + "," + flowNode.getDisplayFunctionName() + "])");
+        LOGGER.log(Level.FINEST, () -> "> getAncestors([" + flowNode.getClass().getSimpleName() + ", " + flowNode.getId() + ", '" + flowNode.getDisplayFunctionName() + "'])");
         List<FlowNode> ancestors = new ArrayList<>();
         buildListOfAncestors(flowNode, ancestors);
         // troubleshoot https://github.com/jenkinsci/opentelemetry-plugin/issues/197
-        LOGGER.log(Level.FINEST, () -> "< getAncestors([" +  flowNode.getClass().getSimpleName() + ", " + flowNode.getId() + "," + flowNode.getDisplayFunctionName() + "]): " + ancestors.stream().map(fn -> "[" + fn.getId() + ", " + fn.getDisplayFunctionName() + "]").collect(Collectors.joining(", ")));
+        LOGGER.log(Level.FINEST, () -> "< getAncestors([" +  flowNode.getClass().getSimpleName() + ", " + flowNode.getId() + ", '" + flowNode.getDisplayFunctionName() + "']): " + ancestors.stream().map(fn -> "[" + fn.getId() + ", " + fn.getDisplayFunctionName() + "]").collect(Collectors.joining(", ")));
         return ancestors;
     }
 
@@ -150,8 +150,8 @@ public class OtelTraceService {
         if (LOGGER.isLoggable(Level.FINEST)) {
             // troubleshoot https://github.com/jenkinsci/opentelemetry-plugin/issues/197
             LOGGER.log(Level.FINEST, "buildListOfAncestors: [" + flowNode.getClass().getSimpleName() + ", " +
-                flowNode.getId() + ", " + flowNode.getDisplayFunctionName() + "]   -   " +
-                parents.stream().map(fn -> "[" + fn.getId() + ", " + fn.getDisplayFunctionName() + "]").collect(Collectors.joining(", ")));
+                flowNode.getId() + ", '" + flowNode.getDisplayFunctionName() + "']   -   " +
+                parents.stream().map(fn -> "[" + fn.getId() + ", '" + fn.getDisplayFunctionName() + "']").collect(Collectors.joining(", ")));
         }
         parents.add(flowNode);
         if (flowNode instanceof StepEndNode) {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Add troubleshooting details on `OtelTraceService#buildListOfAncestors()`
Help troubleshoot
- https://github.com/jenkinsci/opentelemetry-plugin/issues/197

To get the log messages, enabled `io.jenkins.plugins.opentelemetry.job.OtelTraceService : FINEST``


```
> getAncestors([StepAtomNode, 14, 'sh'])
Nov 15, 2021 9:55:10 AM FINEST io.jenkins.plugins.opentelemetry.job.OtelTraceService
buildListOfAncestors: [StepAtomNode, 14, 'sh']   -   
Nov 15, 2021 9:55:10 AM FINEST io.jenkins.plugins.opentelemetry.job.OtelTraceService
buildListOfAncestors: [StepStartNode, 13, '{ (Build)']   -   [14, 'sh']
Nov 15, 2021 9:55:10 AM FINEST io.jenkins.plugins.opentelemetry.job.OtelTraceService
buildListOfAncestors: [StepStartNode, 12, 'stage']   -   [14, 'sh'], [13, '{ (Build)']
Nov 15, 2021 9:55:10 AM FINEST io.jenkins.plugins.opentelemetry.job.OtelTraceService
buildListOfAncestors: [StepStartNode, 11, '{']   -   [14, 'sh'], [13, '{ (Build)'], [12, 'stage']
Nov 15, 2021 9:55:10 AM FINEST io.jenkins.plugins.opentelemetry.job.OtelTraceService
buildListOfAncestors: [StepStartNode, 10, 'withEnv']   -   [14, 'sh'], [13, '{ (Build)'], [12, 'stage'], [11, '{']
Nov 15, 2021 9:55:10 AM FINEST io.jenkins.plugins.opentelemetry.job.OtelTraceService
buildListOfAncestors: [StepEndNode, 9, '// stage']   -   [14, 'sh'], [13, '{ (Build)'], [12, 'stage'], [11, '{'], [10, 'withEnv']
Nov 15, 2021 9:55:10 AM FINEST io.jenkins.plugins.opentelemetry.job.OtelTraceService
buildListOfAncestors: [StepStartNode, 4, '{']   -   [14, 'sh'], [13, '{ (Build)'], [12, 'stage'], [11, '{'], [10, 'withEnv'], [9, '// stage'], [5, 'stage']
Nov 15, 2021 9:55:10 AM FINEST io.jenkins.plugins.opentelemetry.job.OtelTraceService
buildListOfAncestors: [StepStartNode, 3, 'node']   -   [14, 'sh'], [13, '{ (Build)'], [12, 'stage'], [11, '{'], [10, 'withEnv'], [9, '// stage'], [5, 'stage'], [4, '{']
Nov 15, 2021 9:55:10 AM FINEST io.jenkins.plugins.opentelemetry.job.OtelTraceService
buildListOfAncestors: [FlowStartNode, 2, 'Start of Pipeline']   -   [14, 'sh'], [13, '{ (Build)'], [12, 'stage'], [11, '{'], [10, 'withEnv'], [9, '// stage'], [5, 'stage'], [4, '{'], [3, 'node']
Nov 15, 2021 9:55:10 AM FINEST io.jenkins.plugins.opentelemetry.job.OtelTraceService
< getAncestors([StepAtomNode, 14, 'sh']): [14, sh], [13, { (Build)], [12, stage], [11, {], [10, withEnv], [9, // stage], [5, stage], [4, {], [3, node], [2, Start of Pipeline]
```

--

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
