### PR TITLE
JENKINS-68116 Export metrics for SCM Event queue (req Jenkins 2.289.3)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <revision>2.3.1</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.277.1</jenkins.version>
+        <jenkins.version>2.289.3</jenkins.version>
         <java.level>8</java.level>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <opentelemetry.version>1.13.0</opentelemetry.version>
@@ -38,8 +38,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.249.x</artifactId>
-                <version>984.vb5eaac999a7e</version>
+                <artifactId>bom-2.289.x</artifactId>
+                <version>1280.vd669827e38cd</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -79,10 +79,10 @@
                 <version>3.12.0</version>
             </dependency>
             <dependency>
-                <!-- workflow-basic-steps:2.22 vs gitlab-plugin:1.5.22 -->
-                <groupId>javax.activation</groupId>
-                <artifactId>activation</artifactId>
-                <version>1.1.1</version>
+                <!-- Jenkins core ships this till 2.330, can probably remove this after the baseline is above that  -->
+                <groupId>com.sun.activation</groupId>
+                <artifactId>jakarta.activation</artifactId>
+                <version>1.2.2</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -127,6 +127,11 @@
                     <!-- we get okhttp from io.jenkins.plugins:okhttp-api -->
                     <groupId>com.squareup.okhttp3</groupId>
                     <artifactId>okhttp</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- we get okhttp from org.jenkins-ci.plugins:jackson2-api -->
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -280,6 +285,10 @@
             <artifactId>pipeline-stage-step</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>scm-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-multibranch</artifactId>
         </dependency>
@@ -308,13 +317,12 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
-            <version>1.18</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>job-dsl</artifactId>
-            <version>1.77</version>
+            <version>1.78.3</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -325,7 +333,7 @@
         <dependency>
             <groupId>com.coravy.hudson.plugins.github</groupId>
             <artifactId>github</artifactId>
-            <version>1.32.0</version>
+            <version>1.34.3</version>
             <optional>true</optional>
             <exclusions>
                 <exclusion>
@@ -337,7 +345,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>gitlab-plugin</artifactId>
-            <version>1.5.22</version>
+            <version>1.5.29</version>
             <optional>true</optional>
             <exclusions>
                 <exclusion>

--- a/src/main/java/io/jenkins/plugins/opentelemetry/init/SCMEventMonitoringInitializer.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/init/SCMEventMonitoringInitializer.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.init;
+
+import hudson.Extension;
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
+import io.jenkins.plugins.opentelemetry.OpenTelemetrySdkProvider;
+import io.jenkins.plugins.opentelemetry.semconv.JenkinsSemanticMetrics;
+import io.opentelemetry.api.metrics.Meter;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+import jenkins.YesNoMaybe;
+import jenkins.scm.api.SCMEvent;
+
+/**
+ * Capture SCM Events metrics
+ */
+@Extension(dynamicLoadable = YesNoMaybe.YES, optional = true)
+public class SCMEventMonitoringInitializer {
+
+    private final static Logger LOGGER = Logger.getLogger(SCMEventMonitoringInitializer.class.getName());
+
+    protected Meter meter;
+
+    @Initializer(after = InitMilestone.JOB_CONFIG_ADAPTED)
+    public void initialize() {
+        meter.counterBuilder(JenkinsSemanticMetrics.JENKINS_SCM_EVENT_POOL_SIZE)
+            .setDescription("Number of threads handling SCM Events")
+            .setUnit("1")
+            .buildWithCallback(valueObserver -> valueObserver.record(SCMEvent.getEventProcessingMetrics().getPoolSize()));
+
+        meter.upDownCounterBuilder(JenkinsSemanticMetrics.JENKINS_SCM_EVENT_ACTIVE_THREADS)
+            .setDescription("Number of threads actively handling SCM Events")
+            .setUnit("1")
+            .buildWithCallback(valueObserver -> valueObserver.record(SCMEvent.getEventProcessingMetrics().getActiveThreads()));
+
+        meter.upDownCounterBuilder(JenkinsSemanticMetrics.JENKINS_SCM_EVENT_QUEUED_TASKS)
+            .setDescription("Number of queued SCM Event tasks")
+            .setUnit("1")
+            .buildWithCallback(valueObserver -> valueObserver.record(SCMEvent.getEventProcessingMetrics().getQueuedTasks()));
+
+        meter.counterBuilder(JenkinsSemanticMetrics.JENKINS_SCM_EVENT_COMPLETED_TASKS)
+            .setDescription("Number of completed SCM Event tasks")
+            .setUnit("1")
+            .buildWithCallback(valueObserver -> valueObserver.record(SCMEvent.getEventProcessingMetrics().getCompletedTasks()));
+
+        LOGGER.log(Level.FINE, () -> "Start monitoring SCM events");
+    }
+
+    /**
+     * Jenkins doesn't support {@link com.google.inject.Provides} so we manually wire dependencies :-(
+     */
+    @Inject
+    public void setMeter(@Nonnull OpenTelemetrySdkProvider openTelemetrySdkProvider) {
+        this.meter = openTelemetrySdkProvider.getMeter();
+    }
+}

--- a/src/main/java/io/jenkins/plugins/opentelemetry/semconv/JenkinsSemanticMetrics.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/semconv/JenkinsSemanticMetrics.java
@@ -24,6 +24,11 @@ public class JenkinsSemanticMetrics {
     public static final String JENKINS_CLOUD_AGENTS_COMPLETED =     "jenkins.cloud.agents.completed";
     public static final String JENKINS_DISK_USAGE_BYTES =           "jenkins.disk.usage.bytes";
 
+    public static final String JENKINS_SCM_EVENT_POOL_SIZE =         "jenkins.scm.event.pool_size";
+    public static final String JENKINS_SCM_EVENT_ACTIVE_THREADS =    "jenkins.scm.event.active_threads";
+    public static final String JENKINS_SCM_EVENT_QUEUED_TASKS =      "jenkins.scm.event.queued_tasks";
+    public static final String JENKINS_SCM_EVENT_COMPLETED_TASKS =   "jenkins.scm.event.completed_tasks";
+
 
 
     public static final String LOGIN =           "login";


### PR DESCRIPTION
I would like to be able to monitor our SCM event queue and be able to measure the effect that tuning I do has on it.

see https://issues.jenkins.io/browse/JENKINS-68116

requires https://github.com/jenkinsci/scm-api-plugin/pull/127

<img width="1416" alt="image" src="https://user-images.githubusercontent.com/21194782/161569702-64e3cc62-b5e7-41ee-83b7-f7bad6c36575.png">
