### PR TITLE
Mark metrics listener `@Extension`s as dynamically loadable for JCasC

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/computer/MonitoringCloudListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/computer/MonitoringCloudListener.java
@@ -10,7 +10,6 @@ import hudson.Extension;
 import hudson.model.Node;
 import hudson.slaves.CloudProvisioningListener;
 import hudson.slaves.NodeProvisioner;
-import io.jenkins.plugins.opentelemetry.OpenTelemetrySdkProvider;
 import io.jenkins.plugins.opentelemetry.OtelComponent;
 import io.jenkins.plugins.opentelemetry.semconv.JenkinsSemanticMetrics;
 import io.opentelemetry.api.metrics.LongCounter;
@@ -18,14 +17,12 @@ import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.logs.LogEmitter;
+import jenkins.YesNoMaybe;
 
-import javax.annotation.Nonnull;
-import javax.annotation.PostConstruct;
-import javax.inject.Inject;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-@Extension
+@Extension(dynamicLoadable = YesNoMaybe.YES, optional = true)
 public class MonitoringCloudListener extends CloudProvisioningListener implements OtelComponent {
     private final static Logger LOGGER = Logger.getLogger(MonitoringCloudListener.class.getName());
 

--- a/src/main/java/io/jenkins/plugins/opentelemetry/computer/MonitoringComputerListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/computer/MonitoringComputerListener.java
@@ -22,6 +22,7 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.logs.LogEmitter;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import jenkins.YesNoMaybe;
 import jenkins.model.Jenkins;
 import jenkins.security.MasterToSlaveCallable;
 
@@ -33,7 +34,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-@Extension
+@Extension(dynamicLoadable = YesNoMaybe.YES, optional = true)
 public class MonitoringComputerListener extends ComputerListener implements OtelComponent {
     private final static Logger LOGGER = Logger.getLogger(MonitoringComputerListener.class.getName());
 

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringBuildStepListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringBuildStepListener.java
@@ -27,6 +27,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.logs.LogEmitter;
+import jenkins.YesNoMaybe;
 import jenkins.model.Jenkins;
 
 import javax.annotation.CheckForNull;
@@ -38,7 +39,7 @@ import java.util.logging.Logger;
 import static com.google.common.base.Verify.verifyNotNull;
 import static io.jenkins.plugins.opentelemetry.OtelUtils.JENKINS_CORE;
 
-@Extension
+@Extension(dynamicLoadable = YesNoMaybe.YES)
 public class MonitoringBuildStepListener extends BuildStepListener implements OtelComponent {
 
     protected static final Logger LOGGER = Logger.getLogger(MonitoringRunListener.class.getName());

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
@@ -34,6 +34,7 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.logs.LogEmitter;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import jenkins.YesNoMaybe;
 import jenkins.model.CauseOfInterruption;
 import org.apache.commons.compress.utils.Sets;
 import org.jenkinsci.plugins.structs.SymbolLookup;
@@ -73,7 +74,7 @@ import java.util.stream.Collectors;
 import static com.google.common.base.Verify.verifyNotNull;
 
 
-@Extension
+@Extension(dynamicLoadable = YesNoMaybe.YES, optional = true)
 public class MonitoringPipelineListener extends AbstractPipelineListener implements PipelineListener, StepListener, OtelComponent {
     private final static Logger LOGGER = Logger.getLogger(MonitoringPipelineListener.class.getName());
 

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringRunListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringRunListener.java
@@ -42,6 +42,7 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.logs.LogEmitter;
 import io.opentelemetry.sdk.trace.ReadWriteSpan;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import jenkins.YesNoMaybe;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.support.steps.build.BuildUpstreamCause;
@@ -66,7 +67,7 @@ import java.util.stream.Collectors;
 
 import static com.google.common.base.Verify.verifyNotNull;
 
-@Extension
+@Extension(dynamicLoadable = YesNoMaybe.YES, optional = true)
 public class MonitoringRunListener extends OtelContextAwareAbstractRunListener {
 
     protected static final Logger LOGGER = Logger.getLogger(MonitoringRunListener.class.getName());

--- a/src/main/java/io/jenkins/plugins/opentelemetry/queue/MonitoringQueueListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/queue/MonitoringQueueListener.java
@@ -16,6 +16,7 @@ import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.logs.LogEmitter;
+import jenkins.YesNoMaybe;
 import jenkins.model.Jenkins;
 
 import javax.annotation.Nonnull;
@@ -29,7 +30,7 @@ import java.util.logging.Logger;
 /**
  * Monitor the Jenkins Build queue
  */
-@Extension
+@Extension(dynamicLoadable = YesNoMaybe.YES, optional = true)
 public class MonitoringQueueListener extends QueueListener implements OtelComponent {
 
     private final static Logger LOGGER = Logger.getLogger(MonitoringQueueListener.class.getName());

--- a/src/main/java/io/jenkins/plugins/opentelemetry/security/AuditingSecurityListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/security/AuditingSecurityListener.java
@@ -22,6 +22,7 @@ import io.opentelemetry.sdk.logs.LogBuilder;
 import io.opentelemetry.sdk.logs.LogEmitter;
 import io.opentelemetry.sdk.logs.data.Severity;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import jenkins.YesNoMaybe;
 import jenkins.security.SecurityListener;
 import org.acegisecurity.userdetails.UserDetails;
 import org.springframework.security.core.Authentication;
@@ -38,7 +39,7 @@ import java.util.logging.Logger;
  * {@link AuditingSecurityListener} events ({@link #loggedIn(String)}, {@link #failedToLogIn(String)}...) are invoked
  * within a trace.
  */
-@Extension
+@Extension(dynamicLoadable = YesNoMaybe.YES, optional = true)
 public class AuditingSecurityListener extends SecurityListener implements OtelComponent {
 
     private final static Logger LOGGER = Logger.getLogger(AuditingSecurityListener.class.getName());

--- a/src/test/java/io/jenkins/plugins/opentelemetry/LifecycleDebugger.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/LifecycleDebugger.java
@@ -8,11 +8,12 @@ package io.jenkins.plugins.opentelemetry;
 import hudson.Extension;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
+import jenkins.YesNoMaybe;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-@Extension
+@Extension(dynamicLoadable = YesNoMaybe.YES, optional = true)
 public class LifecycleDebugger {
     private final static Logger logger = Logger.getLogger(LifecycleDebugger.class.getName());
     @Initializer(after = InitMilestone.SYSTEM_CONFIG_LOADED, before = InitMilestone.SYSTEM_CONFIG_ADAPTED)


### PR DESCRIPTION
Fix:
* https://github.com/jenkinsci/opentelemetry-plugin/issues/437 

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
