### PR TITLE
Don't modify default column set

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/ViewColumn.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/ViewColumn.java
@@ -47,7 +47,7 @@ public class ViewColumn extends ListViewColumn {
         }
 
         public boolean shownByDefault() {
-            return true;
+            return false;
         }
     }
 }


### PR DESCRIPTION
I don't think it's a good practice to modify the default column set as the user can't modify it.

I currently don't plan to link to an observability system and so my users shouldn't be forced to see a column in the table 'please configure...'