### PR TITLE
Fix major algorithm inefficiency that can lead to a StackOverflowError

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelTraceService.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelTraceService.java
@@ -46,7 +46,6 @@ import static com.google.common.base.Verify.verify;
 
 @Extension
 public class OtelTraceService {
-
     private static Logger LOGGER = Logger.getLogger(OtelTraceService.class.getName());
 
     private transient ConcurrentMap<RunIdentifier, RunSpans> spansByRun;
@@ -101,8 +100,8 @@ public class OtelTraceService {
         LOGGER.log(Level.FINEST, () -> "getSpan(" + run.getFullDisplayName() + ", FlowNode[name" + flowNode.getDisplayName() + ", function:" + flowNode.getDisplayFunctionName() + ", id=" + flowNode.getId() + "]) -  " + runSpans);
         LOGGER.log(Level.FINEST, () -> "parentFlowNodes: " + flowNode.getParents().stream().map(node -> node.getDisplayName() + ", id: " + node.getId()).collect(Collectors.toList()));
 
-        // TODO optimise lazy loading the list of ancestors just loading until w have found a span
         Iterable<FlowNode> ancestors = getAncestors(flowNode);
+
         for (FlowNode ancestor : ancestors) {
             final Collection<PipelineSpanContext> pipelineSpanContexts = runSpans.pipelineStepSpansByFlowNodeId.get(ancestor.getId());
             PipelineSpanContext pipelineSpanContext = Iterables.getLast(pipelineSpanContexts, null);
@@ -135,40 +134,66 @@ public class OtelTraceService {
         return span;
     }
 
+    /**
+     * Return the chain of enclosing flowNodes including the given flow node. If the given flow node is a step end node,
+     * the associated step start node is also added.
+     *
+     * Example
+     * <pre>
+     * test-pipeline-with-parallel-step8
+     *    |
+     *    |- Phase: Start
+     *    |
+     *    |- Phase: Run
+     *    |   |
+     *    |   |- Agent, function: node, name: agent, node.id: 3
+     *    |       |
+     *    |       |- Agent Allocation, function: node, name: agent.allocate, node.id: 3
+     *    |       |
+     *    |       |- Stage: ze-parallel-stage, function: stage, name: ze-parallel-stage, node.id: 6
+     *    |           |
+     *    |           |- Parallel branch: parallelBranch1, function: parallel, name: parallelBranch1, node.id: 10
+     *    |           |   |
+     *    |           |   |- shell-1, function: sh, name: Shell Script, node.id: 14
+     *    |           |
+     *    |           |- Parallel branch: parallelBranch2, function: parallel, name: parallelBranch2, node.id: 11
+     *    |           |   |
+     *    |           |   |- shell-2, function: sh, name: Shell Script, node.id: 16
+     *    |           |
+     *    |           |- Parallel branch: parallelBranch3, function: parallel, name: parallelBranch3, node.id: 12
+     *    |               |
+     *    |               |- shell-3, function: sh, name: Shell Script, node.id: 18
+     *    |
+     *    |- Phase: Finalise
+     * </pre>
+     *
+     * {@code getAncestors("shell-3/node.id: 18")} will return {@code [
+     *    "shell-3/node.id: 18",
+     *    "Parallel branch: parallelBranch3/node.id: 12",
+     *    "Stage: ze-parallel-stage, node.id: 6",
+     *    "node / node.id: 3",
+     *    "Start of Pipeline / node.id: 2" // not visualized above
+     *    ]}
+     * TODO optimize lazing loading the enclosing blocks using {@link org.jenkinsci.plugins.workflow.graph.GraphLookupView#findEnclosingBlockStart(org.jenkinsci.plugins.workflow.graph.FlowNode)}
+     * @param flowNode
+     * @return list of enclosing flow nodes starting with the passed flow nodes
+     */
     @Nonnull
-    private Iterable<FlowNode> getAncestors(@Nonnull FlowNode flowNode) {
+    private Iterable<FlowNode> getAncestors(@Nonnull final FlowNode flowNode) {
         // troubleshoot https://github.com/jenkinsci/opentelemetry-plugin/issues/197
-        LOGGER.log(Level.FINEST, () -> "> getAncestors([" + flowNode.getClass().getSimpleName() + ", " + flowNode.getId() + ", '" + flowNode.getDisplayFunctionName() + "'])");
+        LOGGER.log(Level.FINEST, () -> "> getAncestorsV2([" + flowNode.getClass().getSimpleName() + ", " + flowNode.getId() + ", '" + flowNode.getDisplayFunctionName() + "'])");
         List<FlowNode> ancestors = new ArrayList<>();
-        buildListOfAncestors(flowNode, ancestors);
-        // troubleshoot https://github.com/jenkinsci/opentelemetry-plugin/issues/197
-        LOGGER.log(Level.FINEST, () -> "< getAncestors([" +  flowNode.getClass().getSimpleName() + ", " + flowNode.getId() + ", '" + flowNode.getDisplayFunctionName() + "']): " + ancestors.stream().map(fn -> "[" + fn.getId() + ", " + fn.getDisplayFunctionName() + "]").collect(Collectors.joining(", ")));
-        return ancestors;
-    }
-
-    public void buildListOfAncestors(@Nonnull FlowNode flowNode, @Nonnull List<FlowNode> parents) {
-        if (LOGGER.isLoggable(Level.FINEST)) {
-            // troubleshoot https://github.com/jenkinsci/opentelemetry-plugin/issues/197
-            LOGGER.log(Level.FINEST, "buildListOfAncestors: [" + flowNode.getClass().getSimpleName() + ", " +
-                flowNode.getId() + ", '" + flowNode.getDisplayFunctionName() + "']   -   " +
-                parents.stream().map(fn -> "[" + fn.getId() + ", '" + fn.getDisplayFunctionName() + "']").collect(Collectors.joining(", ")));
-        }
-        parents.add(flowNode);
+        FlowNode startNode;
         if (flowNode instanceof StepEndNode) {
-            StepEndNode endNode = (StepEndNode) flowNode;
-            final StepStartNode startNode = endNode.getStartNode();
-            parents.add(startNode);
-            flowNode = startNode;
+            startNode = ((StepEndNode) flowNode).getStartNode();
+        } else {
+            startNode = flowNode;
         }
-        for (FlowNode parentNode : flowNode.getParents()) {
-            if (flowNode.equals(parentNode)) {
-                LOGGER.log(Level.INFO, "buildListOfAncestors(" + flowNode + "): skip parentFlowNode as it is the current node"); // TODO change message to Level.FINE once the cause is understood
-            } else if (parents.contains(parentNode)) {
-                LOGGER.log(Level.INFO, "buildListOfAncestors(" + flowNode + "): skip already added " + parentNode);  // TODO can we remove this check once the cause is understood?
-            } else {
-                buildListOfAncestors(parentNode, parents);
-            }
-        }
+        ancestors.add(startNode);
+        ancestors.addAll(startNode.getEnclosingBlocks());
+        // troubleshoot https://github.com/jenkinsci/opentelemetry-plugin/issues/197
+        LOGGER.log(Level.FINEST, () -> "< getAncestorsV2([" +  flowNode.getClass().getSimpleName() + ", " + flowNode.getId() + ", '" + flowNode.getDisplayFunctionName() + "']): " + ancestors.stream().map(fn -> "[" + fn.getId() + ", " + fn.getDisplayFunctionName() + "]").collect(Collectors.joining(", ")));
+        return ancestors;
     }
 
     public void removePipelineStepSpan(@Nonnull Run run, @Nonnull FlowNode flowNode, @Nonnull Span span) {


### PR DESCRIPTION
Fix major algorithm inefficiency that can lead to a StackOverflowError

Use `nodeFlow.getEnclosingBlocks()` instead of `nodeFlow.getParents()`.

Fix
- https://github.com/jenkinsci/opentelemetry-plugin/issues/197

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
