### PR TITLE
Stop capturing of http request params as trace attributes

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/servlet/OpenTelemetryServletFilter.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/servlet/OpenTelemetryServletFilter.java
@@ -226,15 +226,6 @@ public class OpenTelemetryServletFilter implements Filter {
             spanBuilder.setAttribute(SemanticAttributes.ENDUSER_ID, user.getId());
         }
 
-        for (Map.Entry<String, String[]> entry : servletRequest.getParameterMap().entrySet()) {
-            String name = entry.getKey();
-            String[] values = entry.getValue();
-            if (values.length == 1) {
-                spanBuilder.setAttribute("query." + name, values[0]);
-            } else {
-                spanBuilder.setAttribute(AttributeKey.stringArrayKey("query." + name), Arrays.asList(values));
-            }
-        }
         Span span = spanBuilder.startSpan();
         try (Scope scope = span.makeCurrent()) {
             filterChain.doFilter(servletRequest, servletResponse);


### PR DESCRIPTION
Remove capture of http servlet request params as trace attributes
* Prevent sensitive data leakage problems
* Align with other http instrumentation which don't capture request params but just request query string
* Fix bug when a downstream plugin invokes request.getReader() or request.getInputstream(). See https://github.com/jenkinsci/opentelemetry-plugin/issues/419


Fixes 
* https://github.com/jenkinsci/opentelemetry-plugin/issues/419

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
