### PR TITLE
Better memory consumption of the JenkinsHttpSessionLineBytesToLineNumberConverter

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/RunFlowNodeIdentifier.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/RunFlowNodeIdentifier.java
@@ -6,6 +6,7 @@
 package io.jenkins.plugins.opentelemetry.job;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import java.util.Objects;
 
@@ -13,7 +14,7 @@ import java.util.Objects;
 public class RunFlowNodeIdentifier extends RunIdentifier {
     final String flowNodeId;
 
-    public RunFlowNodeIdentifier(@Nonnull String jobFullName, @Nonnull int runNumber, @Nonnull String flowNodeId) {
+    public RunFlowNodeIdentifier(@Nonnull String jobFullName, int runNumber, @Nullable String flowNodeId) {
         super(jobFullName, runNumber);
         this.flowNodeId = flowNodeId;
     }
@@ -24,7 +25,7 @@ public class RunFlowNodeIdentifier extends RunIdentifier {
         if (o == null || getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
         RunFlowNodeIdentifier that = (RunFlowNodeIdentifier) o;
-        return flowNodeId.equals(that.flowNodeId);
+        return Objects.equals(flowNodeId, that.flowNodeId);
     }
 
     @Override

--- a/src/test/java/io/jenkins/plugins/opentelemetry/job/log/util/LineIteratorTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/job/log/util/LineIteratorTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.job.log.util;
+
+import io.jenkins.plugins.opentelemetry.job.RunFlowNodeIdentifier;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class LineIteratorTest {
+
+    @Test
+    public void testJenkinsHttpSessionLineBytesToLineNumberConverter() {
+        final Map<RunFlowNodeIdentifier, Map<Long, Long>> context = new HashMap<>();
+
+
+        LineIterator.JenkinsHttpSessionLineBytesToLineNumberConverter converterJob1Run1 = new LineIterator.JenkinsHttpSessionLineBytesToLineNumberConverter("job-1", 1, null) {
+            @Override
+            Map<RunFlowNodeIdentifier, Map<Long, Long>> getContext() {
+                return context;
+            }
+        };
+
+        converterJob1Run1.putLogBytesToLogLine(100, 111);
+        converterJob1Run1.putLogBytesToLogLine(1_000, 1_111);
+        converterJob1Run1.putLogBytesToLogLine(10_000, 11_111);
+
+        LineIterator.JenkinsHttpSessionLineBytesToLineNumberConverter converterJob1Run1FlowNode1 = new LineIterator.JenkinsHttpSessionLineBytesToLineNumberConverter("job-1", 1, "1") {
+            @Override
+            Map<RunFlowNodeIdentifier, Map<Long, Long>> getContext() {
+                return context;
+            }
+        };
+        converterJob1Run1FlowNode1.putLogBytesToLogLine(100, 7_111);
+        converterJob1Run1FlowNode1.putLogBytesToLogLine(1_000, 71_111);
+        converterJob1Run1FlowNode1.putLogBytesToLogLine(10_000, 711_111);
+
+        LineIterator.JenkinsHttpSessionLineBytesToLineNumberConverter converterJob2Run2 = new LineIterator.JenkinsHttpSessionLineBytesToLineNumberConverter("job-2", 2, null) {
+            @Override
+            Map<RunFlowNodeIdentifier, Map<Long, Long>> getContext() {
+                return context;
+            }
+        };
+
+        converterJob2Run2.putLogBytesToLogLine(100, 222);
+        converterJob2Run2.putLogBytesToLogLine(1_000, 2_222);
+        converterJob2Run2.putLogBytesToLogLine(10_000, 22_222);
+
+        LineIterator.JenkinsHttpSessionLineBytesToLineNumberConverter converterJob2Run2FlowNode2 = new LineIterator.JenkinsHttpSessionLineBytesToLineNumberConverter("job-2", 2, "2") {
+            @Override
+            Map<RunFlowNodeIdentifier, Map<Long, Long>> getContext() {
+                return context;
+            }
+        };
+        converterJob2Run2FlowNode2.putLogBytesToLogLine(100, 7_222);
+        converterJob2Run2FlowNode2.putLogBytesToLogLine(1_000, 72_222);
+        converterJob2Run2FlowNode2.putLogBytesToLogLine(10_000, 722_222);
+
+
+        assertEquals(Long.valueOf(111), converterJob1Run1.getLogLineFromLogBytes(100));
+        assertEquals(Long.valueOf(7_111), converterJob1Run1FlowNode1.getLogLineFromLogBytes(100));
+        assertEquals(Long.valueOf(222), converterJob2Run2.getLogLineFromLogBytes(100));
+        assertEquals(Long.valueOf(7_222), converterJob2Run2FlowNode2.getLogLineFromLogBytes(100));
+        assertEquals(Long.valueOf(722_222), converterJob2Run2FlowNode2.getLogLineFromLogBytes(10_000));
+
+    }
+
+}


### PR DESCRIPTION
Better memory consumption of the JenkinsHttpSessionLineBytesToLineNumberConverter.

Limit memory consumption using a structured object as the key of the the PipelineRunFlowNodeId
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
