### PR TITLE
Remove incorrectly placed @Extension

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/CustomObservabilityBackend.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/CustomObservabilityBackend.java
@@ -15,7 +15,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
-@Extension
 public class CustomObservabilityBackend extends ObservabilityBackend {
 
     public static final String OTEL_CUSTOM_URL = "OTEL_CUSTOM_URL";

--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/ElasticBackend.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/ElasticBackend.java
@@ -33,7 +33,6 @@ import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-@Extension
 public class ElasticBackend extends ObservabilityBackend implements TemplateBindingsProvider {
 
     private final static Logger LOGGER = Logger.getLogger(ElasticBackend.class.getName());

--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/JaegerBackend.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/JaegerBackend.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-@Extension
 public class JaegerBackend extends ObservabilityBackend {
 
     public static final String OTEL_JAEGER_URL = "OTEL_JAEGER_URL";

--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/ZipkinBackend.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/ZipkinBackend.java
@@ -17,7 +17,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-@Extension
 public class ZipkinBackend extends ObservabilityBackend {
 
     public static final String OTEL_ZIPKIN_URL = "OTEL_ZIPKIN_URL";


### PR DESCRIPTION
Extension should go on the descriptor (and it's also there already)

I noticed this in https://github.com/jenkinsci/opentelemetry-plugin/pull/441 when I tried to set a mandatory parameter in the constructor which failed. if there's mandatory fields in this extensions they could also be moved. 

All still works:

![image](https://user-images.githubusercontent.com/21194782/169087770-c7a5ba91-33bf-4879-963e-cf8cf20fa93c.png)
