### PR TITLE
NoElasticLogsBackend shouldn't activate `otel.logs.exporter=otlp`

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/ElasticBackend.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/ElasticBackend.java
@@ -10,6 +10,7 @@ import hudson.Extension;
 import hudson.util.FormValidation;
 import io.jenkins.plugins.opentelemetry.TemplateBindingsProvider;
 import io.jenkins.plugins.opentelemetry.backend.elastic.ElasticLogsBackend;
+import io.jenkins.plugins.opentelemetry.backend.elastic.NoElasticLogsBackend;
 import io.jenkins.plugins.opentelemetry.job.log.LogStorageRetriever;
 import org.apache.commons.lang.StringUtils;
 import org.jenkins.ui.icon.Icon;
@@ -199,7 +200,7 @@ public class ElasticBackend extends ObservabilityBackend implements TemplateBind
         if (elasticLogsBackend == null) {
             return Collections.emptyMap();
         } else {
-            return Collections.singletonMap("otel.logs.exporter", "otlp");
+            return elasticLogsBackend.getOtelConfigurationProperties();
         }
     }
 

--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/elastic/ElasticLogsBackend.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/elastic/ElasticLogsBackend.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -74,6 +76,10 @@ public abstract class ElasticLogsBackend extends AbstractDescribableImpl<Elastic
             }
         }
         return buildLogsVisualizationUrlGTemplate;
+    }
+
+    public Map<String, String> getOtelConfigurationProperties() {
+        return Collections.singletonMap("otel.logs.exporter", "otlp");
     }
 
     private String getKibanaSpaceIdentifier() {

--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/elastic/NoElasticLogsBackend.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/elastic/NoElasticLogsBackend.java
@@ -11,6 +11,9 @@ import io.jenkins.plugins.opentelemetry.TemplateBindingsProvider;
 import io.jenkins.plugins.opentelemetry.job.log.LogStorageRetriever;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import java.util.Collections;
+import java.util.Map;
+
 public class NoElasticLogsBackend extends ElasticLogsBackend {
     @DataBoundConstructor
     public NoElasticLogsBackend() {
@@ -19,6 +22,10 @@ public class NoElasticLogsBackend extends ElasticLogsBackend {
     @Override
     public LogStorageRetriever newLogStorageRetriever(TemplateBindingsProvider templateBindingsProvider) {
         return null;
+    }
+
+    public Map<String, String> getOtelConfigurationProperties() {
+        return Collections.emptyMap();
     }
 
     @Override

--- a/src/test/java/io/jenkins/plugins/opentelemetry/backend/ElasticBackendTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/backend/ElasticBackendTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.backend;
+
+import io.jenkins.plugins.opentelemetry.backend.elastic.ElasticLogsBackendWithJenkinsVisualization;
+import io.jenkins.plugins.opentelemetry.backend.elastic.ElasticLogsBackendWithoutJenkinsVisualization;
+import io.jenkins.plugins.opentelemetry.backend.elastic.NoElasticLogsBackend;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class ElasticBackendTest {
+
+    @Test
+    public void testNoElasticLogsBackend() {
+        ElasticBackend elasticBackend = new ElasticBackend();
+        elasticBackend.setElasticLogsBackend(new NoElasticLogsBackend());
+        Map<String, String> actual = elasticBackend.getOtelConfigurationProperties();
+        Map<String, String> expected = Collections.emptyMap();
+        Assert.assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testElasticLogsBackendWithJenkinsVisualization() {
+        ElasticBackend elasticBackend = new ElasticBackend();
+        elasticBackend.setElasticLogsBackend(new ElasticLogsBackendWithJenkinsVisualization());
+        Map<String, String> actual = elasticBackend.getOtelConfigurationProperties();
+        Map<String, String> expected = Collections.singletonMap("otel.logs.exporter", "otlp");
+        Assert.assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testElasticLogsBackendWithoutJenkinsVisualization() {
+        ElasticBackend elasticBackend = new ElasticBackend();
+        elasticBackend.setElasticLogsBackend(new ElasticLogsBackendWithoutJenkinsVisualization());
+        Map<String, String> actual = elasticBackend.getOtelConfigurationProperties();
+        Map<String, String> expected = Collections.singletonMap("otel.logs.exporter", "otlp");
+        Assert.assertEquals(actual, expected);
+    }
+}


### PR DESCRIPTION
Fix
* https://github.com/jenkinsci/opentelemetry-plugin/issues/498

`NoElasticLogsBackend` shouldn't activate `otel.logs.exporter=otlp`


* <!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
