### PR TITLE
Add support for progressive rendering of logs stored in Elasticsearch while builds are in progress

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/elastic/ElasticsearchLogStorageRetriever.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/elastic/ElasticsearchLogStorageRetriever.java
@@ -136,7 +136,6 @@ public class ElasticsearchLogStorageRetriever implements LogStorageRetriever, Cl
                 context = new ElasticsearchSearchContext();
                 session.setAttribute(runIdentifier.getId(), context);
                 spanBuilder.setAttribute("elasticsearchSearchContext", "new");
-                spanBuilder.setAttribute("elasticsearchSearchContext.identityHashCode", System.identityHashCode(context));
             }
         } else {
             if (complete) {
@@ -145,7 +144,6 @@ public class ElasticsearchLogStorageRetriever implements LogStorageRetriever, Cl
             } else {
                 spanBuilder.setAttribute("elasticsearchSearchContext", "reuse");
             }
-            spanBuilder.setAttribute("elasticsearchSearchContext.identityHashCode", System.identityHashCode(context));
             spanBuilder.setAttribute("from", context.from);
         }
         Span span = spanBuilder

--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/elastic/ElasticsearchLogsSearchIterator.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/elastic/ElasticsearchLogsSearchIterator.java
@@ -193,8 +193,7 @@ public class ElasticsearchLogsSearchIterator implements Iterator<String>, Closea
                 .setAttribute("query.size", PAGE_SIZE)
                 .setAttribute("query.match.traceId", traceId)
                 .setAttribute("query.match.jobFullName", jobFullName)
-                .setAttribute("query.match.runNumber", runNumber)
-                .setAttribute("elasticsearchSearchContext.identityHashCode", System.identityHashCode(context));
+                .setAttribute("query.match.runNumber", runNumber);
 
             BoolQuery.Builder queryBuilder = QueryBuilders.bool()
                 .must(

--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/elastic/ElasticsearchSearchContext.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/elastic/ElasticsearchSearchContext.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.backend.elastic;
+
+import java.util.Objects;
+
+public class ElasticsearchSearchContext {
+    int from;
+
+    public int getFrom() {
+        return from;
+    }
+
+    public void setFrom(int from) {
+        this.from = from;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ElasticsearchSearchContext that = (ElasticsearchSearchContext) o;
+        return from == that.from;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(from);
+    }
+
+    @Override
+    public String toString() {
+        return "ElasticsearchSearchContext{" +
+            "from=" + from +
+            '}';
+    }
+}

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/RunIdentifier.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/RunIdentifier.java
@@ -31,6 +31,14 @@ public class RunIdentifier implements Comparable<RunIdentifier> {
         this.runNumber = runNumber;
     }
 
+    /**
+     * String identifier for this run
+     */
+    @Nonnull
+    public String getId() {
+        return jobName + "#" + runNumber;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/log/OverallLog.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/log/OverallLog.java
@@ -7,6 +7,7 @@ package io.jenkins.plugins.opentelemetry.job.log;
 
 import hudson.Main;
 import hudson.console.AnnotatedLargeText;
+import io.jenkins.plugins.opentelemetry.job.log.util.StreamingInputStream;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
@@ -207,7 +208,12 @@ public class OverallLog extends AnnotatedLargeText<FlowExecutionOwner.Executable
             if (start != null && !start.isEmpty()) {
                 span.setAttribute("request.start", start);
             }
-            super.doProgressText(req, rsp);
+            try {
+                StreamingInputStream.setProgressiveStreaming();
+                super.doProgressText(req, rsp);
+            } finally {
+                StreamingInputStream.unsetProgressiveStreaming();
+            }
             String xTextSize = rsp.getHeader("X-Text-Size");
             if (xTextSize != null) {
                 span.setAttribute("response.textSize", Long.parseLong(xTextSize));

--- a/src/test/java/io/jenkins/plugins/opentelemetry/backend/elastic/ElasticsearchLogsSearchIteratorIT.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/backend/elastic/ElasticsearchLogsSearchIteratorIT.java
@@ -43,6 +43,7 @@ public class ElasticsearchLogsSearchIteratorIT {
         ByteStreams.copy(streamingInputStream, System.out);
 
         System.out.println("Queries count: " + elasticsearchLogsSearchIterator.queryCounter.get());
+        System.out.println("context : " + elasticsearchLogsSearchIterator.context);
     }
 
     @Nonnull
@@ -67,7 +68,7 @@ public class ElasticsearchLogsSearchIteratorIT {
         ElasticsearchClient esClient = new ElasticsearchClient(elasticsearchTransport);
 
 
-        ElasticsearchLogsSearchIterator elasticsearchLogsSearchIterator = new ElasticsearchLogsSearchIterator("my-war/master", 136, "1253b77680aa4f5a709e76381e5523f1", "", esClient, TracerProvider.noop().get("noop"));
+        ElasticsearchLogsSearchIterator elasticsearchLogsSearchIterator = new ElasticsearchLogsSearchIterator("my-war/master", 136, "1253b77680aa4f5a709e76381e5523f1", null, null, esClient, TracerProvider.noop().get("noop"));
         return elasticsearchLogsSearchIterator;
     }
 


### PR DESCRIPTION
Add support for progressive rendering of logs stored in Elasticsearch while builds are in progress.


<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
