### PR TITLE
Better readability of failures in parallel pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ In addition, if the backends were configured then there will be an environment v
 
 #### Attributes
 
-##### Pipeline run root span
+##### Pipeline, freestyle, and matrix project build spans
 
 | Attribute                        | Description  | Type |
 |----------------------------------|--------------|------|
@@ -138,7 +138,14 @@ In addition, if the backends were configured then there will be an environment v
 | ci.pipeline.parameter.name       | Name of the parameters | String[] |
 | ci.pipeline.parameter.value      | Value of the parameters. "Sensitive" values are redacted | String[] |
 
-##### Spans
+##### Pipeline step spans  
+
+| Status Code | Status Description | Description |
+|-------------|--------------------|-------------|
+| OK | | for step and build success |
+| UNSET | Machine readable status like `FlowInterruptedException:FailFastCause:Failed in branch failingBranch` | For interrupted steps of type fail fast parallel pipeline interruption, pipeline build superseded by a newer build, or pipeline build cancelled by user, the span status is set to `UNSET`  rather than `ERROR` for readability |
+| ERROR | Machine readable status like `FlowInterruptedException:ExceededTimeout:Timeout has been exceeded` | For other causes of step failure |
+
 
 | Attribute                        | Description  | Type |
 |----------------------------------|--------------|------|
@@ -148,6 +155,7 @@ In addition, if the backends were configured then there will be an environment v
 | jenkins.pipeline.step.plugin.name | Jenkins plugin for that particular step | String |
 | jenkins.pipeline.step.plugin.version| Jenkins plugin version | String |
 | jenkins.pipeline.step.agent.label | Labels attached to the agent | String |
+| jenkins.pipeline.step.interruption.causes | List of machine readable causes of the interruption of the step like `FailFastCause:Failed in branch failingBranch`. <p/>Common causes of interruption:  `CanceledCause: Superseded by my-pipeline#123`, `ExceededTimeout: Timeout has been exceeded`, `FailFastCause:Failed in branch the-failing-branch`, `UserInterruption: Aborted by a-user` | String[] |
 | git.branch                       | Git branch name | String |
 | git.repository                   | Git repository | String |
 | git.username                     | Git user | String |

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringRunListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringRunListener.java
@@ -327,13 +327,13 @@ public class MonitoringRunListener extends OtelContextAwareAbstractRunListener {
                 parentSpan.setAttribute(JenkinsOtelSemanticAttributes.CI_PIPELINE_RUN_RESULT, Objects.toString(runResult, null));
 
                 if (Result.SUCCESS.equals(runResult)) {
-                    parentSpan.setStatus(StatusCode.OK);
+                    parentSpan.setStatus(StatusCode.OK, runResult.toString());
                 } else if (Result.FAILURE.equals(runResult) || Result.UNSTABLE.equals(runResult)){
                     parentSpan.setAttribute(SemanticAttributes.EXCEPTION_TYPE, "PIPELINE_" + runResult);
                     parentSpan.setAttribute(SemanticAttributes.EXCEPTION_MESSAGE, "PIPELINE_" + runResult);
-                    parentSpan.setStatus(StatusCode.ERROR);
+                    parentSpan.setStatus(StatusCode.ERROR, runResult.toString());
                 } else if (Result.ABORTED.equals(runResult) || Result.NOT_BUILT.equals(runResult)) {
-                    parentSpan.setStatus(StatusCode.UNSET);
+                    parentSpan.setStatus(StatusCode.UNSET, runResult.toString());
                 }
             }
             // NODE

--- a/src/main/java/io/jenkins/plugins/opentelemetry/semconv/JenkinsOtelSemanticAttributes.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/semconv/JenkinsOtelSemanticAttributes.java
@@ -85,6 +85,8 @@ public final class JenkinsOtelSemanticAttributes {
 
     public static final AttributeKey<String>        JENKINS_STEP_AGENT_LABEL = AttributeKey.stringKey("jenkins.pipeline.step.agent.label");
 
+    public static final AttributeKey<List<String>>  JENKINS_STEP_INTERRUPTION_CAUSES = AttributeKey.stringArrayKey("jenkins.pipeline.step.interruption.causes");
+
     public static final String JENKINS = "jenkins";
 
     /**


### PR DESCRIPTION
Use spanStatus "unset" rather than "ko" when interruption cause is parallel fail fast.

Fix:
* https://github.com/jenkinsci/opentelemetry-plugin/issues/281

![image](https://user-images.githubusercontent.com/459691/147890759-f6c6fef5-65ad-4588-9e6e-8847017bcbe8.png)

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->


```groovy
node() {
    stage('ze-parallel-stage') {
        parallel failingBranch: {
            error 'the failure'
        }, parallelBranch1: {
             sleep 5
        } ,parallelBranch2: {
             sleep 5
        } ,parallelBranch3: {
             sleep 5
        }, failFast:true
    }
}
```

# TODO

* Unit test
* Document added attributes