### PR TITLE
Ensure JCasC configures the OpenTelemetry SDK when started from scratch

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
@@ -150,6 +150,7 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
     @DataBoundConstructor
     public JenkinsOpenTelemetryPluginConfiguration() {
         load();
+        configureOpentelemetryAndInitialize();
     }
 
     @Override
@@ -158,6 +159,13 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
         req.bindJSON(this, json);
         // stapler oddity, empty lists coming from the HTTP request are not set on bean by  `req.bindJSON(this, json)`
         this.observabilityBackends = req.bindJSONToList(ObservabilityBackend.class, json.get("observabilityBackends"));
+        configureOpentelemetryAndInitialize();
+        save();
+        LOGGER.log(Level.FINE, "Configured");
+        return true;
+    }
+
+    private void configureOpentelemetryAndInitialize() {
         this.endpoint = sanitizeOtlpEndpoint(this.endpoint);
         initializeOpenTelemetry();
         if (logStorageRetriever != null && logStorageRetriever instanceof Closeable) {
@@ -169,9 +177,6 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
             }
         }
         this.logStorageRetriever = resolveLogStorageRetriever();
-        save();
-        LOGGER.log(Level.FINE, "Configured");
-        return true;
     }
 
     protected Object readResolve() {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

A hack but it seems to do the job to configure the plugin without the need to save the global settings:

```
2022-05-17 21:21:23.163+0000 [id=40]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
2022-05-17 21:21:28.904+0000 [id=13]	INFO	i.j.p.o.OpenTelemetrySdkProvider#initialize: OpenTelemetry SDK initialized: SDK [config: otel.traces.exporter=none, resource: service.name=jenkins, service.namespace=jenkins, service.version=2.332.3]
2022-05-17 21:21:29.098+0000 [id=38]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
2022-05-17 21:21:29.102+0000 [id=37]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
2022-05-17 21:21:29.282+0000 [id=44]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
2022-05-17 21:21:32.009+0000 [id=44]	INFO	i.j.p.o.OpenTelemetrySdkProvider#initialize: OpenTelemetry SDK initialized: SDK [config: otel.traces.exporter=otlp, otel.metrics.exporter=otlp, otel.exporter.otlp.endpoint=http://otel-collector:4317, resource: service.name=jenkins, service.namespace=jenkins, service.version=2.332.3]
2022-05-17 21:21:32.471+0000 [id=44]	INFO	i.j.p.o.OpenTelemetrySdkProvider#initialize: OpenTelemetry SDK initialized: SDK [config: otel.traces.exporter=otlp, otel.metrics.exporter=otlp, otel.logs.exporter=otlp, otel.exporter.otlp.endpoint=http://otel-collector:4317, resource: service.name=jenkins, service.namespace=jenkins, service.version=2.332.3]
Processing provided DSL script
2022-05-17 21:21:32.944+0000 [id=44]	INFO	j.j.plugin.JenkinsJobManagement#createOrUpdateConfig: createOrUpdateConfig for antifraud
Processing provided DSL script
```

Although it runs three times the `OpenTelemetrySdkProvider#initialize` ... 


I'm not sure whether this is the way we would like to move forward.

Relates https://github.com/jenkinsci/opentelemetry-plugin/issues/437
