### PR TITLE
Export `OTEL_TRACES_EXPORTER` to meet new requirements of the Otel Maven Extension

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
@@ -231,7 +231,12 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
 
     @Nonnull
     public Map<String, String> getOtelConfigurationAsEnvironmentVariables() {
+        if (this.endpoint == null) {
+            return Collections.emptyMap();
+        }
+
         Map<String, String> environmentVariables = new HashMap<>();
+        environmentVariables.put(OTelEnvironmentVariablesConventions.OTEL_TRACES_EXPORTER, "otlp");
         environmentVariables.put(OTelEnvironmentVariablesConventions.OTEL_EXPORTER_OTLP_ENDPOINT, this.endpoint);
         String sanitizeOtlpEndpoint = sanitizeOtlpEndpoint(this.endpoint);
         if (sanitizeOtlpEndpoint != null && sanitizeOtlpEndpoint.startsWith("http://")) {

--- a/src/main/java/io/jenkins/plugins/opentelemetry/semconv/OTelEnvironmentVariablesConventions.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/semconv/OTelEnvironmentVariablesConventions.java
@@ -16,6 +16,7 @@ public class OTelEnvironmentVariablesConventions {
     public static final String OTEL_EXPORTER_OTLP_ENDPOINT = "OTEL_EXPORTER_OTLP_ENDPOINT";
     public static final String OTEL_EXPORTER_OTLP_INSECURE = "OTEL_EXPORTER_OTLP_INSECURE";
     public static final String OTEL_EXPORTER_OTLP_TIMEOUT = "OTEL_EXPORTER_OTLP_TIMEOUT";
+    public static final String OTEL_TRACES_EXPORTER = "OTEL_TRACES_EXPORTER";
 
     public static final String SPAN_ID = "SPAN_ID";
     public static final String TRACE_ID = "TRACE_ID";

--- a/src/test/java/io/jenkins/plugins/opentelemetry/BaseIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/BaseIntegrationTest.java
@@ -175,6 +175,7 @@ public class BaseIntegrationTest {
         MatcherAssert.assertThat(environment.get(OTelEnvironmentVariablesConventions.SPAN_ID), CoreMatchers.is(CoreMatchers.notNullValue()));
         MatcherAssert.assertThat(environment.get(OTelEnvironmentVariablesConventions.TRACE_ID), CoreMatchers.is(CoreMatchers.notNullValue()));
         // See src/test/resources/io/jenkins/plugins/opentelemetry/jcasc-elastic-backend.yml
+        MatcherAssert.assertThat(environment.get(OTelEnvironmentVariablesConventions.OTEL_TRACES_EXPORTER), CoreMatchers.is("otlp"));
         MatcherAssert.assertThat(environment.get(OTelEnvironmentVariablesConventions.OTEL_EXPORTER_OTLP_ENDPOINT), CoreMatchers.is("http://otel-collector-contrib:4317"));
         MatcherAssert.assertThat(environment.get(OTelEnvironmentVariablesConventions.OTEL_EXPORTER_OTLP_INSECURE), CoreMatchers.is("true"));
         MatcherAssert.assertThat(environment.get(OTelEnvironmentVariablesConventions.OTEL_EXPORTER_OTLP_TIMEOUT), CoreMatchers.is("3000"));


### PR DESCRIPTION
Export `OTEL_TRACES_EXPORTER` in shell steps when exporting `OTEL_EXPORTER_OTLP_ENDPOINT` to meet new requirements of the Otel Maven Extension:
* https://github.com/open-telemetry/opentelemetry-java-contrib/pull/132#discussion_r756533576

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
