### PR TITLE
Use the Jenkins okhttp-api plugin as a dependency to pull OKHTTP preventing version conflicts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,13 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk-extension-aws</artifactId>
+            <exclusions>
+                <exclusion>
+                    <!-- we get okhttp from io.jenkins.plugins:okhttp-api -->
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
@@ -147,6 +154,18 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-otlp-http-metrics</artifactId>
+            <exclusions>
+                <exclusion>
+                    <!-- we get okhttp from io.jenkins.plugins:okhttp-api -->
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- we get okhttp from io.jenkins.plugins:okhttp-api -->
+                    <groupId>com.squareup.okio</groupId>
+                    <artifactId>okio</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
@@ -155,6 +174,18 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-otlp-http-trace</artifactId>
+            <exclusions>
+                <exclusion>
+                    <!-- we get okhttp from io.jenkins.plugins:okhttp-api -->
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- we get okhttp from io.jenkins.plugins:okhttp-api -->
+                    <groupId>com.squareup.okio</groupId>
+                    <artifactId>okio</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
@@ -166,6 +197,11 @@
             <artifactId>simpleclient_httpserver</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>okhttp-api</artifactId>
+            <version>4.9.3-105.vb96869f8ac3a</version>
+        </dependency>
         <dependency> <!-- see maskClasses config -->
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>


### PR DESCRIPTION
Use the Jenkins okhttp-api plugin as a dependency to pull OKHTTP preventing version conflicts


<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
