### PR TITLE
Fix typo in admin monitor

### DIFF
--- a/src/main/resources/io/jenkins/plugins/opentelemetry/administrativemonitor/ObservabilityBackendCheckAdministrativeMonitor/message.jelly
+++ b/src/main/resources/io/jenkins/plugins/opentelemetry/administrativemonitor/ObservabilityBackendCheckAdministrativeMonitor/message.jelly
@@ -12,6 +12,6 @@
         The OpenTelemetry Plugin is configured to send observability data but no observability backend is configured
         to navigate from Jenkins GUI to the observability screens and data (Jenkins health and performance dashboard,
         traces of the pipelines...). Observability solutions such as Jaeger, Zipkin, Prometheus, Elastic, and many others
-        can be used. Configured observability backend?
+        can be used. Configure observability backend?
     </div>
 </j:jelly>


### PR DESCRIPTION
I'd also suggest possibly shortening the length of the buttons and moving them below the question, it doesn't look great how it is currently

<img width="1047" alt="image" src="https://user-images.githubusercontent.com/21194782/164558079-5231a8f6-b199-44f9-b7b9-de909bd21e5a.png">

