### PR TITLE
chore: set cloudbees-disk-usage-simple plugin version to 170.va_fd5b_4ee6858

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>cloudbees-disk-usage-simple</artifactId>
-            <version>178.v1a_4d2f6359a_8</version>
+            <version>170.va_fd5b_4ee6858</version>
             <optional>true</optional>
         </dependency>
         <dependency>


### PR DESCRIPTION
****
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

set cloudbees-disk-usage-simple plugin version to 170.va_fd5b_4ee6858

related to https://github.com/jenkinsci/opentelemetry-plugin/commit/2a70bd511ac05c1489d00cb4083ea03776418437