### PR TITLE
Remove deprecated `java.level` property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,6 @@
         <revision>2.9.3</revision>
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.289.3</jenkins.version>
-        <java.level>8</java.level>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <opentelemetry.version>1.17.0</opentelemetry.version>
         <opentelemetry-alpha.version>1.17.0-alpha</opentelemetry-alpha.version>


### PR DESCRIPTION
The `java.level` property was deprecated in [plugin parent POM 4.40](https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.40) and should be removed from this plugin's POM. In the future this warning will be changed to an error and will break the build. See https://github.com/jenkinsci/plugin-pom/pull/522 for details.