### PR TITLE
bump version 8.4.2 for the elastic logs demo

### DIFF
--- a/demos/Makefile
+++ b/demos/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := start
 
 export OTELCOL_IMG?=otel/opentelemetry-collector-contrib-dev:latest
-export ELASTIC_STACK_VERSION?=8.1.2
+export ELASTIC_STACK_VERSION?=8.4.2
 
 .PHONY: build
 build:

--- a/src/test/resources/elastic-stack.yml
+++ b/src/test/resources/elastic-stack.yml
@@ -7,7 +7,6 @@ services:
     elasticsearch:
         environment:
             - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
-            - "network.host="
             - "transport.host=127.0.0.1"
             - "http.host=0.0.0.0"
             - "cluster.routing.allocation.disk.threshold_enabled=false"


### PR DESCRIPTION
Bump the demos for the Elastic logs integration to `8.4.2`