### PR TITLE
Revert "Forward compatibility with jenkins-buttons"

### DIFF
--- a/src/main/resources/io/jenkins/plugins/opentelemetry/administrativemonitor/ElasticBackendDashboardNotEnabledAdministrativeMonitor/message.jelly
+++ b/src/main/resources/io/jenkins/plugins/opentelemetry/administrativemonitor/ElasticBackendDashboardNotEnabledAdministrativeMonitor/message.jelly
@@ -7,7 +7,7 @@
     <div class="alert alert-warning">
         <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
             <f:submit name="yes" value="${%Configure Kibana dashboard}"/>
-            <f:submit primary="false" clazz="jenkins-!-destructive-color" name="no" value="${%Dismiss}"/>
+            <f:submit name="no" value="${%Dismiss}"/>
         </form>
         The OpenTelemetry Plugin is configured with an Elastic Observability backend for which the display of the link
         to the Kibana dashboard of Jenkins health &amp; performance indicators has not been activated.

--- a/src/main/resources/io/jenkins/plugins/opentelemetry/administrativemonitor/ElasticBackendKibanaBaseUrlNotSetAdministrativeMonitor/message.jelly
+++ b/src/main/resources/io/jenkins/plugins/opentelemetry/administrativemonitor/ElasticBackendKibanaBaseUrlNotSetAdministrativeMonitor/message.jelly
@@ -7,7 +7,7 @@
     <div class="alert alert-warning">
         <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
             <f:submit name="yes" value="${%Configure Kibana base URL}"/>
-            <f:submit primary="false" clazz="jenkins-!-destructive-color" name="no" value="${%Dismiss}"/>
+            <f:submit name="no" value="${%Dismiss}"/>
         </form>
         The OpenTelemetry Plugin is configured with an Elastic Observability backend but the Kibana base URL is not
         defined, preventing displaying links from Jenkins GUI to Kibana to visualize traces of the job executions and

--- a/src/main/resources/io/jenkins/plugins/opentelemetry/administrativemonitor/ObservabilityBackendCheckAdministrativeMonitor/message.jelly
+++ b/src/main/resources/io/jenkins/plugins/opentelemetry/administrativemonitor/ObservabilityBackendCheckAdministrativeMonitor/message.jelly
@@ -7,7 +7,7 @@
     <div class="alert alert-warning">
         <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
             <f:submit name="yes" value="${%Configure OpenTelemetry Plugin Observability Backend}"/>
-            <f:submit primary="false" clazz="jenkins-!-destructive-color" name="no" value="${%Dismiss}"/>
+            <f:submit name="no" value="${%Dismiss}"/>
         </form>
         The OpenTelemetry Plugin is configured to send observability data but no observability backend is configured
         to navigate from Jenkins GUI to the observability screens and data (Jenkins health and performance dashboard,


### PR DESCRIPTION
Reverts jenkinsci/opentelemetry-plugin#553 because we're reverting the core PR.