### PR TITLE
fix encoding for the rootSpanName that contains a prefix with a space

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringAction.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringAction.java
@@ -10,6 +10,7 @@ import hudson.model.Action;
 import hudson.model.Run;
 import io.jenkins.plugins.opentelemetry.JenkinsOpenTelemetryPluginConfiguration;
 import io.jenkins.plugins.opentelemetry.backend.ObservabilityBackend;
+import io.jenkins.plugins.opentelemetry.OtelUtils;
 import jenkins.model.Jenkins;
 import jenkins.model.RunAction2;
 import jenkins.tasks.SimpleBuildStep;
@@ -126,7 +127,7 @@ public class MonitoringAction implements Action, RunAction2, SimpleBuildStep.Las
         }
         Map<String, Object> binding = new HashMap<>();
         binding.put("serviceName", Objects.requireNonNull(JenkinsOpenTelemetryPluginConfiguration.get().getServiceName()));
-        binding.put("rootSpanName", this.rootSpanName);
+        binding.put("rootSpanName", OtelUtils.urlEncode(this.rootSpanName));
         binding.put("traceId", this.traceId);
         binding.put("spanId", this.spanId);
         binding.put("startTime", Instant.ofEpochMilli(run.getStartTimeInMillis()));

--- a/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginMBPIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginMBPIntegrationTest.java
@@ -11,6 +11,8 @@ import com.github.rutledgepaulv.prune.Tree;
 import hudson.EnvVars;
 import hudson.model.Run;
 import hudson.util.LogTaskListener;
+import io.jenkins.plugins.opentelemetry.OtelUtils;
+import io.jenkins.plugins.opentelemetry.backend.ElasticBackend;
 import io.jenkins.plugins.opentelemetry.semconv.JenkinsOtelSemanticAttributes;
 import io.opentelemetry.api.common.Attributes;
 import jenkins.branch.BranchProperty;
@@ -20,6 +22,7 @@ import jenkins.plugins.git.GitSCMSource;
 import org.apache.commons.lang3.SystemUtils;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.StringContains;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
@@ -92,5 +95,6 @@ public class JenkinsOtelPluginMBPIntegrationTest extends BaseIntegrationTest {
         // Environment variables are populated
         EnvVars environment = b1.getEnvironment(new LogTaskListener(LOGGER, Level.INFO));
         assertEnvironmentVariables(environment);
+        MatcherAssert.assertThat(environment.get(ElasticBackend.OTEL_ELASTIC_URL), StringContains.containsString("transactionName=" + OtelUtils.urlEncode(rootSpanName)));
     }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

### What

URLEncode the rootSpanName that contains spaces, (Caused by https://github.com/jenkinsci/opentelemetry-plugin/pull/304/files#diff-47daed61318b4c0ca58c9b69f79d8bdb0fba90a8ce1475515c7203a1ef089882R106)

### Further details

Similar to https://github.com/jenkinsci/opentelemetry-plugin/pull/164 but in this case caused by the `BUILD ` prefix.