### PR TITLE
Redirect to valid path when disabling admin monitor

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/administrativemonitor/ElasticBackendDashboardNotEnabledAdministrativeMonitor.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/administrativemonitor/ElasticBackendDashboardNotEnabledAdministrativeMonitor.java
@@ -34,9 +34,8 @@ public class ElasticBackendDashboardNotEnabledAdministrativeMonitor extends Admi
         return pluginConfiguration.getObservabilityBackends().stream().
             filter(backend -> backend instanceof ElasticBackend).
             map(backend -> (ElasticBackend) backend).
-            filter( backend -> StringUtils.isNotEmpty(backend.getKibanaBaseUrl())).
-            filter(elasticBackend -> !elasticBackend.isDisplayKibanaDashboardLink()).
-            count() > 0;
+            filter(backend -> StringUtils.isNotEmpty(backend.getKibanaBaseUrl()))
+            .anyMatch(elasticBackend -> !elasticBackend.isDisplayKibanaDashboardLink());
     }
 
     /**
@@ -46,10 +45,8 @@ public class ElasticBackendDashboardNotEnabledAdministrativeMonitor extends Admi
     public HttpResponse doAct(StaplerRequest req, StaplerResponse rsp) throws IOException {
         if (req.hasParameter("no")) {
             disable(true);
-            return HttpResponses.redirectToDot();
-        } else {
-            return HttpResponses.redirectViaContextPath("/configure");
         }
+        return HttpResponses.redirectViaContextPath("/configure");
     }
 
 

--- a/src/main/java/io/jenkins/plugins/opentelemetry/administrativemonitor/ElasticBackendKibanaBaseUrlNotSetAdministrativeMonitor.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/administrativemonitor/ElasticBackendKibanaBaseUrlNotSetAdministrativeMonitor.java
@@ -33,9 +33,8 @@ public class ElasticBackendKibanaBaseUrlNotSetAdministrativeMonitor extends Admi
     public boolean isActivated() {
         return pluginConfiguration.getObservabilityBackends().stream().
             filter(backend -> backend instanceof ElasticBackend).
-            map(backend -> (ElasticBackend) backend).
-            filter( backend -> StringUtils.isEmpty(backend.getKibanaBaseUrl())).
-            count() > 0;
+            map(backend -> (ElasticBackend) backend)
+            .anyMatch(backend -> StringUtils.isEmpty(backend.getKibanaBaseUrl()));
     }
 
     /**
@@ -45,10 +44,8 @@ public class ElasticBackendKibanaBaseUrlNotSetAdministrativeMonitor extends Admi
     public HttpResponse doAct(StaplerRequest req, StaplerResponse rsp) throws IOException {
         if (req.hasParameter("no")) {
             disable(true);
-            return HttpResponses.redirectToDot();
-        } else {
-            return HttpResponses.redirectViaContextPath("/configure");
         }
+        return HttpResponses.redirectViaContextPath("/configure");
     }
 
 

--- a/src/main/java/io/jenkins/plugins/opentelemetry/administrativemonitor/ObservabilityBackendCheckAdministrativeMonitor.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/administrativemonitor/ObservabilityBackendCheckAdministrativeMonitor.java
@@ -46,9 +46,7 @@ public class ObservabilityBackendCheckAdministrativeMonitor extends Administrati
     public HttpResponse doAct(StaplerRequest req, StaplerResponse rsp) throws IOException {
         if (req.hasParameter("no")) {
             disable(true);
-            return HttpResponses.redirectToDot();
-        } else {
-            return HttpResponses.redirectViaContextPath("/configure");
         }
+        return HttpResponses.redirectViaContextPath("/configure");
     }
 }


### PR DESCRIPTION
When I dismissed one of the admin monitors I got redirected to a 404 page.

This seems safer