### PR TITLE
fix: avoid NPE when clone options are not present

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/step/GitCheckoutStepHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/step/GitCheckoutStepHandler.java
@@ -101,8 +101,8 @@ public class GitCheckoutStepHandler extends AbstractGitStepHandler {
             final Map<String, ?> cloneOption = Iterables.getFirst(extensions, null);
 
             if (cloneOption != null) {
-                shallow = (Boolean) cloneOption.get("shallow");
-                depth = (Integer) cloneOption.get("depth");
+                shallow = cloneOption.containsKey ("shallow") ? (Boolean) cloneOption.get("shallow") : shallow;
+                depth = cloneOption.containsKey ("depth") ? (Integer) cloneOption.get("depth") : depth;
             }
 
             List<Map<String, ?>> userRemoteConfigs = (List<Map<String, ?>>) scm.get("userRemoteConfigs");

--- a/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginIntegrationTest.java
@@ -460,6 +460,6 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
         Attributes attributes = checkoutNode.get().getData().spanData.getAttributes();
 
         MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.GIT_CLONE_SHALLOW), CoreMatchers.is(false));
-        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.GIT_CLONE_DEPTH), CoreMatchers.is(0));
+        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.GIT_CLONE_DEPTH), CoreMatchers.is(0L));
     }
 }

--- a/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginIntegrationTest.java
@@ -459,7 +459,7 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
         Optional<Tree.Node<SpanDataWrapper>> checkoutNode = spans.breadthFirstSearchNodes(node -> "checkout: github.com/jenkinsci/opentelemetry-plugin".equals(node.getData().spanData.getName()));
         Attributes attributes = checkoutNode.get().getData().spanData.getAttributes();
 
-        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.GIT_CLONE_SHALLOW), CoreMatchers.nullValue());
-        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.GIT_CLONE_DEPTH), CoreMatchers.nullValue());
+        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.GIT_CLONE_SHALLOW), CoreMatchers.is(false));
+        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.GIT_CLONE_DEPTH), CoreMatchers.is(0));
     }
 }

--- a/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginIntegrationTest.java
@@ -437,4 +437,29 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
         MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.GIT_CLONE_DEPTH), CoreMatchers.is(2L));
     }
 
+    @Test
+    public void testPipelineWithoutCheckoutShallowSteps() throws Exception {
+        assumeFalse(SystemUtils.IS_OS_WINDOWS);
+        final String jobName = "without-checkout-" + jobNameSuffix.incrementAndGet();
+
+        String pipelineScript = "node() {\n" +
+            "  stage('foo') {\n" +
+            "    checkout([$class: 'GitSCM', branches: [[name: '*/master']], extensions: [], userRemoteConfigs: [[url: 'https://github.com/jenkinsci/opentelemetry-plugin']]]) \n" +
+            "  }\n" +
+            "}";
+        final Node agent = jenkinsRule.createOnlineSlave();
+        WorkflowJob pipeline = jenkinsRule.createProject(WorkflowJob.class, jobName);
+        pipeline.setDefinition(new CpsFlowDefinition(pipelineScript, true));
+        WorkflowRun build = jenkinsRule.assertBuildStatus(Result.SUCCESS, pipeline.scheduleBuild2(0));
+
+        final Tree<SpanDataWrapper> spans = getGeneratedSpans();
+        checkChainOfSpans(spans, "checkout: github.com/jenkinsci/opentelemetry-plugin", "Stage: foo", JenkinsOtelSemanticAttributes.AGENT_UI, "Phase: Run");
+        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(8L));
+
+        Optional<Tree.Node<SpanDataWrapper>> checkoutNode = spans.breadthFirstSearchNodes(node -> "checkout: github.com/jenkinsci/opentelemetry-plugin".equals(node.getData().spanData.getName()));
+        Attributes attributes = checkoutNode.get().getData().spanData.getAttributes();
+
+        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.GIT_CLONE_SHALLOW), CoreMatchers.nullValue());
+        MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.GIT_CLONE_DEPTH), CoreMatchers.nullValue());
+    }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

