### PR TITLE
Stop masking Guava classes (req Jenkins 2.321)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.35</version>
+        <version>4.37</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -19,7 +19,7 @@
     <properties>
         <revision>2.1.2</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.277.1</jenkins.version>
+        <jenkins.version>2.332.1</jenkins.version>
         <java.level>8</java.level>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <opentelemetry.version>1.12.0</opentelemetry.version>
@@ -38,8 +38,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.249.x</artifactId>
-                <version>984.vb5eaac999a7e</version>
+                <artifactId>bom-2.332.x</artifactId>
+                <version>1195.v33041c1f1b_b_2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -79,10 +79,9 @@
                 <version>3.12.0</version>
             </dependency>
             <dependency>
-                <!-- workflow-basic-steps:2.22 vs gitlab-plugin:1.5.22 -->
-                <groupId>javax.activation</groupId>
-                <artifactId>activation</artifactId>
-                <version>1.1.1</version>
+                <groupId>org.eclipse.sisu</groupId>
+                <artifactId>org.eclipse.sisu.inject</artifactId>
+                <version>0.3.5</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -200,17 +199,12 @@
             <artifactId>okhttp-api</artifactId>
             <version>4.9.3-105.vb96869f8ac3a</version>
         </dependency>
-        <dependency> <!-- see maskClasses config -->
+        <!--
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <!--
-            Don't bump beyond 20.0 as 21.0 removes com.google.common.util.concurrent.MoreExecutors#sameThreadExecutor()
-            that is used by
-            org.jenkinsci.plugins.workflow.support.concurrent.Futures.addCallback(com.google.common.util.concurrent.ListenableFuture<V>, com.google.common.util.concurrent.FutureCallback<? super V>)
-            See https://github.com/google/guava/wiki/Release21
-            -->
-            <version>20.0</version>
         </dependency>
+        -->
         <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_annotations</artifactId>
@@ -270,29 +264,10 @@
         <dependency>
             <groupId>org.jenkinsci.plugins</groupId>
             <artifactId>pipeline-model-definition</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>jackson2-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.datatype</groupId>
-                    <artifactId>jackson-datatype-json-org</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
-            <version>1.18</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -321,14 +296,8 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>gitlab-plugin</artifactId>
-            <version>1.5.22</version>
+            <version>1.5.28</version>
             <optional>true</optional>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.jaxrs</groupId>
-                    <artifactId>jackson-jaxrs-json-provider</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -372,10 +341,7 @@
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>maven-plugin</artifactId>
-            <!--
-            can bump to 3.9 because it requires jenkins-core 2.270
-            -->
-            <version>3.8</version>
+            <version>3.18</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -384,6 +350,14 @@
                     -->
                     <groupId>commons-net</groupId>
                     <artifactId>commons-net</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jenkins-ci</groupId>
+                    <artifactId>symbol-annotation</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -444,25 +418,6 @@
             <groupId>io.jenkins.configuration-as-code</groupId>
             <artifactId>test-harness</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.datatype</groupId>
-                    <artifactId>jackson-datatype-json-org</artifactId>
-                </exclusion>
-                <exclusion>
-                    <!-- conflicts with pipeline-model-definition -->
-                    <groupId>joda-time</groupId>
-                    <artifactId>joda-time</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <!-- For JUnit test results UI compatibility -->
         <dependency>
@@ -504,9 +459,6 @@
                 <groupId>org.jenkins-ci.tools</groupId>
                 <artifactId>maven-hpi-plugin</artifactId>
                 <configuration>
-                    <!-- JENKINS-50520: since we need a custom version of Guava -->
-                    <maskClasses>com.google.common.</maskClasses>
-                    <minimumJavaVersion>8</minimumJavaVersion>
                     <loggers>
                         <io.jenkins.plugins.opentelemetry.job.log>FINE</io.jenkins.plugins.opentelemetry.job.log>
                     </loggers>

--- a/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
@@ -42,12 +42,12 @@ import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
-import javax.annotation.concurrent.Immutable;
+import net.jcip.annotations.Immutable;
 import javax.inject.Inject;
 import java.io.Closeable;
 import java.io.IOException;
@@ -154,7 +154,7 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
     }
 
 
-    @Nonnull
+    @NonNull
     public OpenTelemetryConfiguration toOpenTelemetryConfiguration() {
         Properties properties = new Properties();
         try {
@@ -220,7 +220,7 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
         initializeOpenTelemetry();
     }
 
-    @Nonnull
+    @NonNull
     public OtlpAuthentication getAuthentication() {
         return this.authentication == null ? new NoAuthentication() : this.authentication;
     }
@@ -248,7 +248,7 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
         initializeOpenTelemetry();
     }
 
