### PR TITLE
Switch demo plugin installation to use jenkins-plugin-cli

### DIFF
--- a/demos/config/Dockerfile
+++ b/demos/config/Dockerfile
@@ -1,4 +1,4 @@
 FROM jenkins/jenkins:lts
 
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
-RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt
+RUN jenkins-plugin-cli --plugins -f /usr/share/jenkins/ref/plugins.txt


### PR DESCRIPTION
Running `make -C demos build` results in this warning: `install-plugins.sh has been removed, please switch to jenkins-plugin-cli`, which results in a failed build locally. Pinning the base image would also beneficial.