## What does this PR do?
It avoids NPE when the git repository is configured without any of the clone options used in this project: shallow-clone and depth. For that, it uses the elvis operator to evaluate if the keys exist in the options map.

## Why is it important?
I've seen this exception while developing my own plugin based on this one, when the test pipeline I have configured for my tests has only one git settings: show authors instead of committers.

The stacktrace that I see:

```java
2021-11-23 18:24:26.997+0000 [id=138]   WARNING i.j.p.o.j.j.GraphListenerAdapterToPipelineListener#fireOnBeforeAtomicStep: Exception invoking `onBeforeAtomicStep` on TracingPipelineListener{}
java.lang.NullPointerException
   at io.jenkins.plugins.opentelemetry.job.step.GitCheckoutStepHandler.createSpanBuilder(GitCheckoutStepHandler.java:104 undefined)
   at io.jenkins.plugins.opentelemetry.job.MonitoringPipelineListener.onAtomicStep(MonitoringPipelineListener.java:180 undefined)
   at io.jenkins.plugins.opentelemetry.job.jenkins.GraphListenerAdapterToPipelineListener.fireOnBeforeAtomicStep(GraphListenerAdapterToPipelineListener.java:212 undefined)
   at io.jenkins.plugins.opentelemetry.job.jenkins.GraphListenerAdapterToPipelineListener.onNewHead(GraphListenerAdapterToPipelineListener.java:75 undefined)
   at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1473 undefined)
   at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.notifyNewHead(CpsThreadGroup.java:472 undefined)
   at org.jenkinsci.plugins.workflow.cps.FlowHead.setNewHead(FlowHead.java:157 undefined)
   at org.jenkinsci.plugins.workflow.cps.DSL.invokeStep(DSL.java:285 undefined)
   at org.jenkinsci.plugins.workflow.cps.DSL.invokeMethod(DSL.java:193 undefined)
   at org.jenkinsci.plugins.workflow.cps.CpsScript.invokeMethod(CpsScript.java:122 undefined)
   at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
   at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62 undefined)
   at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43 undefined)
   at java.lang.reflect.Method.invoke(Method.java:498 undefined)
   at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:93 undefined)
   at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:325 undefined)
   at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1213 undefined)
   at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1022 undefined)
   at org.codehaus.groovy.runtimesite.PogoMetaClassSite.call.call(PogoMetaClassSite.java:42 undefined)
   at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48 undefined)
   at org.codehaus.groovy.runtimesite.AbstractCallSite.call.call(AbstractCallSite.java:113 undefined)
   at org.kohsuke.groovy.sandbox.impl.Checker$1.call(Checker.java:163 undefined)
   at org.kohsuke.groovy.sandbox.GroovyInterceptor.onMethodCall(GroovyInterceptor.java:23 undefined)
   at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxInterceptor.onMethodCall(SandboxInterceptor.java:158 undefined)
   at org.kohsuke.groovy.sandbox.impl.Checker$1.call(Checker.java:161 undefined)
   at org.kohsuke.groovy.sandbox.impl.Checker.checkedCall(Checker.java:165 undefined)
   at org.kohsuke.groovy.sandbox.impl.Checker.checkedCall(Checker.java:135 undefined)
   at com.cloudbees.groovy.cps.sandbox.SandboxInvoker.methodCall(SandboxInvoker.java:17 undefined)
   at com.cloudbees.groovy.cps.impl.ContinuationGroup.methodCall(ContinuationGroup.java:86 undefined)
   at com.cloudbees.groovy.cps.impl.FunctionCallBlock$ContinuationImpl.dispatchOrArg(FunctionCallBlock.java:113 undefined)
   at com.cloudbees.groovy.cps.impl.FunctionCallBlock$ContinuationImpl.fixArg(FunctionCallBlock.java:83 undefined)
   at sun.reflect.GeneratedMethodAccessor114.invoke(Unknown Source)
   at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43 undefined)
   at java.lang.reflect.Method.invoke(Method.java:498 undefined)
   at com.cloudbees.groovy.cps.impl.ContinuationPtr$ContinuationImpl.receive(ContinuationPtr.java:72 undefined)
   at com.cloudbees.groovy.cps.impl.CollectionLiteralBlock$ContinuationImpl.dispatch(CollectionLiteralBlock.java:55 undefined)
   at com.cloudbees.groovy.cps.impl.CollectionLiteralBlock$ContinuationImpl.item(CollectionLiteralBlock.java:45 undefined)
   at sun.reflect.GeneratedMethodAccessor131.invoke(Unknown Source)
   at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43 undefined)
   at java.lang.reflect.Method.invoke(Method.java:498 undefined)
   at com.cloudbees.groovy.cps.impl.ContinuationPtr$ContinuationImpl.receive(ContinuationPtr.java:72 undefined)
   at com.cloudbees.groovy.cps.impl.CollectionLiteralBlock$ContinuationImpl.dispatch(CollectionLiteralBlock.java:55 undefined)
   at com.cloudbees.groovy.cps.impl.CollectionLiteralBlock$ContinuationImpl.item(CollectionLiteralBlock.java:45 undefined)
   at sun.reflect.GeneratedMethodAccessor131.invoke(Unknown Source)
   at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43 undefined)
   at java.lang.reflect.Method.invoke(Method.java:498 undefined)
   at com.cloudbees.groovy.cps.impl.ContinuationPtr$ContinuationImpl.receive(ContinuationPtr.java:72 undefined)
   at com.cloudbees.groovy.cps.impl.CollectionLiteralBlock$ContinuationImpl.dispatch(CollectionLiteralBlock.java:55 undefined)
   at com.cloudbees.groovy.cps.impl.CollectionLiteralBlock$ContinuationImpl.item(CollectionLiteralBlock.java:45 undefined)
   at sun.reflect.GeneratedMethodAccessor131.invoke(Unknown Source)
   at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43 undefined)
   at java.lang.reflect.Method.invoke(Method.java:498 undefined)
   at com.cloudbees.groovy.cps.impl.ContinuationPtr$ContinuationImpl.receive(ContinuationPtr.java:72 undefined)
   at com.cloudbees.groovy.cps.impl.ConstantBlock.eval(ConstantBlock.java:21 undefined)
   at com.cloudbees.groovy.cps.Next.step(Next.java:83 undefined)
   at com.cloudbees.groovy.cps.Continuable$1.call(Continuable.java:174 undefined)
   at com.cloudbees.groovy.cps.Continuable$1.call(Continuable.java:163 undefined)
   at org.codehaus.groovy.runtime.GroovyCategorySupport$ThreadCategoryInfo.use(GroovyCategorySupport.java:129 undefined)
   at org.codehaus.groovy.runtime.GroovyCategorySupport.use(GroovyCategorySupport.java:268 undefined)
   at com.cloudbees.groovy.cps.Continuable.run0(Continuable.java:163 undefined)
   at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.access$001(SandboxContinuable.java:18 undefined)
   at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.run0(SandboxContinuable.java:51 undefined)
   at org.jenkinsci.plugins.workflow.cps.CpsThread.runNextChunk(CpsThread.java:185 undefined)
   at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.run(CpsThreadGroup.java:400 undefined)
   at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.access$400(CpsThreadGroup.java:96 undefined)
   at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:312 undefined)
   at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:276 undefined)
   at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$2.call(CpsVmExecutorService.java:67 undefined)
   at java.util.concurrent.FutureTask.run(FutureTask.java:266 undefined)
   at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:136 undefined)
   at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28 undefined)
   at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:59 undefined)
   at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511 undefined)
   at java.util.concurrent.FutureTask.run(FutureTask.java:266 undefined)
   at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149 undefined)
   at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624 undefined)
   at java.lang.Thread.run(Thread.java:748 undefined)
```

> **at io.jenkins.plugins.opentelemetry.job.step.GitCheckoutStepHandler.createSpanBuilder(GitCheckoutStepHandler.java:104)**