-    @Nonnull
+    @NonNull
     public List<ObservabilityBackend> getObservabilityBackends() {
         if (observabilityBackends == null) {
             observabilityBackends = new ArrayList<>();
@@ -323,7 +323,7 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
         initializeOpenTelemetry();
     }
 
-    @Nonnull
+    @NonNull
     public Map<String, String> getOtelConfigurationAsEnvironmentVariables() {
         if (this.endpoint == null) {
             return Collections.emptyMap();
@@ -350,19 +350,19 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
     private JenkinsLocationConfiguration jenkinsLocationConfiguration;
 
     @Inject
-    public void setJenkinsLocationConfiguration(@Nonnull JenkinsLocationConfiguration jenkinsLocationConfiguration) {
+    public void setJenkinsLocationConfiguration(@NonNull JenkinsLocationConfiguration jenkinsLocationConfiguration) {
         this.jenkinsLocationConfiguration = jenkinsLocationConfiguration;
     }
 
     /**
      * For visualisation in config.jelly
      */
-    @Nonnull
+    @NonNull
     public String getVisualisationObservabilityBackendsString() {
         return "Visualisation observability backends: " + ObservabilityBackend.allDescriptors().stream().sorted().map(d -> d.getDisplayName()).collect(Collectors.joining(", "));
     }
 
-    @Nonnull
+    @NonNull
     public ConcurrentMap<String, StepPlugin> getLoadedStepsPlugins() {
         return loadedStepsPlugins;
     }
@@ -372,7 +372,7 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
     }
 
     @Nullable
-    private Descriptor<? extends Describable> getStepDescriptor(@Nonnull FlowNode node, @Nullable Descriptor<? extends Describable> descriptor) {
+    private Descriptor<? extends Describable> getStepDescriptor(@NonNull FlowNode node, @Nullable Descriptor<? extends Describable> descriptor) {
         // Support for https://javadoc.jenkins.io/jenkins/tasks/SimpleBuildStep.html
         if (descriptor instanceof CoreStep.DescriptorImpl) {
             Map<String, Object> arguments = ArgumentsAction.getFilteredArguments(node);
@@ -387,27 +387,27 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
     }
 
     @Nullable
-    private Descriptor<? extends Describable> getBuildStepDescriptor(@Nonnull BuildStep buildStep) {
+    private Descriptor<? extends Describable> getBuildStepDescriptor(@NonNull BuildStep buildStep) {
         return Jenkins.get().getDescriptor((Class<? extends Describable>) buildStep.getClass());
     }
 
-    @Nonnull
-    public StepPlugin findStepPluginOrDefault(@Nonnull String buildStepName, @Nonnull BuildStep buildStep) {
+    @NonNull
+    public StepPlugin findStepPluginOrDefault(@NonNull String buildStepName, @NonNull BuildStep buildStep) {
         return findStepPluginOrDefault(buildStepName, getBuildStepDescriptor(buildStep));
     }
 
-    @Nonnull
-    public StepPlugin findStepPluginOrDefault(@Nonnull String stepName, @Nonnull StepAtomNode node) {
+    @NonNull
+    public StepPlugin findStepPluginOrDefault(@NonNull String stepName, @NonNull StepAtomNode node) {
         return findStepPluginOrDefault(stepName, getStepDescriptor(node, node.getDescriptor()));
     }
 
-    @Nonnull
-    public StepPlugin findStepPluginOrDefault(@Nonnull String stepName, @Nonnull StepStartNode node) {
+    @NonNull
+    public StepPlugin findStepPluginOrDefault(@NonNull String stepName, @NonNull StepStartNode node) {
         return findStepPluginOrDefault(stepName, getStepDescriptor(node, node.getDescriptor()));
     }
 
-    @Nonnull
-    public StepPlugin findStepPluginOrDefault(@Nonnull String stepName, @Nullable Descriptor<? extends Describable> descriptor) {
+    @NonNull
+    public StepPlugin findStepPluginOrDefault(@NonNull String stepName, @Nullable Descriptor<? extends Describable> descriptor) {
         StepPlugin data = loadedStepsPlugins.get(stepName);
         if (data != null) {
             LOGGER.log(Level.FINEST, " found the plugin for the step '" + stepName + "' - " + data);
@@ -426,13 +426,13 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
         return data;
     }
 
-    @Nonnull
-    public String findSymbolOrDefault(@Nonnull String buildStepName, @Nonnull BuildStep buildStep) {
+    @NonNull
+    public String findSymbolOrDefault(@NonNull String buildStepName, @NonNull BuildStep buildStep) {
         return findSymbolOrDefault(buildStepName, getBuildStepDescriptor(buildStep));
     }
 
-    @Nonnull
-    public String findSymbolOrDefault(@Nonnull String buildStepName, @Nullable Descriptor<? extends Describable> descriptor) {
+    @NonNull
+    public String findSymbolOrDefault(@NonNull String buildStepName, @Nullable Descriptor<? extends Describable> descriptor) {
         String value = buildStepName;
         if (descriptor != null) {
             Set<String> values = SymbolLookup.getSymbolValue(descriptor);
@@ -467,7 +467,7 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
         initializeOpenTelemetry();
     }
 
-    @Nonnull
+    @NonNull
     public Resource getResource() {
         if (this.openTelemetrySdkProvider == null) {
             return Resource.empty();
@@ -480,14 +480,14 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
      * Used in io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration/config.jelly because
      * cyrille doesn't know how to format the content with linebreaks in a html teaxtarea
      */
-    @Nonnull
+    @NonNull
     public String getResourceAsText() {
         return this.getResource().getAttributes().asMap().entrySet().stream().
             map(e -> e.getKey() + "=" + e.getValue()).
             collect(Collectors.joining("\r\n"));
     }
 
-    @Nonnull
+    @NonNull
     public ConfigProperties getConfigProperties() {
         if (this.openTelemetrySdkProvider == null) {
             return ConfigPropertiesUtils.emptyConfig();
@@ -500,14 +500,14 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
      * Used in io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration/config.jelly because
      * cyrille doesn't know how to format the content with linebreaks in a html teaxtarea
      */
-    @Nonnull
+    @NonNull
     public String getNoteworthyConfigPropertiesAsText() {
         return OtelUtils.noteworthyConfigProperties(getConfigProperties()).entrySet().stream().
             map(e -> e.getKey() + "=" + e.getValue()).
             collect(Collectors.joining("\r\n"));
     }
 
-    @Nonnull
+    @NonNull
     public LogStorageRetriever getLogStorageRetriever() {
         if (logStorageRetriever == null) {
             throw new IllegalStateException("logStorageRetriever NOT loaded");
@@ -515,7 +515,7 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
         return logStorageRetriever;
     }
 
-    @Nonnull
+    @NonNull
     private LogStorageRetriever resolveLogStorageRetriever() {
         LogStorageRetriever logStorageRetriever = null;
         for (ObservabilityBackend backend : getObservabilityBackends()) {

--- a/src/main/java/io/jenkins/plugins/opentelemetry/OpenTelemetryAttributesAction.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/OpenTelemetryAttributesAction.java
@@ -9,7 +9,7 @@ import hudson.model.InvisibleAction;
 import io.jenkins.plugins.opentelemetry.job.MonitoringAction;
 import io.opentelemetry.api.common.AttributeKey;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -24,7 +24,7 @@ public class OpenTelemetryAttributesAction extends InvisibleAction {
 
     private transient Map<AttributeKey<?>, Object> attributes;
 
-    @Nonnull
+    @NonNull
     public Map<AttributeKey<?>, Object> getAttributes() {
         if (attributes == null) {
             attributes = new HashMap<>();

--- a/src/main/java/io/jenkins/plugins/opentelemetry/OpenTelemetryConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/OpenTelemetryConfiguration.java
@@ -15,7 +15,7 @@ import io.opentelemetry.sdk.resources.ResourceBuilder;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import org.apache.commons.lang.StringUtils;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -98,7 +98,7 @@ public class OpenTelemetryConfiguration {
     /**
      * @see io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder#addPropertiesSupplier(java.util.function.Supplier)
      */
-    @Nonnull
+    @NonNull
     public Map<String, String> toOpenTelemetryProperties() {
         Map<String, String> properties = new HashMap<>();
         properties.putAll(this.configurationProperties);
@@ -140,7 +140,7 @@ public class OpenTelemetryConfiguration {
     /**
      * @see io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder#addResourceCustomizer(BiFunction)
      */
-    @Nonnull
+    @NonNull
     public Resource toOpenTelemetryResource() {
         ResourceBuilder resourceBuilder = Resource.builder();
         this.getServiceName().ifPresent(serviceName ->

--- a/src/main/java/io/jenkins/plugins/opentelemetry/OpenTelemetrySdkProvider.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/OpenTelemetrySdkProvider.java
@@ -26,7 +26,7 @@ import io.opentelemetry.sdk.logs.SdkLogEmitterProvider;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.resources.ResourceBuilder;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import java.util.logging.Level;
@@ -60,22 +60,22 @@ public class OpenTelemetrySdkProvider {
         initializeNoOp();
     }
 
-    @Nonnull
+    @NonNull
     public Tracer getTracer() {
         return Preconditions.checkNotNull(tracer);
     }
 
-    @Nonnull
+    @NonNull
     public Meter getMeter() {
         return Preconditions.checkNotNull(meter);
     }
 
-    @Nonnull
+    @NonNull
     public Resource getResource() {
         return Preconditions.checkNotNull(resource);
     }
 
-    @Nonnull
+    @NonNull
     public ConfigProperties getConfig() {
         return Preconditions.checkNotNull(config);
     }
@@ -85,13 +85,13 @@ public class OpenTelemetrySdkProvider {
         return otelLogsExporter != null && !otelLogsExporter.equals("none");
     }
 
-    @Nonnull
+    @NonNull
     public LogEmitter getLogEmitter() {
         return Preconditions.checkNotNull(this.logEmitter);
     }
 
     @VisibleForTesting
-    @Nonnull
+    @NonNull
     protected OpenTelemetrySdk getOpenTelemetrySdk() {
         return Preconditions.checkNotNull(openTelemetrySdk);
     }
@@ -106,7 +106,7 @@ public class OpenTelemetrySdkProvider {
         GlobalOpenTelemetry.resetForTest();
     }
 
-    public void initialize(@Nonnull OpenTelemetryConfiguration configuration) {
+    public void initialize(@NonNull OpenTelemetryConfiguration configuration) {
         preDestroy(); // shutdown existing SDK
 
         AutoConfiguredOpenTelemetrySdkBuilder sdkBuilder = AutoConfiguredOpenTelemetrySdk.builder();

--- a/src/main/java/io/jenkins/plugins/opentelemetry/OtelUtils.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/OtelUtils.java
@@ -27,9 +27,9 @@ import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -73,13 +73,13 @@ public class OtelUtils {
         return null;
     }
 
-    public static String getComaSeparatedString(@Nonnull Map<String, String> keyValuePairs) {
+    public static String getComaSeparatedString(@NonNull Map<String, String> keyValuePairs) {
         return keyValuePairs.entrySet().stream()
             .map(keyValuePair -> keyValuePair.getKey() + "=" + keyValuePair.getValue())
             .collect(Collectors.joining(","));
     }
 
-    @Nonnull
+    @NonNull
     public static Map<String, String> getCommaSeparatedMap(@Nullable String comaSeparatedKeyValuePairs) {
         if (StringUtils.isBlank(comaSeparatedKeyValuePairs)) {
             return new HashMap<>();
@@ -108,7 +108,7 @@ public class OtelUtils {
             .collect(Collectors.toList());
     }
 
-    @Nonnull
+    @NonNull
     public static Function<Span, String> spanToDebugString() {
         return span -> {
             if (span == null) {
@@ -128,7 +128,7 @@ public class OtelUtils {
         };
     }
 
-    @Nonnull
+    @NonNull
     public static String getProjectType(Run run) {
         if (isFreestyle(run)) {
             return FREESTYLE;
@@ -148,7 +148,7 @@ public class OtelUtils {
         return UNKNOWN;
     }
 
-    @Nonnull
+    @NonNull
     public static String getMultibranchType(Run run) {
         if (isMultibranch(run)) {
             if (isMultibranchChangeRequest(run)) {
@@ -185,7 +185,7 @@ public class OtelUtils {
         return false;
     }
 
-    @Nonnull
+    @NonNull
     public static boolean isMultibranch(Run run) {
         if (run == null) {
             return false;
@@ -193,7 +193,7 @@ public class OtelUtils {
         return (run instanceof WorkflowRun && run.getParent().getParent() instanceof WorkflowMultiBranchProject);
     }
 
-    @Nonnull
+    @NonNull
     public static boolean isWorkflow(Run run) {
         if (run == null) {
             return false;
@@ -201,7 +201,7 @@ public class OtelUtils {
         return (run instanceof WorkflowRun && !(run.getParent().getParent() instanceof WorkflowMultiBranchProject));
     }
 
-    @Nonnull
+    @NonNull
     public static boolean isFreestyle(Run run) {
         if (run == null) {
             return false;
@@ -209,7 +209,7 @@ public class OtelUtils {
         return (run instanceof FreeStyleBuild);
     }
 
-    @Nonnull
+    @NonNull
     public static boolean isMatrix(Run run) {
         if (run == null) {
             return false;
@@ -219,7 +219,7 @@ public class OtelUtils {
             isInstance(run, "hudson.matrix.MatrixRun");
     }
 
-    @Nonnull
+    @NonNull
     public static boolean isMaven(Run run) {
         if (run == null) {
             return false;
@@ -236,12 +236,12 @@ public class OtelUtils {
         return false;
     }
 
-    @Nonnull
+    @NonNull
     public static String toDebugString(@Nullable Span span) {
         return spanToDebugString().apply(span);
     }
 
-    @Nonnull
+    @NonNull
     public static String urlEncode(String value) {
         try {
             return URLEncoder.encode(value, StandardCharsets.UTF_8.toString());
@@ -250,13 +250,13 @@ public class OtelUtils {
         }
     }
 
-    @Nonnull
+    @NonNull
     public static String getJenkinsVersion() {
         final VersionNumber versionNumber = Jenkins.getVersion();
         return versionNumber == null ? UNKNOWN_VALUE : versionNumber.toString(); // should not be null except maybe in development of Jenkins itself
     }
 
-    @Nonnull
+    @NonNull
     public static String getOpentelemetryPluginVersion() {
         final Jenkins instance = Jenkins.getInstanceOrNull();
         if (instance == null) {

--- a/src/main/java/io/jenkins/plugins/opentelemetry/authentication/BearerTokenAuthentication.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/authentication/BearerTokenAuthentication.java
@@ -21,7 +21,7 @@ import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;

--- a/src/main/java/io/jenkins/plugins/opentelemetry/authentication/NoAuthentication.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/authentication/NoAuthentication.java
@@ -11,7 +11,7 @@ import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
 import java.util.logging.Logger;
 

--- a/src/main/java/io/jenkins/plugins/opentelemetry/authentication/OtlpAuthentication.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/authentication/OtlpAuthentication.java
@@ -14,7 +14,7 @@ import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporterBuilder;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder;
 import jenkins.model.Jenkins;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
 
 public abstract class OtlpAuthentication implements Describable<OtlpAuthentication>, ExtensionPoint {
@@ -25,7 +25,7 @@ public abstract class OtlpAuthentication implements Describable<OtlpAuthenticati
      * typically appending credentials to the {@code OTEL_EXPORTER_OTLP_HEADERS} variable
      * @param environmentVariables the builder to configure
      */
-    public abstract void enrichOtelEnvironmentVariables(@Nonnull Map<String, String> environmentVariables);
+    public abstract void enrichOtelEnvironmentVariables(@NonNull Map<String, String> environmentVariables);
 
     @Override
     public Descriptor<OtlpAuthentication> getDescriptor() {

--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/CustomObservabilityBackend.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/CustomObservabilityBackend.java
@@ -10,7 +10,7 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;

--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/ElasticBackend.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/ElasticBackend.java
@@ -17,8 +17,8 @@ import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;

--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/JaegerBackend.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/JaegerBackend.java
@@ -12,7 +12,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;

--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/ObservabilityBackend.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/ObservabilityBackend.java
@@ -20,8 +20,8 @@ import io.opentelemetry.sdk.resources.Resource;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
@@ -157,7 +157,7 @@ public abstract class ObservabilityBackend implements Describable<ObservabilityB
     /**
      * Extension point for Observability backends to contribute to the configuration properties used to instantiate the OpenTelemetry SDK.
      */
-    @Nonnull
+    @NonNull
     public Map<String, String> getOtelConfigurationProperties() {
         LogStorageRetriever logStorageRetriever = getLogStorageRetriever(TemplateBindingsProvider.empty());
         if (logStorageRetriever != null) {

--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/ZipkinBackend.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/ZipkinBackend.java
@@ -10,7 +10,7 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;

--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/custom/CustomLogStorageRetriever.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/custom/CustomLogStorageRetriever.java
@@ -13,7 +13,7 @@ import io.jenkins.plugins.opentelemetry.job.log.LogsQueryResult;
 import io.jenkins.plugins.opentelemetry.job.log.LogsViewHeader;
 import org.kohsuke.stapler.framework.io.ByteBuffer;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -21,7 +21,7 @@ import java.util.Map;
 
 public class CustomLogStorageRetriever implements LogStorageRetriever {
 
-    @Nonnull
+    @NonNull
     private final Template buildLogsVisualizationUrlTemplate;
 
     private final TemplateBindingsProvider templateBindingsProvider;
@@ -31,20 +31,20 @@ public class CustomLogStorageRetriever implements LogStorageRetriever {
         this.templateBindingsProvider = templateBindingsProvider;
     }
 
-    @Nonnull
+    @NonNull
     @Override
-    public LogsQueryResult overallLog(@Nonnull String jobFullName, @Nonnull int runNumber, @Nonnull String traceId, @Nonnull String spanId, boolean complete) throws IOException {
+    public LogsQueryResult overallLog(@NonNull String jobFullName, @NonNull int runNumber, @NonNull String traceId, @NonNull String spanId, boolean complete) throws IOException {
         return getLogsQueryResult(traceId, spanId);
     }
 
-    @Nonnull
+    @NonNull
     @Override
-    public LogsQueryResult stepLog(@Nonnull String jobFullName, @Nonnull int runNumber, @Nonnull String flowNodeId, @Nonnull String traceId, @Nonnull String spanId, boolean complete) throws IOException {
+    public LogsQueryResult stepLog(@NonNull String jobFullName, @NonNull int runNumber, @NonNull String flowNodeId, @NonNull String traceId, @NonNull String spanId, boolean complete) throws IOException {
         return getLogsQueryResult(traceId, spanId);
     }
 
-    @Nonnull
-    private LogsQueryResult getLogsQueryResult(@Nonnull String traceId, @Nonnull String spanId) throws IOException {
+    @NonNull
+    private LogsQueryResult getLogsQueryResult(@NonNull String traceId, @NonNull String spanId) throws IOException {
 
         Map<String, String> localBindings = new HashMap<>();
         localBindings.put("traceId", traceId);

--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/elastic/ElasticLogsBackend.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/elastic/ElasticLogsBackend.java
@@ -18,8 +18,8 @@ import io.jenkins.plugins.opentelemetry.job.log.LogStorageRetriever;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;

--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/elastic/ElasticLogsBackendWithJenkinsVisualization.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/elastic/ElasticLogsBackendWithJenkinsVisualization.java
@@ -27,7 +27,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;

--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/elastic/ElasticsearchLogStorageRetriever.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/elastic/ElasticsearchLogStorageRetriever.java
@@ -48,7 +48,7 @@ import org.elasticsearch.client.RestClient;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.framework.io.ByteBuffer;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.servlet.http.HttpSession;
 import java.io.Closeable;
 import java.io.IOException;
@@ -74,31 +74,31 @@ public class ElasticsearchLogStorageRetriever implements LogStorageRetriever, Cl
 
     private final static Logger logger = Logger.getLogger(ElasticsearchLogStorageRetriever.class.getName());
 
-    @Nonnull
+    @NonNull
     private final Template buildLogsVisualizationUrlTemplate;
 
     private final TemplateBindingsProvider templateBindingsProvider;
 
-    @Nonnull
+    @NonNull
     final Credentials elasticsearchCredentials;
-    @Nonnull
+    @NonNull
     final String elasticsearchUrl;
 
-    @Nonnull
+    @NonNull
     final RestClientTransport elasticsearchTransport;
-    @Nonnull
+    @NonNull
     private final ElasticsearchClient esClient;
 
-    @Nonnull
+    @NonNull
     private final Tracer tracer;
 
     /**
      * TODO verify unsername:password auth vs apiKey auth
      */
     public ElasticsearchLogStorageRetriever(
-        @Nonnull String elasticsearchUrl, @Nonnull Credentials elasticsearchCredentials,
-        @Nonnull Template buildLogsVisualizationUrlTemplate, @Nonnull TemplateBindingsProvider templateBindingsProvider,
-        @Nonnull Tracer tracer) {
+        @NonNull String elasticsearchUrl, @NonNull Credentials elasticsearchCredentials,
+        @NonNull Template buildLogsVisualizationUrlTemplate, @NonNull TemplateBindingsProvider templateBindingsProvider,
+        @NonNull Tracer tracer) {
 
         if (StringUtils.isBlank(elasticsearchUrl)) {
             throw new IllegalArgumentException("Elasticsearch url cannot be blank");
@@ -120,10 +120,10 @@ public class ElasticsearchLogStorageRetriever implements LogStorageRetriever, Cl
         this.templateBindingsProvider = templateBindingsProvider;
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public LogsQueryResult overallLog(
-        @Nonnull String jobFullName, int runNumber, @Nonnull String traceId, @Nonnull String spanId, boolean complete) {
+        @NonNull String jobFullName, int runNumber, @NonNull String traceId, @NonNull String spanId, boolean complete) {
         Charset charset = StandardCharsets.UTF_8;
 
         SpanBuilder spanBuilder = tracer.spanBuilder("ElasticsearchLogStorageRetriever.overallLog")
@@ -178,9 +178,9 @@ public class ElasticsearchLogStorageRetriever implements LogStorageRetriever, Cl
         }
     }
 
-    @Nonnull
+    @NonNull
     @Override
-    public LogsQueryResult stepLog(@Nonnull String jobFullName, int runNumber, @Nonnull String flowNodeId, @Nonnull String traceId, @Nonnull String spanId, boolean complete) {
+    public LogsQueryResult stepLog(@NonNull String jobFullName, int runNumber, @NonNull String flowNodeId, @NonNull String traceId, @NonNull String spanId, boolean complete) {
         final Charset charset = StandardCharsets.UTF_8;
 
         SpanBuilder spanBuilder = tracer.spanBuilder("ElasticsearchLogStorageRetriever.stepLog")
@@ -323,7 +323,7 @@ public class ElasticsearchLogStorageRetriever implements LogStorageRetriever, Cl
         return validations;
     }
 
-    @Nonnull
+    @NonNull
     protected static String prettyPrintPhaseRetentionPolicy(Phase phase, String phaseName) {
         if (phase == null) {
             return phaseName + " [phase not defined]";

--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/elastic/ElasticsearchLogsSearchIterator.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/elastic/ElasticsearchLogsSearchIterator.java
@@ -28,8 +28,8 @@ import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.Scope;
 import net.sf.json.JSONArray;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collections;
@@ -67,11 +67,11 @@ public class ElasticsearchLogsSearchIterator implements Iterator<String>, Closea
     Iterator<String> delegate;
     boolean endOfStream;
 
-    public ElasticsearchLogsSearchIterator(@Nonnull String jobFullName, int runNumber, @Nonnull String traceId, @Nullable ElasticsearchSearchContext context, @Nonnull ElasticsearchClient esClient, @Nonnull Tracer tracer) {
+    public ElasticsearchLogsSearchIterator(@NonNull String jobFullName, int runNumber, @NonNull String traceId, @Nullable ElasticsearchSearchContext context, @NonNull ElasticsearchClient esClient, @NonNull Tracer tracer) {
         this(jobFullName, runNumber, traceId, null, context, esClient, tracer);
     }
 
-    public ElasticsearchLogsSearchIterator(@Nonnull String jobFullName, int runNumber, @Nonnull String traceId, @Nullable String flowNodeId, @Nullable ElasticsearchSearchContext context, @Nonnull ElasticsearchClient esClient, @Nonnull Tracer tracer) {
+    public ElasticsearchLogsSearchIterator(@NonNull String jobFullName, int runNumber, @NonNull String traceId, @Nullable String flowNodeId, @Nullable ElasticsearchSearchContext context, @NonNull ElasticsearchClient esClient, @NonNull Tracer tracer) {
         this.tracer = tracer;
         this.jobFullName = jobFullName;
         this.runNumber = runNumber;
@@ -101,7 +101,7 @@ public class ElasticsearchLogsSearchIterator implements Iterator<String>, Closea
         return pointInTimeId;
     }
 
-    @Nonnull
+    @NonNull
     Iterator<String> getCurrentIterator() {
         try {
             if (endOfStream) {

--- a/src/main/java/io/jenkins/plugins/opentelemetry/computer/MonitoringCloudListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/computer/MonitoringCloudListener.java
@@ -15,7 +15,7 @@ import io.jenkins.plugins.opentelemetry.semconv.JenkinsSemanticMetrics;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import java.util.logging.Level;
@@ -65,7 +65,7 @@ public class MonitoringCloudListener extends CloudProvisioningListener {
      * Jenkins doesn't support {@link com.google.inject.Provides} so we manually wire dependencies :-(
      */
     @Inject
-    public void setMeter(@Nonnull OpenTelemetrySdkProvider openTelemetrySdkProvider) {
+    public void setMeter(@NonNull OpenTelemetrySdkProvider openTelemetrySdkProvider) {
         this.meter = openTelemetrySdkProvider.getMeter();
     }
 }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/computer/MonitoringComputerListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/computer/MonitoringComputerListener.java
@@ -22,7 +22,7 @@ import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import jenkins.model.Jenkins;
 import jenkins.security.MasterToSlaveCallable;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import java.io.IOException;
@@ -157,7 +157,7 @@ public class MonitoringComputerListener extends ComputerListener {
      * Jenkins doesn't support {@link com.google.inject.Provides} so we manually wire dependencies :-(
      */
     @Inject
-    public void setMeter(@Nonnull OpenTelemetrySdkProvider openTelemetrySdkProvider) {
+    public void setMeter(@NonNull OpenTelemetrySdkProvider openTelemetrySdkProvider) {
         this.meter = openTelemetrySdkProvider.getMeter();
     }
 }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/init/DiskUsageMonitoringInitializer.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/init/DiskUsageMonitoringInitializer.java
@@ -17,7 +17,7 @@ import io.opentelemetry.api.metrics.Meter;
 import jenkins.YesNoMaybe;
 import jenkins.model.Jenkins;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.inject.Inject;
 import java.io.IOException;
 import java.util.logging.Level;
@@ -61,7 +61,7 @@ public class DiskUsageMonitoringInitializer {
         }
         return calculateDiskUsageInBytes(quickDiskUsagePlugin);
     }
-    private long calculateDiskUsageInBytes(@Nonnull QuickDiskUsagePlugin diskUsagePlugin) {
+    private long calculateDiskUsageInBytes(@NonNull QuickDiskUsagePlugin diskUsagePlugin) {
         LOGGER.log(Level.FINE, "calculateDiskUsageInBytes");
         try {
             DiskItem disk = diskUsagePlugin.getDirectoriesUsages()
@@ -84,7 +84,7 @@ public class DiskUsageMonitoringInitializer {
      * Jenkins doesn't support {@link com.google.inject.Provides} so we manually wire dependencies :-(
      */
     @Inject
-    public void setMeter(@Nonnull OpenTelemetrySdkProvider openTelemetrySdkProvider) {
+    public void setMeter(@NonNull OpenTelemetrySdkProvider openTelemetrySdkProvider) {
         this.meter = openTelemetrySdkProvider.getMeter();
     }
 }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/init/OpenTelemetryPluginAbstractInitializer.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/init/OpenTelemetryPluginAbstractInitializer.java
@@ -9,7 +9,7 @@ package io.jenkins.plugins.opentelemetry.init;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.jenkins.plugins.opentelemetry.OpenTelemetrySdkProvider;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.inject.Inject;
 
 public abstract class OpenTelemetryPluginAbstractInitializer {
@@ -24,7 +24,7 @@ public abstract class OpenTelemetryPluginAbstractInitializer {
      * using {@link io.opentelemetry.api.GlobalOpenTelemetry}, proper dependency injection can be implemented.
      */
     @Inject
-    public void setOpenTelemetrySdkProvider(@Nonnull OpenTelemetrySdkProvider openTelemetrySdkProvider){
+    public void setOpenTelemetrySdkProvider(@NonNull OpenTelemetrySdkProvider openTelemetrySdkProvider){
         this.openTelemetrySdkProvider = openTelemetrySdkProvider;
     }
 }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringAction.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringAction.java
@@ -16,8 +16,8 @@ import jenkins.model.RunAction2;
 import jenkins.tasks.SimpleBuildStep;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
@@ -87,7 +87,7 @@ public class MonitoringAction implements Action, RunAction2, SimpleBuildStep.Las
     /**
      * Add per {@link FlowNode} contextual information.
      */
-    public void addContext(@Nonnull FlowNode node, @Nonnull Map<String, String> context) {
+    public void addContext(@NonNull FlowNode node, @NonNull Map<String, String> context) {
         if (contextPerNodeId == null) {
             contextPerNodeId = new HashMap<>();
         }
@@ -102,16 +102,16 @@ public class MonitoringAction implements Action, RunAction2, SimpleBuildStep.Las
     /**
      * See `io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator#inject(io.opentelemetry.context.Context, java.lang.Object, io.opentelemetry.context.propagation.TextMapSetter)`
      */
-    public void addRootContext(@Nonnull Map<String, String> context) {
+    public void addRootContext(@NonNull Map<String, String> context) {
         this.rootContext = context;
     }
 
     @CheckForNull
-    public Map<String, String> getContext(@Nonnull String flowNodeId) {
+    public Map<String, String> getContext(@NonNull String flowNodeId) {
         return contextPerNodeId.get(flowNodeId);
     }
 
-    @Nonnull
+    @NonNull
     public List<ObservabilityBackendLink> getLinks() {
         List<ObservabilityBackend> tracingCapableBackends = JenkinsOpenTelemetryPluginConfiguration.get().getObservabilityBackends()
             .stream()

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringBuildStepListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringBuildStepListener.java
@@ -25,8 +25,8 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import jenkins.model.Jenkins;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.inject.Inject;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -100,7 +100,7 @@ public class MonitoringBuildStepListener extends BuildStepListener {
      */
     @CheckForNull
     @MustBeClosed
-    protected Scope setupContext(AbstractBuild build, @Nonnull BuildStep buildStep) {
+    protected Scope setupContext(AbstractBuild build, @NonNull BuildStep buildStep) {
         build = verifyNotNull(build, "%s No build found for step %s", build, buildStep);
         Span span = this.otelTraceService.getSpan(build, buildStep);
 
@@ -110,17 +110,17 @@ public class MonitoringBuildStepListener extends BuildStepListener {
     }
 
     @Inject
-    public final void setOpenTelemetryTracerService(@Nonnull OtelTraceService otelTraceService) {
+    public final void setOpenTelemetryTracerService(@NonNull OtelTraceService otelTraceService) {
         this.otelTraceService = otelTraceService;
         this.tracer = this.otelTraceService.getTracer();
     }
 
-    @Nonnull
+    @NonNull
     public OtelTraceService getTracerService() {
         return otelTraceService;
     }
 
-    @Nonnull
+    @NonNull
     public Tracer getTracer() {
         return tracer;
     }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
@@ -7,6 +7,7 @@ package io.jenkins.plugins.opentelemetry.job;
 
 import com.google.common.base.Strings;
 import com.google.errorprone.annotations.MustBeClosed;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.model.Computer;
@@ -48,9 +49,9 @@ import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import java.io.IOException;
@@ -90,8 +91,9 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
         this.statusUnsetCausesOfInterruption = new HashSet<>(jenkinsOpenTelemetryPluginConfiguration.getStatusUnsetCausesOfInterruption());
     }
 
+    @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "see https://github.com/spotbugs/spotbugs/issues/651")
     @Override
-    public void onStartNodeStep(@Nonnull StepStartNode stepStartNode, @Nullable String agentLabel, @Nonnull WorkflowRun run) {
+    public void onStartNodeStep(@NonNull StepStartNode stepStartNode, @Nullable String agentLabel, @NonNull WorkflowRun run) {
         try (Scope nodeSpanScope = setupContext(run, stepStartNode)) {
             verifyNotNull(nodeSpanScope, "%s - No span found for node %s", run, stepStartNode);
             String stepType = getStepType(stepStartNode, stepStartNode.getDescriptor(), JenkinsOtelSemanticAttributes.STEP_NODE);
@@ -128,13 +130,13 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
     }
 
     @Override
-    public void onAfterStartNodeStep(@Nonnull StepStartNode stepStartNode, @Nullable String nodeLabel, @Nonnull WorkflowRun run) {
+    public void onAfterStartNodeStep(@NonNull StepStartNode stepStartNode, @Nullable String nodeLabel, @NonNull WorkflowRun run) {
         // end the JenkinsOtelSemanticAttributes.AGENT_ALLOCATE span
         endCurrentSpan(stepStartNode, run);
     }
 
     @Override
-    public void onStartStageStep(@Nonnull StepStartNode stepStartNode, @Nonnull String stageName, @Nonnull WorkflowRun run) {
+    public void onStartStageStep(@NonNull StepStartNode stepStartNode, @NonNull String stageName, @NonNull WorkflowRun run) {
         try (Scope ignored = setupContext(run, stepStartNode)) {
             verifyNotNull(ignored, "%s - No span found for node %s", run, stepStartNode);
             String spanStageName = "Stage: " + stageName;
@@ -157,12 +159,12 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
     }
 
     @Override
-    public void onEndNodeStep(@Nonnull StepEndNode node, @Nonnull String nodeName, @Nonnull WorkflowRun run) {
+    public void onEndNodeStep(@NonNull StepEndNode node, @NonNull String nodeName, @NonNull WorkflowRun run) {
         endCurrentSpan(node, run);
     }
 
     @Override
-    public void onEndStageStep(@Nonnull StepEndNode node, @Nonnull String stageName, @Nonnull WorkflowRun run) {
+    public void onEndStageStep(@NonNull StepEndNode node, @NonNull String stageName, @NonNull WorkflowRun run) {
         endCurrentSpan(node, run);
     }
 
@@ -175,7 +177,7 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
         return this.stepHandlers;
     }
     @Override
-    public void onAtomicStep(@Nonnull StepAtomNode node, @Nonnull WorkflowRun run) {
+    public void onAtomicStep(@NonNull StepAtomNode node, @NonNull WorkflowRun run) {
         if (isIgnoredStep(node.getDescriptor())){
             LOGGER.log(Level.FINE, () -> run.getFullDisplayName() + " - don't create span for step '" + node.getDisplayFunctionName() + "'");
             return;
@@ -213,7 +215,7 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
     }
 
     @Override
-    public void onAfterAtomicStep(@Nonnull StepAtomNode node, @Nonnull WorkflowRun run) {
+    public void onAfterAtomicStep(@NonNull StepAtomNode node, @NonNull WorkflowRun run) {
         if (isIgnoredStep(node.getDescriptor())){
             LOGGER.log(Level.FINE, () -> run.getFullDisplayName() + " - don't end span for step '" + node.getDisplayFunctionName() + "'");
             return;
@@ -230,7 +232,7 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
         return ignoreStep;
     }
 
-    private String getStepName(@Nonnull StepAtomNode node, @Nonnull String name) {
+    private String getStepName(@NonNull StepAtomNode node, @NonNull String name) {
         StepDescriptor stepDescriptor = node.getDescriptor();
         if (stepDescriptor == null) {
             return name;
@@ -243,7 +245,7 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
         return stepDescriptor.getDisplayName();
     }
 
-    private String getStepType(@Nonnull FlowNode node, @Nullable StepDescriptor stepDescriptor, @Nonnull String type) {
+    private String getStepType(@NonNull FlowNode node, @Nullable StepDescriptor stepDescriptor, @NonNull String type) {
         if (stepDescriptor == null) {
             return type;
         }
@@ -255,7 +257,7 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
     }
 
     @Nullable
-    private UninstantiatedDescribable getUninstantiatedDescribableOrNull(@Nonnull FlowNode node, @Nullable StepDescriptor stepDescriptor) {
+    private UninstantiatedDescribable getUninstantiatedDescribableOrNull(@NonNull FlowNode node, @Nullable StepDescriptor stepDescriptor) {
         // Support for https://javadoc.jenkins.io/jenkins/tasks/SimpleBuildStep.html
         if (stepDescriptor instanceof CoreStep.DescriptorImpl) {
             Map<String, Object> arguments = ArgumentsAction.getFilteredArguments(node);
@@ -267,7 +269,7 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
     }
 
     @Override
-    public void onStartParallelStepBranch(@Nonnull StepStartNode stepStartNode, @Nonnull String branchName, @Nonnull WorkflowRun run) {
+    public void onStartParallelStepBranch(@NonNull StepStartNode stepStartNode, @NonNull String branchName, @NonNull WorkflowRun run) {
         try (Scope ignored = setupContext(run, stepStartNode)) {
             verifyNotNull(ignored, "%s - No span found for node %s", run, stepStartNode);
 
@@ -289,7 +291,7 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
     }
 
     @Override
-    public void onEndParallelStepBranch(@Nonnull StepEndNode node, @Nonnull String branchName, @Nonnull WorkflowRun run) {
+    public void onEndParallelStepBranch(@NonNull StepEndNode node, @NonNull String branchName, @NonNull WorkflowRun run) {
         endCurrentSpan(node, run);
     }
 
@@ -338,7 +340,7 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
     }
 
     @Override
-    public void notifyOfNewStep(@Nonnull Step step, @Nonnull StepContext context) {
+    public void notifyOfNewStep(@NonNull Step step, @NonNull StepContext context) {
         try {
             WorkflowRun run = context.get(WorkflowRun.class);
             FlowNode node = context.get(FlowNode.class);
@@ -375,7 +377,7 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
      */
     @CheckForNull
     @MustBeClosed
-    protected Scope setupContext(WorkflowRun run, @Nonnull FlowNode node) {
+    protected Scope setupContext(WorkflowRun run, @NonNull FlowNode node) {
         run = verifyNotNull(run, "%s No run found for node %s", run, node);
         Span span = this.otelTraceService.getSpan(run, node);
 
@@ -385,17 +387,17 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
     }
 
     @Inject
-    public final void setOpenTelemetryTracerService(@Nonnull OtelTraceService otelTraceService) {
+    public final void setOpenTelemetryTracerService(@NonNull OtelTraceService otelTraceService) {
         this.otelTraceService = otelTraceService;
         this.tracer = this.otelTraceService.getTracer();
     }
 
-    @Nonnull
+    @NonNull
     public OtelTraceService getTracerService() {
         return otelTraceService;
     }
 
-    @Nonnull
+    @NonNull
     public Tracer getTracer() {
         return tracer;
     }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringRunListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringRunListener.java
@@ -9,6 +9,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.errorprone.annotations.MustBeClosed;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.model.AbstractBuild;
@@ -42,8 +43,8 @@ import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.support.steps.build.BuildUpstreamCause;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import javax.annotation.PostConstruct;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -294,8 +295,8 @@ public class MonitoringRunListener extends OtelContextAwareAbstractRunListener {
     }
 
     @MustBeClosed
-    @Nonnull
-    protected Scope endPipelinePhaseSpan(@Nonnull Run run) {
+    @NonNull
+    protected Scope endPipelinePhaseSpan(@NonNull Run run) {
         Span pipelinePhaseSpan = verifyNotNull(Span.current(), "No pipelinePhaseSpan found in context");
         pipelinePhaseSpan.end();
         LOGGER.log(Level.FINE, () -> run.getFullDisplayName() + " - end " + OtelUtils.toDebugString(pipelinePhaseSpan));
@@ -307,6 +308,7 @@ public class MonitoringRunListener extends OtelContextAwareAbstractRunListener {
         return newScope;
     }
 
+    @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "see https://github.com/spotbugs/spotbugs/issues/651")
     @Override
     public void _onFinalized(@NonNull Run run) {
 
@@ -367,7 +369,7 @@ public class MonitoringRunListener extends OtelContextAwareAbstractRunListener {
         }
     }
 
-    @Nonnull
+    @NonNull
     protected List<RunHandler> getRunHandlers() {
         return Preconditions.checkNotNull(this.runHandlers);
     }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelEnvironmentContributor.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelEnvironmentContributor.java
@@ -11,7 +11,7 @@ import hudson.model.EnvironmentContributor;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.inject.Inject;
 import java.util.logging.Logger;
 
@@ -27,7 +27,7 @@ public class OtelEnvironmentContributor extends EnvironmentContributor {
     private OtelTraceService otelTraceService;
 
     @Override
-    public void buildEnvironmentFor(@Nonnull Run run, @Nonnull EnvVars envs, @Nonnull TaskListener listener) {
+    public void buildEnvironmentFor(@NonNull Run run, @NonNull EnvVars envs, @NonNull TaskListener listener) {
         otelEnvironmentContributorService.addEnvironmentVariables(run, envs, otelTraceService.getSpan(run, false));
     }
 

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelEnvironmentContributorService.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelEnvironmentContributorService.java
@@ -11,7 +11,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.TextMapSetter;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.inject.Inject;
 import java.util.Map;
 import java.util.logging.Level;
@@ -30,7 +30,7 @@ public class OtelEnvironmentContributorService {
 
     private JenkinsOpenTelemetryPluginConfiguration jenkinsOpenTelemetryPluginConfiguration;
 
-    public void addEnvironmentVariables(@Nonnull Run run, @Nonnull EnvVars envs, @Nonnull Span span) {
+    public void addEnvironmentVariables(@NonNull Run run, @NonNull EnvVars envs, @NonNull Span span) {
         String spanId = span.getSpanContext().getSpanId();
         String traceId = span.getSpanContext().getTraceId();
         try (Scope ignored = span.makeCurrent()) {

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelStepEnvironmentContributor.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelStepEnvironmentContributor.java
@@ -14,7 +14,7 @@ import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepEnvironmentContributor;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.inject.Inject;
 import java.io.IOException;
 import java.util.logging.Level;
@@ -33,7 +33,7 @@ public class OtelStepEnvironmentContributor extends StepEnvironmentContributor {
     private OtelTraceService otelTraceService;
 
     @Override
-    public void buildEnvironmentFor(@Nonnull StepContext stepContext, @Nonnull EnvVars envs, @Nonnull TaskListener listener) throws IOException, InterruptedException {
+    public void buildEnvironmentFor(@NonNull StepContext stepContext, @NonNull EnvVars envs, @NonNull TaskListener listener) throws IOException, InterruptedException {
         super.buildEnvironmentFor(stepContext, envs, listener);
         Run run = stepContext.get(Run.class);
         FlowNode flowNode = stepContext.get(FlowNode.class);

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelTraceService.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelTraceService.java
@@ -27,8 +27,8 @@ import org.jenkinsci.plugins.workflow.graph.AtomNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.support.steps.ExecutorStep;
 
-import javax.annotation.Nonnull;
-import javax.annotation.concurrent.Immutable;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import net.jcip.annotations.Immutable;
 import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -69,13 +69,13 @@ public class OtelTraceService {
         freestyleSpansByRun = new ConcurrentHashMap();
     }
 
-    @Nonnull
-    public Span getSpan(@Nonnull Run run) {
+    @NonNull
+    public Span getSpan(@NonNull Run run) {
         return getSpan(run, true);
     }
 
-    @Nonnull
-    public Span getSpan(@Nonnull Run run, boolean verifyIfRemainingSteps) {
+    @NonNull
+    public Span getSpan(@NonNull Run run, boolean verifyIfRemainingSteps) {
         RunIdentifier runIdentifier = RunIdentifier.fromRun(run);
         RunSpans runSpans = spansByRun.computeIfAbsent(runIdentifier, runIdentifier1 -> new RunSpans()); // absent when Jenkins restarts during build
 
@@ -91,8 +91,8 @@ public class OtelTraceService {
         return span;
     }
 
-    @Nonnull
-    public Span getSpan(@Nonnull Run run, FlowNode flowNode) {
+    @NonNull
+    public Span getSpan(@NonNull Run run, FlowNode flowNode) {
 
         RunIdentifier runIdentifier = RunIdentifier.fromRun(run);
         RunSpans runSpans = spansByRun.computeIfAbsent(runIdentifier, runIdentifier1 -> new RunSpans()); // absent when Jenkins restarts during build
@@ -117,8 +117,8 @@ public class OtelTraceService {
         return span;
     }
 
-    @Nonnull
-    public Span getSpan(@Nonnull AbstractBuild build, @Nonnull BuildStep buildStep) {
+    @NonNull
+    public Span getSpan(@NonNull AbstractBuild build, @NonNull BuildStep buildStep) {
 
         RunIdentifier runIdentifier = RunIdentifier.fromBuild(build);
         FreestyleRunSpans freestyleRunSpans = freestyleSpansByRun.computeIfAbsent(runIdentifier, runIdentifier1 -> new FreestyleRunSpans()); // absent when Jenkins restarts during build
@@ -177,8 +177,8 @@ public class OtelTraceService {
      * @param flowNode
      * @return list of enclosing flow nodes starting with the passed flow nodes
      */
-    @Nonnull
-    private Iterable<FlowNode> getAncestors(@Nonnull final FlowNode flowNode) {
+    @NonNull
+    private Iterable<FlowNode> getAncestors(@NonNull final FlowNode flowNode) {
         // troubleshoot https://github.com/jenkinsci/opentelemetry-plugin/issues/197
         LOGGER.log(Level.FINEST, () -> "> getAncestorsV2([" + flowNode.getClass().getSimpleName() + ", " + flowNode.getId() + ", '" + flowNode.getDisplayFunctionName() + "'])");
         List<FlowNode> ancestors = new ArrayList<>();
@@ -195,7 +195,7 @@ public class OtelTraceService {
         return ancestors;
     }
 
-    public void removePipelineStepSpan(@Nonnull Run run, @Nonnull FlowNode flowNode, @Nonnull Span span) {
+    public void removePipelineStepSpan(@NonNull Run run, @NonNull FlowNode flowNode, @NonNull Span span) {
         RunIdentifier runIdentifier = RunIdentifier.fromRun(run);
         RunSpans runSpans = this.spansByRun.computeIfAbsent(runIdentifier, runIdentifier1 -> new RunSpans()); // absent when Jenkins restarts during build
 
@@ -223,7 +223,7 @@ public class OtelTraceService {
 
     }
 
-    public void removeJobPhaseSpan(@Nonnull Run run, @Nonnull Span span) {
+    public void removeJobPhaseSpan(@NonNull Run run, @NonNull Span span) {
         RunIdentifier runIdentifier = RunIdentifier.fromRun(run);
         RunSpans runSpans = this.spansByRun.computeIfAbsent(runIdentifier, runIdentifier1 -> new RunSpans()); // absent when Jenkins restarts during build
 
@@ -244,7 +244,7 @@ public class OtelTraceService {
         throw new VerifyException(run.getFullDisplayName() + " - Failure to remove span " + span + " - " + runSpans);
     }
 
-    public void removeBuildStepSpan(@Nonnull AbstractBuild build, @Nonnull BuildStep buildStep, @Nonnull Span span) {
+    public void removeBuildStepSpan(@NonNull AbstractBuild build, @NonNull BuildStep buildStep, @NonNull Span span) {
         RunIdentifier runIdentifier = RunIdentifier.fromBuild(build);
         FreestyleRunSpans freestyleRunSpans = this.freestyleSpansByRun.computeIfAbsent(runIdentifier, runIdentifier1 -> new FreestyleRunSpans()); // absent when Jenkins restarts during build
 
@@ -263,7 +263,7 @@ public class OtelTraceService {
         throw new VerifyException(build.getFullDisplayName() + " - Failure to remove span " + span + " - " + freestyleRunSpans);
     }
 
-    public void purgeRun(@Nonnull Run run) {
+    public void purgeRun(@NonNull Run run) {
         RunIdentifier runIdentifier = RunIdentifier.fromRun(run);
         RunSpans runSpans = this.spansByRun.remove(runIdentifier);
         if (runSpans == null) {
@@ -275,7 +275,7 @@ public class OtelTraceService {
         }
     }
 
-    public void putSpan(@Nonnull AbstractBuild build, @Nonnull Span span) {
+    public void putSpan(@NonNull AbstractBuild build, @NonNull Span span) {
         RunIdentifier runIdentifier = RunIdentifier.fromBuild(build);
         FreestyleRunSpans runSpans = freestyleSpansByRun.computeIfAbsent(runIdentifier, runIdentifier1 -> new FreestyleRunSpans());
         runSpans.runPhasesSpans.add(span);
@@ -283,7 +283,7 @@ public class OtelTraceService {
         LOGGER.log(Level.FINEST, () -> "putSpan(" + build.getFullDisplayName() + "," + span + ") - new stack: " + runSpans);
     }
 
-    public void putSpan(@Nonnull Run run, @Nonnull Span span) {
+    public void putSpan(@NonNull Run run, @NonNull Span span) {
         RunIdentifier runIdentifier = RunIdentifier.fromRun(run);
         RunSpans runSpans = spansByRun.computeIfAbsent(runIdentifier, runIdentifier1 -> new RunSpans());
         runSpans.runPhasesSpans.add(span);
@@ -291,7 +291,7 @@ public class OtelTraceService {
         LOGGER.log(Level.FINEST, () -> "putSpan(" + run.getFullDisplayName() + "," + span + ") - new stack: " + runSpans);
     }
 
-    public void putSpan(@Nonnull Run run, @Nonnull Span span, @Nonnull FlowNode flowNode) {
+    public void putSpan(@NonNull Run run, @NonNull Span span, @NonNull FlowNode flowNode) {
         RunIdentifier runIdentifier = RunIdentifier.fromRun(run);
         RunSpans runSpans = spansByRun.computeIfAbsent(runIdentifier, runIdentifier1 -> new RunSpans());
         runSpans.pipelineStepSpansByFlowNodeId.put(flowNode.getId(), new PipelineSpanContext(span, flowNode));
@@ -300,7 +300,7 @@ public class OtelTraceService {
     }
 
     @Inject
-    public void setJenkinsOtelPlugin(@Nonnull OpenTelemetrySdkProvider openTelemetrySdkProvider) {
+    public void setJenkinsOtelPlugin(@NonNull OpenTelemetrySdkProvider openTelemetrySdkProvider) {
         this.tracer = openTelemetrySdkProvider.getTracer();
         this.noOpTracer = TracerProvider.noop().get("jenkins");
     }
@@ -309,18 +309,18 @@ public class OtelTraceService {
      * @return If no span has been found (ie Jenkins restart), then the scope of a NoOp span is returned
      * @see #setupContext(Run, boolean) 
      */
-    @Nonnull
+    @NonNull
     @MustBeClosed
-    public Scope setupContext(@Nonnull Run run) {
+    public Scope setupContext(@NonNull Run run) {
         return setupContext(run, true);
     }
 
     /**
      * @return If no span has been found (ie Jenkins restart), then the scope of a NoOp span is returned
      */
-    @Nonnull
+    @NonNull
     @MustBeClosed
-    public Scope setupContext(@Nonnull Run run, boolean verifyIfRemainingSteps) {
+    public Scope setupContext(@NonNull Run run, boolean verifyIfRemainingSteps) {
         Span span = getSpan(run, verifyIfRemainingSteps);
         Scope scope = span.makeCurrent();
         Context.current().with(RunContextKey.KEY, run);
@@ -368,7 +368,7 @@ public class OtelTraceService {
         final transient Span span;
         final String flowNodeId;
 
-        public FreestyleSpanContext(@Nonnull Span span, @Nonnull BuildStep buildStep) {
+        public FreestyleSpanContext(@NonNull Span span, @NonNull BuildStep buildStep) {
             this.span = span;
             this.flowNodeId = buildStep.getClass().getSimpleName();
         }
@@ -376,7 +376,7 @@ public class OtelTraceService {
         /**
          * FIXME handle cases where the data structure has been deserialized and {@link Span} is null.
          */
-        @Nonnull
+        @NonNull
         public Span getSpan() {
             return span;
         }
@@ -408,7 +408,7 @@ public class OtelTraceService {
         final String flowNodeId;
         final List<String> parentFlowNodeIds;
 
-        public PipelineSpanContext(@Nonnull Span span, @Nonnull FlowNode flowNode) {
+        public PipelineSpanContext(@NonNull Span span, @NonNull FlowNode flowNode) {
             this.span = span;
             this.flowNodeId = flowNode.getId();
             List<FlowNode> parents = flowNode.getParents();
@@ -423,7 +423,7 @@ public class OtelTraceService {
          *
          * @see FlowNode#getParents()
          */
-        @Nonnull
+        @NonNull
         public List<String> getParentFlowNodeIds() {
             return parentFlowNodeIds;
         }
@@ -431,7 +431,7 @@ public class OtelTraceService {
         /**
          * FIXME handle cases where the data structure has been deserialized and {@link Span} is null.
          */
-        @Nonnull
+        @NonNull
         public Span getSpan() {
             return span;
         }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/RunFlowNodeIdentifier.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/RunFlowNodeIdentifier.java
@@ -5,15 +5,15 @@
 
 package io.jenkins.plugins.opentelemetry.job;
 
-import javax.annotation.Nonnull;
-import javax.annotation.concurrent.Immutable;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import net.jcip.annotations.Immutable;
 import java.util.Objects;
 
 @Immutable
 public class RunFlowNodeIdentifier extends RunIdentifier {
     final String flowNodeId;
 
-    public RunFlowNodeIdentifier(@Nonnull String jobFullName, @Nonnull int runNumber, @Nonnull String flowNodeId) {
+    public RunFlowNodeIdentifier(@NonNull String jobFullName, @NonNull int runNumber, @NonNull String flowNodeId) {
         super(jobFullName, runNumber);
         this.flowNodeId = flowNodeId;
     }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/RunIdentifier.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/RunIdentifier.java
@@ -9,8 +9,8 @@ import com.google.common.collect.ComparisonChain;
 import hudson.model.AbstractBuild;
 import hudson.model.Run;
 
-import javax.annotation.Nonnull;
-import javax.annotation.concurrent.Immutable;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import net.jcip.annotations.Immutable;
 import java.util.Objects;
 
 @Immutable
@@ -18,15 +18,15 @@ public class RunIdentifier implements Comparable<RunIdentifier> {
     final String jobName;
     final int runNumber;
 
-    static RunIdentifier fromRun(@Nonnull Run run) {
+    static RunIdentifier fromRun(@NonNull Run run) {
         return new RunIdentifier(run.getParent().getFullName(), run.getNumber());
     }
 
-    static RunIdentifier fromBuild(@Nonnull AbstractBuild build) {
+    static RunIdentifier fromBuild(@NonNull AbstractBuild build) {
         return new RunIdentifier(build.getParent().getFullName(), build.getNumber());
     }
 
-    public RunIdentifier(@Nonnull String jobName, @Nonnull int runNumber) {
+    public RunIdentifier(@NonNull String jobName, @NonNull int runNumber) {
         this.jobName = jobName;
         this.runNumber = runNumber;
     }
@@ -34,7 +34,7 @@ public class RunIdentifier implements Comparable<RunIdentifier> {
     /**
      * String identifier for this run
      */
-    @Nonnull
+    @NonNull
     public String getId() {
         return jobName + "#" + runNumber;
     }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/cause/BitBucketPushCauseHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/cause/BitBucketPushCauseHandler.java
@@ -10,7 +10,7 @@ import hudson.Extension;
 import hudson.model.Cause;
 import jenkins.YesNoMaybe;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 @Extension(optional = true, dynamicLoadable = YesNoMaybe.YES)
 public class BitBucketPushCauseHandler implements CauseHandler {
@@ -21,7 +21,7 @@ public class BitBucketPushCauseHandler implements CauseHandler {
     }
 
     @Override
-    public boolean isSupported(@Nonnull Cause cause) {
+    public boolean isSupported(@NonNull Cause cause) {
         return isBitBucketPushCause(cause);
     }
 
@@ -30,7 +30,7 @@ public class BitBucketPushCauseHandler implements CauseHandler {
     }
 
     @Override
-    public String getStructuredDescription(@Nonnull Cause cause) {
+    public String getStructuredDescription(@NonNull Cause cause) {
         // https://github.com/jenkinsci/bitbucket-plugin/blob/master/src/main/java/com/cloudbees/jenkins/plugins/BitBucketPushCause.java#L33
         String id = cause.getShortDescription().replaceAll(".* by ", "");
         return cause.getClass().getSimpleName() + ":" + id;

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/cause/BranchIndexingCauseHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/cause/BranchIndexingCauseHandler.java
@@ -10,7 +10,7 @@ import hudson.model.Cause;
 import jenkins.YesNoMaybe;
 import jenkins.branch.BranchIndexingCause;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 @Extension(optional = true, dynamicLoadable = YesNoMaybe.YES)
 public class BranchIndexingCauseHandler implements CauseHandler {
@@ -21,7 +21,7 @@ public class BranchIndexingCauseHandler implements CauseHandler {
     }
 
     @Override
-    public boolean isSupported(@Nonnull Cause cause) {
+    public boolean isSupported(@NonNull Cause cause) {
         return cause instanceof jenkins.branch.BranchIndexingCause;
     }
 }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/cause/CauseHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/cause/CauseHandler.java
@@ -8,19 +8,19 @@ package io.jenkins.plugins.opentelemetry.job.cause;
 import hudson.model.Cause;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 public interface CauseHandler extends Comparable<CauseHandler> {
 
     default void configure(ConfigProperties config){};
 
-    boolean isSupported(@Nonnull Cause cause);
+    boolean isSupported(@NonNull Cause cause);
 
     /**
      * Machine-readable description of the cause like "UserIdCause:anonymous"...
      */
-    @Nonnull
-    default String getStructuredDescription(@Nonnull Cause cause) {
+    @NonNull
+    default String getStructuredDescription(@NonNull Cause cause) {
         return cause.getClass().getSimpleName();
     }
 

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/cause/DefaultCauseHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/cause/DefaultCauseHandler.java
@@ -9,13 +9,13 @@ import hudson.Extension;
 import hudson.model.Cause;
 import jenkins.YesNoMaybe;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 @Extension(optional = true, dynamicLoadable = YesNoMaybe.YES)
 public class DefaultCauseHandler implements CauseHandler {
 
     @Override
-    public boolean isSupported(@Nonnull Cause cause) {
+    public boolean isSupported(@NonNull Cause cause) {
         return true;
     }
 

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/cause/GitHubPushCauseHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/cause/GitHubPushCauseHandler.java
@@ -10,7 +10,7 @@ import hudson.Extension;
 import hudson.model.Cause;
 import jenkins.YesNoMaybe;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 @Extension(optional = true, dynamicLoadable = YesNoMaybe.YES)
 public class GitHubPushCauseHandler implements CauseHandler {
@@ -21,12 +21,12 @@ public class GitHubPushCauseHandler implements CauseHandler {
     }
 
     @Override
-    public boolean isSupported(@Nonnull Cause cause) {
+    public boolean isSupported(@NonNull Cause cause) {
         return cause instanceof GitHubPushCause;
     }
 
     @Override
-    public String getStructuredDescription(@Nonnull Cause cause) {
+    public String getStructuredDescription(@NonNull Cause cause) {
         // https://github.com/jenkinsci/github-plugin/blob/master/src/main/java/com/cloudbees/jenkins/GitHubPushCause.java#L39
         String id = cause.getShortDescription().replaceAll(".* by ", "");
         return cause.getClass().getSimpleName() + ":" + id;

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/cause/GitLabWebHookCauseHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/cause/GitLabWebHookCauseHandler.java
@@ -10,7 +10,7 @@ import hudson.Extension;
 import hudson.model.Cause;
 import jenkins.YesNoMaybe;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 @Extension(optional = true, dynamicLoadable = YesNoMaybe.YES)
 public class GitLabWebHookCauseHandler implements CauseHandler {
@@ -21,12 +21,12 @@ public class GitLabWebHookCauseHandler implements CauseHandler {
     }
 
     @Override
-    public boolean isSupported(@Nonnull Cause cause) {
+    public boolean isSupported(@NonNull Cause cause) {
         return cause instanceof GitLabWebHookCause;
     }
 
     @Override
-    public String getStructuredDescription(@Nonnull Cause cause) {
+    public String getStructuredDescription(@NonNull Cause cause) {
         // https://github.com/jenkinsci/gitlab-plugin/blob/master/src/main/resources/com/dabsquared/gitlabjenkins/cause/Messages.properties#L2
         String id = cause.getShortDescription().replaceAll(".* by ", "");
         return cause.getClass().getSimpleName() + ":" + id;

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/cause/RemoteCauseHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/cause/RemoteCauseHandler.java
@@ -9,7 +9,7 @@ import hudson.Extension;
 import hudson.model.Cause;
 import jenkins.YesNoMaybe;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 @Extension(optional = true, dynamicLoadable = YesNoMaybe.YES)
 public class RemoteCauseHandler implements CauseHandler {
@@ -20,12 +20,12 @@ public class RemoteCauseHandler implements CauseHandler {
     }
 
     @Override
-    public boolean isSupported(@Nonnull Cause cause) {
+    public boolean isSupported(@NonNull Cause cause) {
         return (cause instanceof Cause.RemoteCause);
     }
 
     @Override
-    public String getStructuredDescription(@Nonnull Cause cause) {
+    public String getStructuredDescription(@NonNull Cause cause) {
         Cause.RemoteCause remoteCause = (Cause.RemoteCause) cause;
         return cause.getClass().getSimpleName() + ":" + remoteCause.getAddr();
     }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/cause/SCMTriggerCauseHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/cause/SCMTriggerCauseHandler.java
@@ -10,7 +10,7 @@ import hudson.model.Cause;
 import hudson.triggers.SCMTrigger;
 import jenkins.YesNoMaybe;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 @Extension(optional = true, dynamicLoadable = YesNoMaybe.YES)
 public class SCMTriggerCauseHandler implements CauseHandler {
@@ -21,7 +21,7 @@ public class SCMTriggerCauseHandler implements CauseHandler {
     }
 
     @Override
-    public boolean isSupported(@Nonnull Cause cause) {
+    public boolean isSupported(@NonNull Cause cause) {
         return cause instanceof SCMTrigger.SCMTriggerCause;
     }
 

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/cause/TimerTriggerCauseHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/cause/TimerTriggerCauseHandler.java
@@ -10,7 +10,7 @@ import hudson.model.Cause;
 import hudson.triggers.TimerTrigger;
 import jenkins.YesNoMaybe;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 @Extension(optional = true, dynamicLoadable = YesNoMaybe.YES)
 public class TimerTriggerCauseHandler implements CauseHandler {
@@ -21,7 +21,7 @@ public class TimerTriggerCauseHandler implements CauseHandler {
     }
 
     @Override
-    public boolean isSupported(@Nonnull Cause cause) {
+    public boolean isSupported(@NonNull Cause cause) {
         return (cause instanceof TimerTrigger.TimerTriggerCause);
     }
 }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/cause/UpstreamCauseHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/cause/UpstreamCauseHandler.java
@@ -9,7 +9,7 @@ import hudson.Extension;
 import hudson.model.Cause;
 import jenkins.YesNoMaybe;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 @Extension(optional = true, dynamicLoadable = YesNoMaybe.YES)
 public class UpstreamCauseHandler implements CauseHandler {
@@ -20,12 +20,12 @@ public class UpstreamCauseHandler implements CauseHandler {
     }
 
     @Override
-    public boolean isSupported(@Nonnull Cause cause) {
+    public boolean isSupported(@NonNull Cause cause) {
         return (cause instanceof Cause.UpstreamCause);
     }
 
     @Override
-    public String getStructuredDescription(@Nonnull Cause cause) {
+    public String getStructuredDescription(@NonNull Cause cause) {
         Cause.UpstreamCause upstreamCause = (Cause.UpstreamCause) cause;
         return upstreamCause.getClass().getSimpleName() + ":" + upstreamCause.getUpstreamProject() + "#" + upstreamCause.getUpstreamBuild();
     }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/cause/UserIdCauseHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/cause/UserIdCauseHandler.java
@@ -9,7 +9,7 @@ import hudson.Extension;
 import hudson.model.Cause;
 import jenkins.YesNoMaybe;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 @Extension(optional = true, dynamicLoadable = YesNoMaybe.YES)
 public class UserIdCauseHandler implements CauseHandler {
@@ -20,13 +20,13 @@ public class UserIdCauseHandler implements CauseHandler {
     }
 
     @Override
-    public boolean isSupported(@Nonnull Cause cause) {
+    public boolean isSupported(@NonNull Cause cause) {
         return cause instanceof Cause.UserIdCause;
     }
 
-    @Nonnull
+    @NonNull
     @Override
-    public String getStructuredDescription(@Nonnull Cause cause) {
+    public String getStructuredDescription(@NonNull Cause cause) {
         Cause.UserIdCause userIdCause = (Cause.UserIdCause) cause;
         String id = userIdCause.getUserId();
         if (id == null) {

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/jenkins/AbstractPipelineListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/jenkins/AbstractPipelineListener.java
@@ -11,62 +11,62 @@ import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 public class AbstractPipelineListener implements PipelineListener {
     @Override
-    public void onStartPipeline(@Nonnull FlowNode node, @Nonnull WorkflowRun run) {
+    public void onStartPipeline(@NonNull FlowNode node, @NonNull WorkflowRun run) {
 
     }
 
     @Override
-    public void onStartNodeStep(@Nonnull StepStartNode stepStartNode, @Nullable String nodeLabel, @Nonnull WorkflowRun run) {
+    public void onStartNodeStep(@NonNull StepStartNode stepStartNode, @Nullable String nodeLabel, @NonNull WorkflowRun run) {
 
     }
 
     @Override
-    public void onStartStageStep(@Nonnull StepStartNode stepStartNode, @Nonnull String stageName, @Nonnull WorkflowRun run) {
+    public void onStartStageStep(@NonNull StepStartNode stepStartNode, @NonNull String stageName, @NonNull WorkflowRun run) {
 
     }
 
     @Override
-    public void onAfterStartNodeStep(@Nonnull StepStartNode stepStartNode, @Nullable String nodeLabel, @Nonnull WorkflowRun run) {
+    public void onAfterStartNodeStep(@NonNull StepStartNode stepStartNode, @Nullable String nodeLabel, @NonNull WorkflowRun run) {
 
     }
 
     @Override
-    public void onEndNodeStep(@Nonnull StepEndNode nodeStepEndNode, @Nonnull String nodeName, @Nonnull WorkflowRun run) {
+    public void onEndNodeStep(@NonNull StepEndNode nodeStepEndNode, @NonNull String nodeName, @NonNull WorkflowRun run) {
 
     }
 
     @Override
-    public void onEndStageStep(@Nonnull StepEndNode stageStepEndNode, @Nonnull String stageName, @Nonnull WorkflowRun run) {
+    public void onEndStageStep(@NonNull StepEndNode stageStepEndNode, @NonNull String stageName, @NonNull WorkflowRun run) {
 
     }
 
     @Override
-    public void onAtomicStep(@Nonnull StepAtomNode node, @Nonnull WorkflowRun run) {
+    public void onAtomicStep(@NonNull StepAtomNode node, @NonNull WorkflowRun run) {
 
     }
 
     @Override
-    public void onAfterAtomicStep(@Nonnull StepAtomNode stepAtomNode, @Nonnull WorkflowRun run) {
+    public void onAfterAtomicStep(@NonNull StepAtomNode stepAtomNode, @NonNull WorkflowRun run) {
 
     }
 
     @Override
-    public void onStartParallelStepBranch(@Nonnull StepStartNode stepStartNode, @Nonnull String branchName, @Nonnull WorkflowRun run) {
+    public void onStartParallelStepBranch(@NonNull StepStartNode stepStartNode, @NonNull String branchName, @NonNull WorkflowRun run) {
 
     }
 
     @Override
-    public void onEndParallelStepBranch(@Nonnull StepEndNode stepStepNode, @Nonnull String branchName, @Nonnull WorkflowRun run) {
+    public void onEndParallelStepBranch(@NonNull StepEndNode stepStepNode, @NonNull String branchName, @NonNull WorkflowRun run) {
 
     }
 
     @Override
-    public void onEndPipeline(@Nonnull FlowNode node, @Nonnull WorkflowRun run) {
+    public void onEndPipeline(@NonNull FlowNode node, @NonNull WorkflowRun run) {
 
     }
 }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/jenkins/GraphListenerAdapterToPipelineListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/jenkins/GraphListenerAdapterToPipelineListener.java
@@ -26,7 +26,7 @@ import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
@@ -97,7 +97,7 @@ public class GraphListenerAdapterToPipelineListener implements StepListener, Gra
     }
 
     @Override
-    public void notifyOfNewStep(@Nonnull Step step, @Nonnull StepContext context) {
+    public void notifyOfNewStep(@NonNull Step step, @NonNull StepContext context) {
         try {
             Run run = context.get(Run.class);
             FlowNode flowNode = context.get(FlowNode.class);
@@ -111,7 +111,7 @@ public class GraphListenerAdapterToPipelineListener implements StepListener, Gra
         }
     }
 
-    private void fireOnBeforeStartParallelStepBranch(@Nonnull StepStartNode node, @Nonnull String branchName, @Nonnull WorkflowRun run) {
+    private void fireOnBeforeStartParallelStepBranch(@NonNull StepStartNode node, @NonNull String branchName, @NonNull WorkflowRun run) {
         for (PipelineListener pipelineListener : PipelineListener.all()) {
             log(Level.FINE, () -> "onBeforeStartParallelStepBranch(branchName: " + branchName + ", " + node.getDisplayName() + "): " + pipelineListener.toString());
             try {
@@ -122,7 +122,7 @@ public class GraphListenerAdapterToPipelineListener implements StepListener, Gra
         }
     }
 
-    private void fireOnAfterEndParallelStepBranch(@Nonnull StepEndNode node, @Nonnull String branchName, @Nonnull WorkflowRun run) {
+    private void fireOnAfterEndParallelStepBranch(@NonNull StepEndNode node, @NonNull String branchName, @NonNull WorkflowRun run) {
         for (PipelineListener pipelineListener : PipelineListener.all()) {
             log(Level.FINE, () -> "onAfterEndParallelStepBranch(branchName: " + branchName + ", node[name:" + node.getDisplayName() + ", id: " + node.getId() + "]): " + pipelineListener.toString());
             try {
@@ -133,7 +133,7 @@ public class GraphListenerAdapterToPipelineListener implements StepListener, Gra
         }
     }
 
-    private void logFlowNodeDetails(@Nonnull FlowNode node, @Nonnull WorkflowRun run) {
+    private void logFlowNodeDetails(@NonNull FlowNode node, @NonNull WorkflowRun run) {
         log(Level.FINE, () ->
         {
             String message = run.getFullDisplayName() + " - " +
@@ -150,7 +150,7 @@ public class GraphListenerAdapterToPipelineListener implements StepListener, Gra
         });
     }
 
-    public void fireOnAfterAtomicStep(@Nonnull StepAtomNode stepAtomNode, @Nonnull WorkflowRun run) {
+    public void fireOnAfterAtomicStep(@NonNull StepAtomNode stepAtomNode, @NonNull WorkflowRun run) {
         for (PipelineListener pipelineListener : PipelineListener.all()) {
             log(() -> "onAfterAtomicStep(" + stepAtomNode.getDisplayName() + "): " + pipelineListener.toString());
             try {
@@ -161,7 +161,7 @@ public class GraphListenerAdapterToPipelineListener implements StepListener, Gra
         }
     }
 
-    public void fireOnEndPipeline(@Nonnull FlowEndNode node, @Nonnull WorkflowRun run) {
+    public void fireOnEndPipeline(@NonNull FlowEndNode node, @NonNull WorkflowRun run) {
         for (PipelineListener pipelineListener : PipelineListener.all()) {
             log(() -> "onEndPipeline(" + node.getDisplayName() + "): " + pipelineListener.toString());
             try {
@@ -172,7 +172,7 @@ public class GraphListenerAdapterToPipelineListener implements StepListener, Gra
         }
     }
 
-    public void fireOnStartPipeline(@Nonnull FlowStartNode node, @Nonnull WorkflowRun run) {
+    public void fireOnStartPipeline(@NonNull FlowStartNode node, @NonNull WorkflowRun run) {
         for (PipelineListener pipelineListener : PipelineListener.all()) {
             log(() -> "onStartPipeline(" + node.getDisplayName() + ") run " + run.getFullDisplayName() + ", pipelineListenerStep:" + pipelineListener.toString());
             try {
@@ -183,7 +183,7 @@ public class GraphListenerAdapterToPipelineListener implements StepListener, Gra
         }
     }
 
-    public void fireOnAfterEndNodeStep(@Nonnull StepEndNode node, @Nonnull String nodeName, @Nonnull WorkflowRun run) {
+    public void fireOnAfterEndNodeStep(@NonNull StepEndNode node, @NonNull String nodeName, @NonNull WorkflowRun run) {
         for (PipelineListener pipelineListener : PipelineListener.all()) {
             log(() -> "onAfterEndNodeStep(" + node.getDisplayName() + "): " + pipelineListener.toString() + (node.getError() != null ? ("error: " + node.getError().getError().toString()) : ""));
             try {
@@ -194,7 +194,7 @@ public class GraphListenerAdapterToPipelineListener implements StepListener, Gra
         }
     }
 
-    public void fireOnAfterEndStageStep(@Nonnull StepEndNode node, @Nonnull String stageName, @Nonnull WorkflowRun run) {
+    public void fireOnAfterEndStageStep(@NonNull StepEndNode node, @NonNull String stageName, @NonNull WorkflowRun run) {
         for (PipelineListener pipelineListener : PipelineListener.all()) {
             log(() -> "onAfterEndStageStep(" + node.getDisplayName() + "): " + pipelineListener.toString() + (node.getError() != null ? ("error: " + node.getError().getError().toString()) : ""));
             try {
@@ -205,7 +205,7 @@ public class GraphListenerAdapterToPipelineListener implements StepListener, Gra
         }
     }
 
-    public void fireOnBeforeAtomicStep(@Nonnull StepAtomNode node, @Nonnull WorkflowRun run) {
+    public void fireOnBeforeAtomicStep(@NonNull StepAtomNode node, @NonNull WorkflowRun run) {
         for (PipelineListener pipelineListener : PipelineListener.all()) {
             log(() -> "onBeforeAtomicStep(" + node.getDisplayName() + "): " + pipelineListener.toString());
             try {
@@ -216,7 +216,7 @@ public class GraphListenerAdapterToPipelineListener implements StepListener, Gra
         }
     }
 
-    public void fireOnStartNodeStep(@Nonnull StepStartNode node, @Nonnull String nodeLabel, @Nonnull WorkflowRun run) {
+    public void fireOnStartNodeStep(@NonNull StepStartNode node, @NonNull String nodeLabel, @NonNull WorkflowRun run) {
         for (PipelineListener pipelineListener : PipelineListener.all()) {
             log(() -> "onStartNodeStep(" + node.getDisplayName() + "): " + pipelineListener.toString());
             try {
@@ -227,7 +227,7 @@ public class GraphListenerAdapterToPipelineListener implements StepListener, Gra
         }
     }
 
-    public void fireOnAfterStartNodeStep(@Nonnull StepStartNode node, @Nonnull String nodeLabel, @Nonnull WorkflowRun run) {
+    public void fireOnAfterStartNodeStep(@NonNull StepStartNode node, @NonNull String nodeLabel, @NonNull WorkflowRun run) {
         for (PipelineListener pipelineListener : PipelineListener.all()) {
             log(() -> "onAfterStartNodeStep(" + node.getDisplayName() + "): " + pipelineListener.toString());
             try {
@@ -238,7 +238,7 @@ public class GraphListenerAdapterToPipelineListener implements StepListener, Gra
         }
     }
 
-    public void fireOnBeforeStartStageStep(@Nonnull StepStartNode node, @Nonnull String stageName, @Nonnull WorkflowRun run) {
+    public void fireOnBeforeStartStageStep(@NonNull StepStartNode node, @NonNull String stageName, @NonNull WorkflowRun run) {
         for (PipelineListener pipelineListener : PipelineListener.all()) {
             log(() -> "onBeforeStartStageStep(" + node.getDisplayName() + "): " + pipelineListener.toString());
             try {
@@ -249,23 +249,23 @@ public class GraphListenerAdapterToPipelineListener implements StepListener, Gra
         }
     }
 
-    private boolean isBeforeEndExecutorNodeStep(@Nonnull FlowNode node) {
+    private boolean isBeforeEndExecutorNodeStep(@NonNull FlowNode node) {
         return (node instanceof StepEndNode) && PipelineNodeUtil.isStartExecutorNode(((StepEndNode) node).getStartNode());
     }
 
-    private boolean isBeforeEndStageStep(@Nonnull FlowNode node) {
+    private boolean isBeforeEndStageStep(@NonNull FlowNode node) {
         return (node instanceof StepEndNode) && PipelineNodeUtil.isStartStage(((StepEndNode) node).getStartNode());
     }
 
-    private boolean isBeforeEndParallelBranch(@Nonnull FlowNode node) {
+    private boolean isBeforeEndParallelBranch(@NonNull FlowNode node) {
         return (node instanceof StepEndNode) && PipelineNodeUtil.isStartParallelBranch(((StepEndNode) node).getStartNode());
     }
 
-    protected void log(@Nonnull Supplier<String> message) {
+    protected void log(@NonNull Supplier<String> message) {
         log(Level.FINE, message);
     }
 
-    protected void log(@Nonnull Level level, @Nonnull Supplier<String> message) {
+    protected void log(@NonNull Level level, @NonNull Supplier<String> message) {
         LOGGER.log(level, message);
     }
 }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/jenkins/PipelineListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/jenkins/PipelineListener.java
@@ -12,13 +12,13 @@ import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.List;
 
 public interface PipelineListener {
 
-    @Nonnull
+    @NonNull
     static List<PipelineListener> all() {
         return ExtensionList.lookup(PipelineListener.class);
     }
@@ -26,56 +26,56 @@ public interface PipelineListener {
     /**
      * Just before the pipeline starts
      */
-    void onStartPipeline(@Nonnull FlowNode node, @Nonnull WorkflowRun run);
+    void onStartPipeline(@NonNull FlowNode node, @NonNull WorkflowRun run);
 
     /**
      * Just before the `node` step starts.
      */
-    void onStartNodeStep(@Nonnull StepStartNode stepStartNode, @Nullable String nodeLabel, @Nonnull WorkflowRun run);
+    void onStartNodeStep(@NonNull StepStartNode stepStartNode, @Nullable String nodeLabel, @NonNull WorkflowRun run);
 
     /**
      * Just after the `node` step starts.
      */
-    void onAfterStartNodeStep(@Nonnull StepStartNode stepStartNode, @Nullable String nodeLabel, @Nonnull WorkflowRun run);
+    void onAfterStartNodeStep(@NonNull StepStartNode stepStartNode, @Nullable String nodeLabel, @NonNull WorkflowRun run);
 
     /**
      * Just after the `node` step ends
      */
-    void onEndNodeStep(@Nonnull StepEndNode nodeStepEndNode, @Nonnull String nodeName, @Nonnull WorkflowRun run);
+    void onEndNodeStep(@NonNull StepEndNode nodeStepEndNode, @NonNull String nodeName, @NonNull WorkflowRun run);
 
     /**
      * Just before the `stage`step starts
      */
-    void onStartStageStep(@Nonnull StepStartNode stepStartNode, @Nonnull String stageName, @Nonnull WorkflowRun run);
+    void onStartStageStep(@NonNull StepStartNode stepStartNode, @NonNull String stageName, @NonNull WorkflowRun run);
 
     /**
      * Just after the `stage` step ends
      */
-    void onEndStageStep(@Nonnull StepEndNode stageStepEndNode, @Nonnull String stageName, @Nonnull WorkflowRun run);
+    void onEndStageStep(@NonNull StepEndNode stageStepEndNode, @NonNull String stageName, @NonNull WorkflowRun run);
 
     /**
      * Just before the `parallel` branch starts
      */
-    void onStartParallelStepBranch(@Nonnull StepStartNode stepStartNode, @Nonnull String branchName, @Nonnull WorkflowRun run);
+    void onStartParallelStepBranch(@NonNull StepStartNode stepStartNode, @NonNull String branchName, @NonNull WorkflowRun run);
 
     /**
      * Just before the `parallel` branch ends
      */
-    void onEndParallelStepBranch(@Nonnull StepEndNode stepStepNode, @Nonnull String branchName, @Nonnull WorkflowRun run);
+    void onEndParallelStepBranch(@NonNull StepEndNode stepStepNode, @NonNull String branchName, @NonNull WorkflowRun run);
 
     /**
      * Just before the atomic step starts
      */
-    void onAtomicStep(@Nonnull StepAtomNode node, @Nonnull WorkflowRun run);
+    void onAtomicStep(@NonNull StepAtomNode node, @NonNull WorkflowRun run);
 
     /**
      * Just after the atomic step
      */
-    void onAfterAtomicStep(@Nonnull StepAtomNode stepAtomNode, @Nonnull WorkflowRun run);
+    void onAfterAtomicStep(@NonNull StepAtomNode stepAtomNode, @NonNull WorkflowRun run);
 
     /**
      * Just after the pipeline ends
      */
-    void onEndPipeline(@Nonnull FlowNode node, @Nonnull WorkflowRun run);
+    void onEndPipeline(@NonNull FlowNode node, @NonNull WorkflowRun run);
 
 }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/jenkins/PipelineNodeUtil.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/jenkins/PipelineNodeUtil.java
@@ -22,9 +22,9 @@ import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.jenkinsci.plugins.workflow.support.steps.ExecutorStep;
 import org.jenkinsci.plugins.workflow.support.steps.StageStep;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
 import java.util.List;
 import java.util.logging.Level;
@@ -212,7 +212,7 @@ public class PipelineNodeUtil {
         return isStartParallelBlock(stepEndNode.getStartNode());
     }
 
-    public static boolean isStartExecutorNodeExecution(@Nonnull FlowNode node) {
+    public static boolean isStartExecutorNodeExecution(@NonNull FlowNode node) {
         if (node == null) {
             return false;
         }
@@ -231,8 +231,8 @@ public class PipelineNodeUtil {
     /**
      * copy of {@code io.jenkins.blueocean.rest.impl.pipeline.PipelineNodeUtil}
      */
-    @Nonnull
-    public static String getDisplayName(@Nonnull FlowNode node) {
+    @NonNull
+    public static String getDisplayName(@NonNull FlowNode node) {
         ThreadNameAction threadNameAction = node.getAction(ThreadNameAction.class);
         return threadNameAction != null
                 ? threadNameAction.getThreadName()
@@ -245,7 +245,7 @@ public class PipelineNodeUtil {
      * @return the {@link FlowNode} that has previously executed or {@code null}
      */
     @CheckForNull
-    public static FlowNode getPreviousNode(@Nonnull FlowNode node) {
+    public static FlowNode getPreviousNode(@NonNull FlowNode node) {
         List<FlowNode> parents = node.getParents();
         if (parents.size() > 1) {
             System.out.println(PipelineNodeUtil.getDetailedDebugString(node));
@@ -255,7 +255,7 @@ public class PipelineNodeUtil {
 
 
     @CheckForNull
-    public static WorkflowRun getWorkflowRun(@Nonnull FlowNode flowNode) {
+    public static WorkflowRun getWorkflowRun(@NonNull FlowNode flowNode) {
         Queue.Executable executable;
         try {
             executable = flowNode.getExecution().getOwner().getExecutable();
@@ -271,7 +271,7 @@ public class PipelineNodeUtil {
         return null;
     }
 
-    @Nonnull
+    @NonNull
     public static String getDebugString(@Nullable FlowNode flowNode) {
         if (flowNode == null) {
             return "#null#";
@@ -287,7 +287,7 @@ public class PipelineNodeUtil {
         return value;
     }
 
-    @Nonnull
+    @NonNull
     public static String getDetailedDebugString(@Nullable FlowNode flowNode) {
         if (flowNode == null) {
             return "#null#";

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/log/BuildInfo.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/log/BuildInfo.java
@@ -13,8 +13,8 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashMap;
@@ -60,7 +60,7 @@ public final class BuildInfo implements Serializable {
         this.w3cTraceContext = new HashMap<>(buildInfo.w3cTraceContext);
     }
 
-    @Nonnull
+    @NonNull
     public Attributes toAttributes() {
         return Attributes.builder()
             .put(JenkinsOtelSemanticAttributes.CI_PIPELINE_ID, jobFullName)

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/log/ConsoleNotes.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/log/ConsoleNotes.java
@@ -11,8 +11,8 @@ import io.jenkins.plugins.opentelemetry.semconv.JenkinsOtelSemanticAttributes;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/log/LogStorageRetriever.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/log/LogStorageRetriever.java
@@ -5,7 +5,7 @@
 
 package io.jenkins.plugins.opentelemetry.job.log;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 
 public interface LogStorageRetriever {
@@ -15,8 +15,8 @@ public interface LogStorageRetriever {
      * @param runNumber see {@link hudson.model.Run#getNumber()}
      * @param complete if true, we claim to be serving the complete log for a build, so implementations should be sure to retrieve final log lines
      */
-    @Nonnull
-    LogsQueryResult overallLog(@Nonnull String jobFullName, @Nonnull int runNumber, @Nonnull String traceId, @Nonnull String spanId, boolean complete) throws IOException;
+    @NonNull
+    LogsQueryResult overallLog(@NonNull String jobFullName, @NonNull int runNumber, @NonNull String traceId, @NonNull String spanId, boolean complete) throws IOException;
 
 
     /**
@@ -25,6 +25,6 @@ public interface LogStorageRetriever {
      * @param flowNodeId see {@link org.jenkinsci.plugins.workflow.graph.FlowNode#getId()}
      * @param complete if true, we claim to be serving the complete log for a build, so implementations should be sure to retrieve final log lines
      */
-    @Nonnull LogsQueryResult stepLog(@Nonnull String jobFullName, @Nonnull int runNumber, @Nonnull String flowNodeId, @Nonnull String traceId, @Nonnull String spanId, boolean complete) throws IOException;
+    @NonNull LogsQueryResult stepLog(@NonNull String jobFullName, @NonNull int runNumber, @NonNull String flowNodeId, @NonNull String traceId, @NonNull String spanId, boolean complete) throws IOException;
 
 }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/log/LogsQueryResult.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/log/LogsQueryResult.java
@@ -7,11 +7,11 @@ package io.jenkins.plugins.opentelemetry.job.log;
 
 import org.kohsuke.stapler.framework.io.ByteBuffer;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.charset.Charset;
 
 public class LogsQueryResult {
-    public LogsQueryResult(@Nonnull ByteBuffer byteBuffer, @Nonnull LogsViewHeader logsViewHeader, @Nonnull Charset charset, boolean completed) {
+    public LogsQueryResult(@NonNull ByteBuffer byteBuffer, @NonNull LogsViewHeader logsViewHeader, @NonNull Charset charset, boolean completed) {
         this.byteBuffer = byteBuffer;
         this.logsViewHeader = logsViewHeader;
         this.charset = charset;
@@ -23,22 +23,22 @@ public class LogsQueryResult {
     final Charset charset;
     final boolean complete;
 
-    @Nonnull
+    @NonNull
     public ByteBuffer getByteBuffer() {
         return byteBuffer;
     }
 
-    @Nonnull
+    @NonNull
     public Charset getCharset() {
         return charset;
     }
 
-    @Nonnull
+    @NonNull
     public boolean isComplete() {
         return complete;
     }
 
-    @Nonnull
+    @NonNull
     public LogsViewHeader getLogsViewHeader() {
         return logsViewHeader;
     }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/log/LogsViewHeader.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/log/LogsViewHeader.java
@@ -13,7 +13,7 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.charset.Charset;
@@ -39,7 +39,7 @@ public class LogsViewHeader {
     public long writeHeader(Writer w, FlowExecutionOwner.Executable context, Charset charset) throws IOException {
         ConsoleAnnotator consoleAnnotator = new ConsoleAnnotator() {
             @Override
-            public ConsoleAnnotator annotate(@Nonnull Object context, @Nonnull MarkupText text) {
+            public ConsoleAnnotator annotate(@NonNull Object context, @NonNull MarkupText text) {
                 StaplerRequest currentRequest = Stapler.getCurrentRequest();
                 String iconRootContextRelativeUrl;
                 if (currentRequest == null) { // unit test

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/log/OtelLogOutputStream.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/log/OtelLogOutputStream.java
@@ -11,8 +11,8 @@ import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.logs.LogEmitter;
 import org.apache.commons.lang.StringUtils;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -29,7 +29,7 @@ final class OtelLogOutputStream extends LineTransformationOutputStream {
     public static boolean ENABLE_LOG_FORMATTING = Boolean.valueOf(System.getProperty("pipeline.log.elastic.enable.log.formatting", "false"));
     private final static Logger LOGGER = Logger.getLogger(OtelLogOutputStream.class.getName());
 
-    @Nonnull
+    @NonNull
     final BuildInfo buildInfo;
     @Nullable String flowNodeId;
     /**
@@ -44,7 +44,7 @@ final class OtelLogOutputStream extends LineTransformationOutputStream {
      * @param buildInfo
      * @param w3cTraceContext Serializable version of the {@link Context} used to associate log messages with {@link io.opentelemetry.api.trace.Span}s
      */
-    public OtelLogOutputStream(@Nonnull BuildInfo buildInfo, @Nullable String flowNodeId, @Nonnull Map<String, String> w3cTraceContext, @Nonnull LogEmitter logEmitter, @Nonnull Clock clock) {
+    public OtelLogOutputStream(@NonNull BuildInfo buildInfo, @Nullable String flowNodeId, @NonNull Map<String, String> w3cTraceContext, @NonNull LogEmitter logEmitter, @NonNull Clock clock) {
         this.buildInfo = buildInfo;
         this.flowNodeId = flowNodeId;
         this.logEmitter = logEmitter;

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/log/OtelLogSenderBuildListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/log/OtelLogSenderBuildListener.java
@@ -13,9 +13,9 @@ import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.logs.LogEmitter;
 import jenkins.util.JenkinsJVM;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
@@ -53,11 +53,11 @@ abstract class OtelLogSenderBuildListener implements BuildListener {
     @CheckForNull
     transient PrintStream logger;
 
-    public OtelLogSenderBuildListener(@Nonnull BuildInfo buildInfo, @Nonnull Map<String, String> otelConfigProperties, @Nonnull Map<String, String> otelResourceAttributes) {
+    public OtelLogSenderBuildListener(@NonNull BuildInfo buildInfo, @NonNull Map<String, String> otelConfigProperties, @NonNull Map<String, String> otelResourceAttributes) {
         this(buildInfo, null, otelConfigProperties, otelResourceAttributes);
     }
 
-    public OtelLogSenderBuildListener(@Nonnull BuildInfo buildInfo, @Nullable String flowNodeId, @Nonnull Map<String, String> otelConfigProperties, @Nonnull Map<String, String> otelResourceAttributes) {
+    public OtelLogSenderBuildListener(@NonNull BuildInfo buildInfo, @Nullable String flowNodeId, @NonNull Map<String, String> otelConfigProperties, @NonNull Map<String, String> otelResourceAttributes) {
         this.buildInfo = new BuildInfo(buildInfo);
         this.w3cTraceContext = buildInfo.getW3cTraceContext();
         this.flowNodeId = flowNodeId;
@@ -69,7 +69,7 @@ abstract class OtelLogSenderBuildListener implements BuildListener {
         JenkinsJVM.checkJenkinsJVM();
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public synchronized final PrintStream getLogger() {
         if (logger == null) {
@@ -93,11 +93,11 @@ abstract class OtelLogSenderBuildListener implements BuildListener {
 
         private final static Logger logger = Logger.getLogger(OtelLogSenderBuildListenerOnController.class.getName());
 
-        public OtelLogSenderBuildListenerOnController(@Nonnull BuildInfo buildInfo, @Nonnull Map<String, String> otelConfigProperties, @Nonnull Map<String, String> otelResourceAttributes) {
+        public OtelLogSenderBuildListenerOnController(@NonNull BuildInfo buildInfo, @NonNull Map<String, String> otelConfigProperties, @NonNull Map<String, String> otelResourceAttributes) {
             this(buildInfo, null, otelConfigProperties, otelResourceAttributes);
         }
 
-        public OtelLogSenderBuildListenerOnController(@Nonnull BuildInfo buildInfo, @Nullable String flowNodeId, @Nonnull Map<String, String> otelConfigProperties, @Nonnull Map<String, String> otelResourceAttributes) {
+        public OtelLogSenderBuildListenerOnController(@NonNull BuildInfo buildInfo, @Nullable String flowNodeId, @NonNull Map<String, String> otelConfigProperties, @NonNull Map<String, String> otelResourceAttributes) {
             super(buildInfo, flowNodeId, otelConfigProperties, otelResourceAttributes);
             logger.log(Level.FINEST, () -> "new OtelLogSenderBuildListenerOnController()");
             JenkinsJVM.checkJenkinsJVM();
@@ -141,7 +141,7 @@ abstract class OtelLogSenderBuildListener implements BuildListener {
         /**
          * Intended to be exclusively called on the Jenkins Controller by {@link OtelLogSenderBuildListenerOnController#writeReplace()}.
          */
-        private OtelLogSenderBuildListenerOnAgent(@Nonnull BuildInfo buildInfo, @Nullable String flowNodeId, @Nonnull Map<String, String> otelConfigProperties, @Nonnull Map<String, String> otelResourceAttributes) {
+        private OtelLogSenderBuildListenerOnAgent(@NonNull BuildInfo buildInfo, @Nullable String flowNodeId, @NonNull Map<String, String> otelConfigProperties, @NonNull Map<String, String> otelResourceAttributes) {
             super(buildInfo, flowNodeId, otelConfigProperties, otelResourceAttributes);
             logger.log(Level.FINEST, () -> "new OtelLogSenderBuildListenerOnAgent()");
             JenkinsJVM.checkJenkinsJVM();

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/log/OtelLogStorage.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/log/OtelLogStorage.java
@@ -18,7 +18,7 @@ import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.log.BrokenLogStorage;
 import org.jenkinsci.plugins.workflow.log.LogStorage;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
@@ -41,12 +41,12 @@ class OtelLogStorage implements LogStorage {
     final BuildInfo buildInfo;
     final Tracer tracer;
 
-    public OtelLogStorage(@Nonnull BuildInfo buildInfo, @Nonnull  Tracer tracer) {
+    public OtelLogStorage(@NonNull BuildInfo buildInfo, @NonNull  Tracer tracer) {
         this.buildInfo = buildInfo;
         this.tracer = tracer;
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public BuildListener overallListener() {
         OpenTelemetryConfiguration otelConfiguration = JenkinsOpenTelemetryPluginConfiguration.get().toOpenTelemetryConfiguration();
@@ -56,9 +56,9 @@ class OtelLogStorage implements LogStorage {
         return new OtelLogSenderBuildListener.OtelLogSenderBuildListenerOnController(buildInfo, otelConfigurationProperties, otelResourceAttributes);
     }
 
-    @Nonnull
+    @NonNull
     @Override
-    public TaskListener nodeListener(@Nonnull FlowNode flowNode) {
+    public TaskListener nodeListener(@NonNull FlowNode flowNode) {
         OpenTelemetryConfiguration otelConfiguration = JenkinsOpenTelemetryPluginConfiguration.get().toOpenTelemetryConfiguration();
         Map<String, String> otelConfigurationProperties = otelConfiguration.toOpenTelemetryProperties();
         Map<String, String> otelResourceAttributes = new HashMap<>();
@@ -77,9 +77,9 @@ class OtelLogStorage implements LogStorage {
      *       |- hudson.model.Run#writeLogTo(long, org.apache.commons.jelly.XMLOutput)
      *          |- workflowRun/console.jelly
      */
-    @Nonnull
+    @NonNull
     @Override
-    public AnnotatedLargeText<FlowExecutionOwner.Executable> overallLog(@Nonnull FlowExecutionOwner.Executable build, boolean complete) {
+    public AnnotatedLargeText<FlowExecutionOwner.Executable> overallLog(@NonNull FlowExecutionOwner.Executable build, boolean complete) {
         Span span = tracer.spanBuilder("OtelLogStorage.overallLog")
             .setAttribute(JenkinsOtelSemanticAttributes.CI_PIPELINE_ID, buildInfo.getJobFullName())
             .setAttribute(JenkinsOtelSemanticAttributes.CI_PIPELINE_RUN_NUMBER, (long) buildInfo.runNumber)
@@ -98,9 +98,9 @@ class OtelLogStorage implements LogStorage {
         }
     }
 
-    @Nonnull
+    @NonNull
     @Override
-    public AnnotatedLargeText<FlowNode> stepLog(@Nonnull FlowNode flowNode, boolean complete) {
+    public AnnotatedLargeText<FlowNode> stepLog(@NonNull FlowNode flowNode, boolean complete) {
         Span span = tracer.spanBuilder("OtelLogStorage.stepLog")
             .setAttribute(JenkinsOtelSemanticAttributes.CI_PIPELINE_ID, buildInfo.getJobFullName())
             .setAttribute(JenkinsOtelSemanticAttributes.CI_PIPELINE_RUN_NUMBER, (long) buildInfo.runNumber)
@@ -166,7 +166,7 @@ class OtelLogStorage implements LogStorage {
             '}';
     }
 
-    @Nonnull
+    @NonNull
     public LogStorageRetriever getLogStorageRetriever() {
         return JenkinsOpenTelemetryPluginConfiguration.get().getLogStorageRetriever();
     }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/log/OtelLogStorageFactory.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/log/OtelLogStorageFactory.java
@@ -20,8 +20,8 @@ import org.jenkinsci.plugins.workflow.log.BrokenLogStorage;
 import org.jenkinsci.plugins.workflow.log.LogStorage;
 import org.jenkinsci.plugins.workflow.log.LogStorageFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -55,7 +55,7 @@ public final class OtelLogStorageFactory implements LogStorageFactory {
 
     @Nullable
     @Override
-    public LogStorage forBuild(@Nonnull final FlowExecutionOwner owner) {
+    public LogStorage forBuild(@NonNull final FlowExecutionOwner owner) {
         if (!getOpenTelemetrySdkProvider().isOtelLogsEnabled()) {
             logger.log(Level.FINE, () -> "forBuild(): null");
             return null;

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/log/util/StreamingByteBuffer.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/log/util/StreamingByteBuffer.java
@@ -11,7 +11,7 @@ import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.Scope;
 import org.kohsuke.stapler.framework.io.ByteBuffer;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -21,10 +21,10 @@ import java.util.logging.Logger;
 public class StreamingByteBuffer extends ByteBuffer {
     final static Logger logger = Logger.getLogger(StreamingByteBuffer.class.getName());
 
-    @Nonnull
+    @NonNull
     private final Tracer tracer;
 
-    @Nonnull
+    @NonNull
     final InputStream in;
 
     public StreamingByteBuffer(InputStream in, Tracer tracer) {
@@ -75,7 +75,7 @@ public class StreamingByteBuffer extends ByteBuffer {
     }
 
     @Override
-    public void write(@Nonnull byte[] b) throws IOException {
+    public void write(@NonNull byte[] b) throws IOException {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/log/util/StreamingInputStream.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/log/util/StreamingInputStream.java
@@ -10,7 +10,7 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.Scope;
 
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/opentelemetry/OtelContextAwareAbstractRunListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/opentelemetry/OtelContextAwareAbstractRunListener.java
@@ -17,7 +17,7 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import java.io.IOException;
@@ -37,7 +37,7 @@ public abstract class OtelContextAwareAbstractRunListener extends RunListener<Ru
     private ConfigProperties config;
 
     @Inject
-    public final void setOpenTelemetryTracerService(@Nonnull OtelTraceService otelTraceService, @Nonnull OpenTelemetrySdkProvider openTelemetrySdkProvider) {
+    public final void setOpenTelemetryTracerService(@NonNull OtelTraceService otelTraceService, @NonNull OpenTelemetrySdkProvider openTelemetrySdkProvider) {
         this.otelTraceService = otelTraceService;
         this.tracer = this.otelTraceService.getTracer();
         this.meter = openTelemetrySdkProvider.getMeter();
@@ -122,7 +122,7 @@ public abstract class OtelContextAwareAbstractRunListener extends RunListener<Ru
         return meter;
     }
 
-    @Nonnull
+    @NonNull
     protected ConfigProperties getConfig() {
         return config;
     }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/opentelemetry/context/BuildStepContextKey.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/opentelemetry/context/BuildStepContextKey.java
@@ -8,7 +8,7 @@ package io.jenkins.plugins.opentelemetry.job.opentelemetry.context;
 import hudson.tasks.BuildStep;
 import io.opentelemetry.context.ContextKey;
 
-import javax.annotation.concurrent.Immutable;
+import net.jcip.annotations.Immutable;
 
 /**
  * See {@code io.opentelemetry.api.trace.SpanContextKey}

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/opentelemetry/context/FlowNodeContextKey.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/opentelemetry/context/FlowNodeContextKey.java
@@ -8,7 +8,7 @@ package io.jenkins.plugins.opentelemetry.job.opentelemetry.context;
 import io.opentelemetry.context.ContextKey;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 
-import javax.annotation.concurrent.Immutable;
+import net.jcip.annotations.Immutable;
 
 /**
  * See {@code io.opentelemetry.api.trace.SpanContextKey}

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/opentelemetry/context/RunContextKey.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/opentelemetry/context/RunContextKey.java
@@ -8,7 +8,7 @@ package io.jenkins.plugins.opentelemetry.job.opentelemetry.context;
 import hudson.model.Run;
 import io.opentelemetry.context.ContextKey;
 
-import javax.annotation.concurrent.Immutable;
+import net.jcip.annotations.Immutable;
 
 /**
  * See {@code io.opentelemetry.api.trace.SpanContextKey}

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/runhandler/DefaultRunHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/runhandler/DefaultRunHandler.java
@@ -15,7 +15,7 @@ import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
 import jenkins.scm.api.mixin.ChangeRequestSCMHead;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -33,13 +33,13 @@ public class DefaultRunHandler implements RunHandler {
         "-" + ChangeRequestCheckoutStrategy.MERGE.name().toLowerCase(Locale.ENGLISH)));
 
     @Override
-    public boolean canCreateSpanBuilder(@Nonnull Run run) {
+    public boolean canCreateSpanBuilder(@NonNull Run run) {
         return true;
     }
 
-    @Nonnull
+    @NonNull
     @Override
-    public SpanBuilder createSpanBuilder(@Nonnull Run run, @Nonnull Tracer tracer) {
+    public SpanBuilder createSpanBuilder(@NonNull Run run, @NonNull Tracer tracer) {
         SCMHead head = SCMHead.HeadByItem.findHead(run.getParent());
         String spanName;
         if (head instanceof ChangeRequestSCMHead) {
@@ -53,8 +53,8 @@ public class DefaultRunHandler implements RunHandler {
     }
 
     @VisibleForTesting
-    @Nonnull
-    protected String getChangeRequestRootSpanName(@Nonnull String jobFullName) {
+    @NonNull
+    protected String getChangeRequestRootSpanName(@NonNull String jobFullName) {
         // org.jenkinsci.plugins.github_branch_source.PullRequestGHEventSubscriber
         // com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource
         // jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/runhandler/JobDslRunHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/runhandler/JobDslRunHandler.java
@@ -20,7 +20,7 @@ import javaposse.jobdsl.plugin.actions.SeedJobAction;
 import javaposse.jobdsl.plugin.actions.SeedJobTransientActionFactory;
 import jenkins.YesNoMaybe;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collection;
 
 
@@ -37,16 +37,16 @@ public class JobDslRunHandler implements RunHandler {
     }
 
     @Override
-    public boolean canCreateSpanBuilder(@Nonnull Run run) {
+    public boolean canCreateSpanBuilder(@NonNull Run run) {
         Job job = run.getParent();
         // perf optimization: directly lookup up in the SeedJobTransientActionFactory over `job.getAction(SeedJobAction.class)`
         Collection<? extends Action> actions = seedJobTransientActionFactory.createFor(job);
         return !actions.isEmpty();
     }
 
-    @Nonnull
+    @NonNull
     @Override
-    public SpanBuilder createSpanBuilder(@Nonnull Run run, @Nonnull Tracer tracer) {
+    public SpanBuilder createSpanBuilder(@NonNull Run run, @NonNull Tracer tracer) {
         Job job = run.getParent();
         // perf optimization: directly lookup up in the SeedJobTransientActionFactory over `job.getAction(SeedJobAction.class)`
         Collection<? extends Action> actions = seedJobTransientActionFactory.createFor(job);
@@ -90,7 +90,7 @@ public class JobDslRunHandler implements RunHandler {
     }
 
     @Inject
-    public void setSeedJobTransientActionFactory(@Nonnull SeedJobTransientActionFactory seedJobTransientActionFactory) {
+    public void setSeedJobTransientActionFactory(@NonNull SeedJobTransientActionFactory seedJobTransientActionFactory) {
         this.seedJobTransientActionFactory = seedJobTransientActionFactory;
     }
 }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/runhandler/MatrixRunHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/runhandler/MatrixRunHandler.java
@@ -18,7 +18,7 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import jenkins.YesNoMaybe;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,13 +33,13 @@ public class MatrixRunHandler implements RunHandler {
     }
 
     @Override
-    public boolean canCreateSpanBuilder(@Nonnull Run run) {
+    public boolean canCreateSpanBuilder(@NonNull Run run) {
         return run instanceof MatrixRun || run instanceof MatrixBuild;
     }
 
-    @Nonnull
+    @NonNull
     @Override
-    public SpanBuilder createSpanBuilder(@Nonnull Run run, @Nonnull Tracer tracer) {
+    public SpanBuilder createSpanBuilder(@NonNull Run run, @NonNull Tracer tracer) {
         if (run instanceof MatrixRun) {
             MatrixRun matrixRun = (MatrixRun) run;
             MatrixConfiguration matrixConfiguration = matrixRun.getParent();

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/runhandler/RunHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/runhandler/RunHandler.java
@@ -10,16 +10,16 @@ import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 public interface RunHandler extends Comparable<RunHandler> {
 
     default void configure(ConfigProperties config){};
 
-    boolean canCreateSpanBuilder(@Nonnull Run run);
+    boolean canCreateSpanBuilder(@NonNull Run run);
 
-    @Nonnull
-    SpanBuilder createSpanBuilder(@Nonnull Run run, @Nonnull Tracer tracer);
+    @NonNull
+    SpanBuilder createSpanBuilder(@NonNull Run run, @NonNull Tracer tracer);
 
     /**
      * @return the ordinal of this handler to execute run handlers in predictable order. The smallest ordinal is executed first.

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/step/AbstractGitStepHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/step/AbstractGitStepHandler.java
@@ -17,15 +17,15 @@ import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import org.eclipse.jgit.transport.URIish;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.net.URISyntaxException;
 import java.util.logging.Logger;
 
 public abstract class AbstractGitStepHandler implements StepHandler {
     private final static Logger LOGGER = Logger.getLogger(AbstractGitStepHandler.class.getName());
 
-    public String searchGitUserName(@Nullable String credentialsId, @Nonnull WorkflowRun run) {
+    public String searchGitUserName(@Nullable String credentialsId, @NonNull WorkflowRun run) {
         if (credentialsId == null) {
             return null;
         }
@@ -47,8 +47,8 @@ public abstract class AbstractGitStepHandler implements StepHandler {
      * https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols
      */
     @VisibleForTesting
-    @Nonnull
-    public SpanBuilder createSpanBuilder(@Nonnull String gitUrl, @Nullable String gitBranch, @Nullable String credentialsId, @Nonnull String stepFunctionName, @Nonnull Tracer tracer, @Nonnull WorkflowRun run) {
+    @NonNull
+    public SpanBuilder createSpanBuilder(@NonNull String gitUrl, @Nullable String gitBranch, @Nullable String credentialsId, @NonNull String stepFunctionName, @NonNull Tracer tracer, @NonNull WorkflowRun run) {
         String gitUserName = searchGitUserName(credentialsId, run);
         return createSpanBuilderFromGitDetails(gitUrl, gitBranch, gitUserName, stepFunctionName, tracer);
     }
@@ -57,7 +57,7 @@ public abstract class AbstractGitStepHandler implements StepHandler {
      * Visible for testing. User {@link #createSpanBuilder(String, String, String, String, Tracer, WorkflowRun)} instead of this method
      */
     @VisibleForTesting
-    protected SpanBuilder createSpanBuilderFromGitDetails(@Nullable String gitUrl, @Nullable String gitBranch, @Nullable String gitUserName, @Nonnull String stepFunctionName, @Nonnull Tracer tracer) {
+    protected SpanBuilder createSpanBuilderFromGitDetails(@Nullable String gitUrl, @Nullable String gitBranch, @Nullable String gitUserName, @NonNull String stepFunctionName, @NonNull Tracer tracer) {
         URIish gitUri;
         try {
             gitUri = new URIish(gitUrl);
@@ -144,8 +144,8 @@ public abstract class AbstractGitStepHandler implements StepHandler {
      * @param gitUri to sanitize
      * @return sanitized url
      */
-    @Nonnull
-    protected String sanitizeUrl(@Nonnull URIish gitUri) {
+    @NonNull
+    protected String sanitizeUrl(@NonNull URIish gitUri) {
         String normalizedUrl = gitUri.getScheme() + "://";
         if (gitUri.getHost() != null) {
             normalizedUrl += gitUri.getHost();

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/step/BuildTriggerStepHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/step/BuildTriggerStepHandler.java
@@ -19,7 +19,7 @@ import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.support.steps.build.BuildTriggerStep;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -30,13 +30,13 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class BuildTriggerStepHandler implements StepHandler {
     private final static Logger LOGGER = Logger.getLogger(BuildTriggerStepHandler.class.getName());
     @Override
-    public boolean canCreateSpanBuilder(@Nonnull FlowNode flowNode, @Nonnull WorkflowRun run) {
+    public boolean canCreateSpanBuilder(@NonNull FlowNode flowNode, @NonNull WorkflowRun run) {
         return flowNode instanceof StepAtomNode && ((StepAtomNode) flowNode).getDescriptor() instanceof BuildTriggerStep.DescriptorImpl;
     }
 
-    @Nonnull
+    @NonNull
     @Override
-    public SpanBuilder createSpanBuilder(@Nonnull FlowNode node, @Nonnull WorkflowRun run, @Nonnull Tracer tracer) {
+    public SpanBuilder createSpanBuilder(@NonNull FlowNode node, @NonNull WorkflowRun run, @NonNull Tracer tracer) {
         Map<String, Object> arguments = ArgumentsAction.getFilteredArguments(node);
         String job = checkNotNull(arguments.get("job")).toString();
         SpanBuilder spanBuilder = tracer.spanBuilder("build: " + job);

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/step/DefaultStepHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/step/DefaultStepHandler.java
@@ -11,18 +11,18 @@ import io.opentelemetry.api.trace.Tracer;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 @Extension
 public class DefaultStepHandler implements StepHandler {
     @Override
-    public boolean canCreateSpanBuilder(@Nonnull FlowNode flowNode, @Nonnull WorkflowRun run) {
+    public boolean canCreateSpanBuilder(@NonNull FlowNode flowNode, @NonNull WorkflowRun run) {
         return true;
     }
 
-    @Nonnull
+    @NonNull
     @Override
-    public SpanBuilder createSpanBuilder(@Nonnull FlowNode node, @Nonnull WorkflowRun run, @Nonnull Tracer tracer) {
+    public SpanBuilder createSpanBuilder(@NonNull FlowNode node, @NonNull WorkflowRun run, @NonNull Tracer tracer) {
         return tracer.spanBuilder(node.getDisplayFunctionName());
     }
 

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/step/DurableTaskHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/step/DurableTaskHandler.java
@@ -16,7 +16,7 @@ import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
 import java.util.Objects;
 
@@ -26,13 +26,13 @@ import java.util.Objects;
 @Extension(optional = true, dynamicLoadable = YesNoMaybe.YES)
 public class  DurableTaskHandler implements StepHandler {
     @Override
-    public boolean canCreateSpanBuilder(@Nonnull FlowNode flowNode, @Nonnull WorkflowRun run) {
+    public boolean canCreateSpanBuilder(@NonNull FlowNode flowNode, @NonNull WorkflowRun run) {
         return flowNode instanceof StepAtomNode && ((StepAtomNode) flowNode).getDescriptor() instanceof DurableTaskStep.DurableTaskStepDescriptor;
     }
 
-    @Nonnull
+    @NonNull
     @Override
-    public SpanBuilder createSpanBuilder(@Nonnull FlowNode node, @Nonnull WorkflowRun run, @Nonnull Tracer tracer) {
+    public SpanBuilder createSpanBuilder(@NonNull FlowNode node, @NonNull WorkflowRun run, @NonNull Tracer tracer) {
         final Map<String, Object> arguments = ArgumentsAction.getFilteredArguments(node);
         final String displayFunctionName = node.getDisplayFunctionName();
         final String label = Objects.toString(arguments.get("label"), null);

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/step/GitCheckoutStepHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/step/GitCheckoutStepHandler.java
@@ -26,7 +26,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.multibranch.BranchJobProperty;
 import org.jenkinsci.plugins.workflow.steps.scm.GenericSCMStep;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -40,7 +40,7 @@ public class GitCheckoutStepHandler extends AbstractGitStepHandler {
     private final static Logger LOGGER = Logger.getLogger(GitCheckoutStepHandler.class.getName());
 
     @Override
-    public boolean canCreateSpanBuilder(@Nonnull FlowNode flowNode, @Nonnull WorkflowRun run) {
+    public boolean canCreateSpanBuilder(@NonNull FlowNode flowNode, @NonNull WorkflowRun run) {
         if (!(flowNode instanceof StepAtomNode)) {
             return false;
         }
@@ -74,9 +74,9 @@ public class GitCheckoutStepHandler extends AbstractGitStepHandler {
         return false;
     }
 
-    @Nonnull
+    @NonNull
     @Override
-    public SpanBuilder createSpanBuilder(@Nonnull FlowNode node, @Nonnull WorkflowRun run, @Nonnull Tracer tracer) {
+    public SpanBuilder createSpanBuilder(@NonNull FlowNode node, @NonNull WorkflowRun run, @NonNull Tracer tracer) {
         final Map<String, ?> rootArguments = ArgumentsAction.getFilteredArguments(node);
         final String stepFunctionName = node.getDisplayFunctionName();
         LOGGER.log(Level.FINE, () -> stepFunctionName + " - begin " + rootArguments);
@@ -152,7 +152,7 @@ public class GitCheckoutStepHandler extends AbstractGitStepHandler {
         }
     }
 
-    private SpanBuilder addCloneAttributes(@Nonnull SpanBuilder spanBuilder, @Nonnull boolean shallow, @Nonnull int depth) {
+    private SpanBuilder addCloneAttributes(@NonNull SpanBuilder spanBuilder, @NonNull boolean shallow, @NonNull int depth) {
         return spanBuilder
             .setAttribute(JenkinsOtelSemanticAttributes.GIT_CLONE_DEPTH, (long) depth)
             .setAttribute(JenkinsOtelSemanticAttributes.GIT_CLONE_SHALLOW, shallow);

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/step/GitStepHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/step/GitStepHandler.java
@@ -15,7 +15,7 @@ import org.jenkinsci.plugins.workflow.cps.nodes.StepAtomNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
 import java.util.Objects;
 import java.util.logging.Logger;
@@ -31,13 +31,13 @@ public class GitStepHandler extends AbstractGitStepHandler {
     private final static Logger LOGGER = Logger.getLogger(GitStepHandler.class.getName());
 
     @Override
-    public boolean canCreateSpanBuilder(@Nonnull FlowNode flowNode, @Nonnull WorkflowRun run) {
+    public boolean canCreateSpanBuilder(@NonNull FlowNode flowNode, @NonNull WorkflowRun run) {
         return flowNode instanceof StepAtomNode && ((StepAtomNode) flowNode).getDescriptor() instanceof GitStep.DescriptorImpl;
     }
 
-    @Nonnull
+    @NonNull
     @Override
-    public SpanBuilder createSpanBuilder(@Nonnull FlowNode node, @Nonnull WorkflowRun run, @Nonnull Tracer tracer) {
+    public SpanBuilder createSpanBuilder(@NonNull FlowNode node, @NonNull WorkflowRun run, @NonNull Tracer tracer) {
         final Map<String, Object> arguments = ArgumentsAction.getFilteredArguments(node);
         final String gitUrl = checkNotNull(arguments.get("url")).toString();
         final String gitBranch = Objects.toString(arguments.get("branch"), null);

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/step/StepHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/step/StepHandler.java
@@ -11,13 +11,13 @@ import org.jenkinsci.plugins.workflow.cps.nodes.StepAtomNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 public interface StepHandler extends Comparable<StepHandler> {
-    boolean canCreateSpanBuilder(@Nonnull FlowNode flowNode, @Nonnull WorkflowRun run);
+    boolean canCreateSpanBuilder(@NonNull FlowNode flowNode, @NonNull WorkflowRun run);
 
-    @Nonnull
-    SpanBuilder createSpanBuilder(@Nonnull FlowNode node, @Nonnull WorkflowRun run, @Nonnull Tracer tracer);
+    @NonNull
+    SpanBuilder createSpanBuilder(@NonNull FlowNode node, @NonNull WorkflowRun run, @NonNull Tracer tracer);
 
     /**
      * @return the ordinal of this handler to execute step handlers in predictable order. The smallest ordinal is executed first.
@@ -41,5 +41,5 @@ public interface StepHandler extends Comparable<StepHandler> {
      *
      * The created {@link io.opentelemetry.api.trace.Span} can be retrieved using {@link io.opentelemetry.api.trace.Span#current()}
      */
-    default void afterSpanCreated(@Nonnull StepAtomNode node, @Nonnull WorkflowRun run) {}
+    default void afterSpanCreated(@NonNull StepAtomNode node, @NonNull WorkflowRun run) {}
 }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/opentelemetry/autoconfigure/ConfigPropertiesUtils.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/opentelemetry/autoconfigure/ConfigPropertiesUtils.java
@@ -7,7 +7,7 @@ package io.jenkins.plugins.opentelemetry.opentelemetry.autoconfigure;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/io/jenkins/plugins/opentelemetry/queue/MonitoringQueueListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/queue/MonitoringQueueListener.java
@@ -14,7 +14,7 @@ import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
 import jenkins.model.Jenkins;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -107,7 +107,7 @@ public class MonitoringQueueListener extends QueueListener {
      * Jenkins doesn't support {@link com.google.inject.Provides} so we manually wire dependencies :-(
      */
     @Inject
-    public void setMeter(@Nonnull OpenTelemetrySdkProvider openTelemetrySdkProvider) {
+    public void setMeter(@NonNull OpenTelemetrySdkProvider openTelemetrySdkProvider) {
         this.meter = openTelemetrySdkProvider.getMeter();
     }
 }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/security/AuditingSecurityListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/security/AuditingSecurityListener.java
@@ -13,7 +13,7 @@ import io.opentelemetry.api.metrics.Meter;
 import jenkins.security.SecurityListener;
 import org.acegisecurity.userdetails.UserDetails;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.inject.Inject;
 
 @Extension
@@ -77,7 +77,7 @@ public class AuditingSecurityListener extends SecurityListener  {
     }
 
     @Inject
-    public void setJenkinsOtelPlugin(@Nonnull OpenTelemetrySdkProvider openTelemetrySdkProvider) {
+    public void setJenkinsOtelPlugin(@NonNull OpenTelemetrySdkProvider openTelemetrySdkProvider) {
         this.meter = openTelemetrySdkProvider.getMeter();
         initialise();
     }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/servlet/OpenTelemetryServletFilter.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/servlet/OpenTelemetryServletFilter.java
@@ -13,7 +13,7 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import org.apache.commons.lang.StringUtils;
 
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;

--- a/src/test/java/io/jenkins/plugins/opentelemetry/BaseIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/BaseIntegrationTest.java
@@ -38,7 +38,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.jvnet.hudson.test.BuildWatcher;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -232,15 +232,15 @@ public class BaseIntegrationTest {
     }
 
     // https://github.com/jenkinsci/workflow-multibranch-plugin/blob/master/src/test/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectTest.java
-    @Nonnull
-    public static WorkflowJob scheduleAndFindBranchProject(@Nonnull WorkflowMultiBranchProject mp, @Nonnull String name) throws Exception {
+    @NonNull
+    public static WorkflowJob scheduleAndFindBranchProject(@NonNull WorkflowMultiBranchProject mp, @NonNull String name) throws Exception {
         mp.scheduleBuild2(0).getFuture().get();
         return findBranchProject(mp, name);
     }
 
     // https://github.com/jenkinsci/workflow-multibranch-plugin/blob/master/src/test/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectTest.java
-    public static @Nonnull
-    WorkflowJob findBranchProject(@Nonnull WorkflowMultiBranchProject mp, @Nonnull String name) throws Exception {
+    public static @NonNull
+    WorkflowJob findBranchProject(@NonNull WorkflowMultiBranchProject mp, @NonNull String name) throws Exception {
         WorkflowJob p = mp.getItem(name);
         showIndexing(mp);
         if (p == null) {
@@ -250,7 +250,7 @@ public class BaseIntegrationTest {
     }
 
     // https://github.com/jenkinsci/workflow-multibranch-plugin/blob/master/src/test/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectTest.java
-    static void showIndexing(@Nonnull WorkflowMultiBranchProject mp) throws Exception {
+    static void showIndexing(@NonNull WorkflowMultiBranchProject mp) throws Exception {
         FolderComputation<?> indexing = mp.getIndexing();
         System.out.println("---%<--- " + indexing.getUrl());
         indexing.writeWholeLogTo(System.out);

--- a/src/test/java/io/jenkins/plugins/opentelemetry/backend/elastic/ElasticsearchLogsSearchIteratorIT.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/backend/elastic/ElasticsearchLogsSearchIteratorIT.java
@@ -20,7 +20,7 @@ import org.elasticsearch.client.RestClient;
 import org.junit.Assert;
 import org.junit.Test;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
@@ -46,7 +46,7 @@ public class ElasticsearchLogsSearchIteratorIT {
         System.out.println("context : " + elasticsearchLogsSearchIterator.context);
     }
 
-    @Nonnull
+    @NonNull
     private ElasticsearchLogsSearchIterator getElasticsearchLogsSearchIterator() throws IOException {
         InputStream envAsStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(".env");
         Assert.assertNotNull(".env file not found in classpath", envAsStream);

--- a/src/test/java/io/jenkins/plugins/opentelemetry/job/step/GitStepHandlerTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/job/step/GitStepHandlerTest.java
@@ -15,8 +15,8 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.Map;
 
 public class GitStepHandlerTest {
@@ -143,7 +143,7 @@ public class GitStepHandlerTest {
         MatcherAssert.assertThat(attributes.get(JenkinsOtelSemanticAttributes.GIT_REPOSITORY), Matchers.equalTo("c:\\srv/git/project"));
     }
 
-    private SpanBuilderMock testGithubUrl(@Nonnull String githubUrl, @Nullable String gitBranch, @Nullable String gitUsername) throws Exception {
+    private SpanBuilderMock testGithubUrl(@NonNull String githubUrl, @Nullable String gitBranch, @Nullable String gitUsername) throws Exception {
 
         GitStepHandler handler = new GitStepHandler();
 

--- a/src/test/java/io/opentelemetry/sdk/testing/exporter/InMemoryMetricExporterUtils.java
+++ b/src/test/java/io/opentelemetry/sdk/testing/exporter/InMemoryMetricExporterUtils.java
@@ -7,7 +7,7 @@ package io.opentelemetry.sdk.testing.exporter;
 
 import io.opentelemetry.sdk.metrics.data.MetricData;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -18,8 +18,8 @@ public class InMemoryMetricExporterUtils {
      *
      * @see InMemoryMetricExporter#getFinishedMetricItems()
      */
-    @Nonnull
-    public static Map<String, MetricData> getLastExportedMetricByMetricName(@Nonnull List<MetricData> metrics){
+    @NonNull
+    public static Map<String, MetricData> getLastExportedMetricByMetricName(@NonNull List<MetricData> metrics){
         Map<String, MetricData> result = new HashMap<>();
         for(MetricData metricData: metrics) {
             result.put(metricData.getName(), metricData);

--- a/src/test/java/io/opentelemetry/sdk/testing/trace/SpanBuilderMock.java
+++ b/src/test/java/io/opentelemetry/sdk/testing/trace/SpanBuilderMock.java
@@ -11,7 +11,7 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.*;
 import io.opentelemetry.context.Context;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
@@ -52,7 +52,7 @@ public class SpanBuilderMock implements SpanBuilder {
     }
 
     @Override
-    public SpanBuilder setAttribute(String key, @Nonnull String value) {
+    public SpanBuilder setAttribute(String key, @NonNull String value) {
         this.attributes.put(AttributeKey.stringKey(key), value);
         delegate.setAttribute(key, value);
         return this;
@@ -80,7 +80,7 @@ public class SpanBuilderMock implements SpanBuilder {
     }
 
     @Override
-    public <T> SpanBuilder setAttribute(AttributeKey<T> key, @Nonnull T value) {
+    public <T> SpanBuilder setAttribute(AttributeKey<T> key, @NonNull T value) {
         this.attributes.put(key, value);
         delegate.setAttribute(key, value);
         return this;
@@ -109,7 +109,7 @@ public class SpanBuilderMock implements SpanBuilder {
         return delegate.startSpan();
     }
 
-    @Nonnull
+    @NonNull
     public Map<AttributeKey, Object> getAttributes() {
         return attributes;
     }


### PR DESCRIPTION
Bumps the core baseline to 2.321 (2021-11-16), which has updated version of Guava and Guice, which removes the need for `<maskClasses>com.google.common.</maskClasses>`. This simplifies this plugin's build and deployment. Note that 2.321 is a weekly (not LTS) release, so you may want to wait to merge this until the Guava update is available in an LTS release.