### PR TITLE
Fix instrumentation name (ie logger.name) in OTel logs

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/OpenTelemetrySdkProvider.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/OpenTelemetrySdkProvider.java
@@ -18,6 +18,7 @@ import io.opentelemetry.api.events.EventEmitter;
 import io.opentelemetry.api.events.EventEmitterProvider;
 import io.opentelemetry.api.events.GlobalEventEmitterProvider;
 import io.opentelemetry.api.logs.GlobalLoggerProvider;
+import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.Tracer;
@@ -54,7 +55,7 @@ public class OpenTelemetrySdkProvider {
     protected transient Meter meter;
     protected transient Resource resource;
     protected transient ConfigProperties config;
-    protected transient io.opentelemetry.api.logs.Logger otelLogger;
+    protected transient LoggerProvider loggerProvider;
     protected transient EventEmitter eventEmitter;
 
     public OpenTelemetrySdkProvider() {
@@ -92,8 +93,8 @@ public class OpenTelemetrySdkProvider {
     }
 
     @Nonnull
-    public io.opentelemetry.api.logs.Logger getOtelLogger() {
-        return Preconditions.checkNotNull(this.otelLogger);
+    public LoggerProvider getLoggerProvider() {
+        return Preconditions.checkNotNull(this.loggerProvider);
     }
 
     @Nonnull
@@ -133,7 +134,7 @@ public class OpenTelemetrySdkProvider {
         }
         LOGGER.log(Level.FINE, () -> "Initialize Otel SDK on components: " + ExtensionList.lookup(OtelComponent.class).stream().sorted().map(e -> e.getClass().getName()).collect(Collectors.joining(", ")));
         ExtensionList.lookup(OtelComponent.class).stream().sorted().forEachOrdered(otelComponent -> {
-            otelComponent.afterSdkInitialized(meter, otelLogger, eventEmitter, tracer, config);
+            otelComponent.afterSdkInitialized(meter, loggerProvider, eventEmitter, tracer, config);
             otelComponent.afterSdkInitialized(openTelemetry, config);
         });
     }
@@ -170,10 +171,7 @@ public class OpenTelemetrySdkProvider {
             .meterBuilder(GlobalOpenTelemetrySdk.INSTRUMENTATION_NAME)
             .setInstrumentationVersion(opentelemetryPluginVersion)
             .build();
-        this.otelLogger = openTelemetrySdk.getSdkLoggerProvider()
-            .loggerBuilder(GlobalOpenTelemetrySdk.INSTRUMENTATION_NAME)
-            .setInstrumentationVersion(opentelemetryPluginVersion)
-            .build();
+        this.loggerProvider = openTelemetrySdk.getSdkLoggerProvider();
         this.eventEmitter = GlobalEventEmitterProvider.get()
             .eventEmitterBuilder(GlobalOpenTelemetrySdk.INSTRUMENTATION_NAME)
             .setInstrumentationVersion(opentelemetryPluginVersion)
@@ -197,7 +195,7 @@ public class OpenTelemetrySdkProvider {
         GlobalOpenTelemetry.set(OpenTelemetry.noop());
         this.tracer.setDelegate(OpenTelemetry.noop().getTracer(GlobalOpenTelemetrySdk.INSTRUMENTATION_NAME));
         this.meter = OpenTelemetry.noop().getMeter(GlobalOpenTelemetrySdk.INSTRUMENTATION_NAME);
-        this.otelLogger = SdkLoggerProvider.builder().build().get(GlobalOpenTelemetrySdk.INSTRUMENTATION_NAME);
+        this.loggerProvider = SdkLoggerProvider.builder().build();
         this.eventEmitter = EventEmitterProvider.noop().get(GlobalOpenTelemetrySdk.INSTRUMENTATION_NAME);
         LOGGER.log(Level.FINE, "OpenTelemetry initialized as NoOp");
     }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/OtelComponent.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/OtelComponent.java
@@ -7,6 +7,7 @@ package io.jenkins.plugins.opentelemetry;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.events.EventEmitter;
+import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.ObservableLongCounter;
 import io.opentelemetry.api.metrics.ObservableLongUpDownCounter;
@@ -31,12 +32,12 @@ public interface OtelComponent extends Comparable<OtelComponent>{
      * plugin takes care of this  (eg {@link ObservableLongUpDownCounter}, {@link ObservableLongCounter}...)
      *
      * @param meter            {@link Meter} of the newly initialized Otel SDK
-     * @param otelLogger       {@link io.opentelemetry.api.logs.Logger} of the newly initialized Otel SDK
+     * @param loggerProvider   {@link io.opentelemetry.api.logs.Logger} of the newly initialized Otel SDK
      * @param eventEmitter
      * @param tracer           {@link Tracer} of the newly initialized Otel SDK
      * @param configProperties {@link ConfigProperties} of the newly initialized Otel SDK
      */
-    default void afterSdkInitialized(Meter meter, io.opentelemetry.api.logs.Logger otelLogger, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {}
+    default void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {}
 
     /**
      * Invoked soon after the Otel SDK has been initialized.

--- a/src/main/java/io/jenkins/plugins/opentelemetry/computer/MonitoringCloudListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/computer/MonitoringCloudListener.java
@@ -13,6 +13,7 @@ import hudson.slaves.NodeProvisioner;
 import io.jenkins.plugins.opentelemetry.OtelComponent;
 import io.jenkins.plugins.opentelemetry.semconv.JenkinsSemanticMetrics;
 import io.opentelemetry.api.events.EventEmitter;
+import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Tracer;
@@ -30,7 +31,7 @@ public class MonitoringCloudListener extends CloudProvisioningListener implement
     private LongCounter totalCloudCount;
 
     @Override
-    public void afterSdkInitialized(Meter meter, io.opentelemetry.api.logs.Logger otelLogger, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
+    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
         failureCloudCounter = meter.counterBuilder(JenkinsSemanticMetrics.JENKINS_CLOUD_AGENTS_FAILURE)
             .setDescription("Number of failed cloud agents when provisioning")
             .setUnit("1")

--- a/src/main/java/io/jenkins/plugins/opentelemetry/computer/MonitoringComputerListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/computer/MonitoringComputerListener.java
@@ -17,6 +17,7 @@ import io.jenkins.plugins.opentelemetry.semconv.JenkinsOtelSemanticAttributes;
 import io.jenkins.plugins.opentelemetry.semconv.JenkinsSemanticMetrics;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.events.EventEmitter;
+import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Tracer;
@@ -41,7 +42,7 @@ public class MonitoringComputerListener extends ComputerListener implements Otel
     private LongCounter failureAgentCounter;
 
     @Override
-    public void afterSdkInitialized(Meter meter, io.opentelemetry.api.logs.Logger otelLogger, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
+    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
         final Jenkins jenkins = Jenkins.get();
         Computer controllerComputer = jenkins.getComputer("");
         if (controllerComputer == null) {

--- a/src/main/java/io/jenkins/plugins/opentelemetry/init/DiskUsageMonitoringInitializer.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/init/DiskUsageMonitoringInitializer.java
@@ -11,6 +11,7 @@ import hudson.Extension;
 import io.jenkins.plugins.opentelemetry.OtelComponent;
 import io.jenkins.plugins.opentelemetry.semconv.JenkinsSemanticMetrics;
 import io.opentelemetry.api.events.EventEmitter;
+import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
@@ -38,7 +39,7 @@ public class DiskUsageMonitoringInitializer implements OtelComponent {
     protected QuickDiskUsagePlugin quickDiskUsagePlugin;
 
     @Override
-    public void afterSdkInitialized(Meter meter, io.opentelemetry.api.logs.Logger otelLogger, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
+    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
             meter.gaugeBuilder(JenkinsSemanticMetrics.JENKINS_DISK_USAGE_BYTES)
                 .ofLongs()
                 .setDescription("Disk usage of first level folder in JENKINS_HOME.")

--- a/src/main/java/io/jenkins/plugins/opentelemetry/init/GitHubClientMonitoring.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/init/GitHubClientMonitoring.java
@@ -11,6 +11,7 @@ import io.jenkins.plugins.opentelemetry.OtelComponent;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.events.EventEmitter;
+import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
@@ -86,7 +87,7 @@ public class GitHubClientMonitoring implements OtelComponent {
     }
 
     @Override
-    public void afterSdkInitialized(Meter meter, io.opentelemetry.api.logs.Logger otelLogger, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
+    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
             meter.gaugeBuilder(GITHUB_API_RATE_LIMIT_REMAINING_REQUESTS)
                 .ofLongs()
                 .setDescription("GitHub Repository API rate limit remaining requests")

--- a/src/main/java/io/jenkins/plugins/opentelemetry/init/JenkinsExecutorMonitoringInitializer.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/init/JenkinsExecutorMonitoringInitializer.java
@@ -11,7 +11,7 @@ import io.jenkins.plugins.opentelemetry.OtelComponent;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.events.EventEmitter;
-import io.opentelemetry.api.logs.Logger;
+import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.ObservableLongMeasurement;
 import io.opentelemetry.api.trace.Tracer;
@@ -25,7 +25,7 @@ import static io.jenkins.plugins.opentelemetry.semconv.JenkinsSemanticMetrics.*;
 public class JenkinsExecutorMonitoringInitializer implements OtelComponent {
 
     @Override
-    public void afterSdkInitialized(Meter meter, Logger otelLogger, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
+    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
 
         final ObservableLongMeasurement availableExecutors = meter.gaugeBuilder(JENKINS_EXECUTOR_AVAILABLE).setUnit("1").setDescription("Available executors").ofLongs().buildObserver();
         final ObservableLongMeasurement busyExecutors = meter.gaugeBuilder(JENKINS_EXECUTOR_BUSY).setUnit("1").setDescription("Busy executors").ofLongs().buildObserver();

--- a/src/main/java/io/jenkins/plugins/opentelemetry/init/OtelJulHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/init/OtelJulHandler.java
@@ -63,7 +63,6 @@ public class OtelJulHandler extends Handler implements OtelComponent {
      * <ul>
      *   <li>Fully qualified class name - {@link LogRecord#getSourceClassName()}
      *   <li>Fully qualified method name - {@link LogRecord#getSourceMethodName()}
-     *   <li>Thread id - {@link LogRecord#getThreadID()}
      * </ul>
      */
     @Override
@@ -76,7 +75,6 @@ public class OtelJulHandler extends Handler implements OtelComponent {
             if (instrumentationName == null || instrumentationName.isEmpty()) {
                 instrumentationName = "ROOT";
             }
-            // TODO set instrumentationScope / logger.name
             LogRecordBuilder logBuilder = loggerProvider.get(instrumentationName).logRecordBuilder();
             // message
             String message = FORMATTER.formatMessage(logRecord);

--- a/src/main/java/io/jenkins/plugins/opentelemetry/init/SCMEventMonitoringInitializer.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/init/SCMEventMonitoringInitializer.java
@@ -9,6 +9,7 @@ import hudson.Extension;
 import io.jenkins.plugins.opentelemetry.OtelComponent;
 import io.jenkins.plugins.opentelemetry.semconv.JenkinsSemanticMetrics;
 import io.opentelemetry.api.events.EventEmitter;
+import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
@@ -27,7 +28,7 @@ public class SCMEventMonitoringInitializer implements OtelComponent {
     private final static Logger logger = Logger.getLogger(SCMEventMonitoringInitializer.class.getName());
 
     @Override
-    public void afterSdkInitialized(Meter meter, io.opentelemetry.api.logs.Logger otelLogger, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
+    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
 
             meter.counterBuilder(JenkinsSemanticMetrics.JENKINS_SCM_EVENT_POOL_SIZE)
                 .setDescription("Number of threads handling SCM Events")

--- a/src/main/java/io/jenkins/plugins/opentelemetry/init/ServletFilterInitializer.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/init/ServletFilterInitializer.java
@@ -11,6 +11,7 @@ import io.jenkins.plugins.opentelemetry.OtelComponent;
 import io.jenkins.plugins.opentelemetry.semconv.JenkinsOtelSemanticAttributes;
 import io.jenkins.plugins.opentelemetry.servlet.OpenTelemetryServletFilter;
 import io.opentelemetry.api.events.EventEmitter;
+import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
@@ -33,7 +34,7 @@ public class ServletFilterInitializer implements OtelComponent {
 
     OpenTelemetryServletFilter openTelemetryServletFilter;
     @Override
-    public void afterSdkInitialized(Meter meter, io.opentelemetry.api.logs.Logger otelLogger, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
+    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
 
         // TODO support live reload of the config flag
         boolean jenkinsWebInstrumentationEnabled = Optional.ofNullable(configProperties.getBoolean(JenkinsOtelSemanticAttributes.OTEL_INSTRUMENTATION_JENKINS_WEB_ENABLED)).orElse(true);

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringBuildStepListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringBuildStepListener.java
@@ -17,6 +17,7 @@ import io.jenkins.plugins.opentelemetry.OtelComponent;
 import io.jenkins.plugins.opentelemetry.OtelUtils;
 import io.jenkins.plugins.opentelemetry.semconv.JenkinsOtelSemanticAttributes;
 import io.opentelemetry.api.events.EventEmitter;
+import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
@@ -128,7 +129,7 @@ public class MonitoringBuildStepListener extends BuildStepListener implements Ot
     }
 
     @Override
-    public void afterSdkInitialized(Meter meter, io.opentelemetry.api.logs.Logger otelLogger, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
+    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
         this.tracer = tracer;
     }
 

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
@@ -23,6 +23,7 @@ import io.jenkins.plugins.opentelemetry.job.step.WithSpanAttributeStep;
 import io.jenkins.plugins.opentelemetry.semconv.JenkinsOtelSemanticAttributes;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.events.EventEmitter;
+import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
@@ -402,7 +403,7 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
     }
 
     @Override
-    public void afterSdkInitialized(Meter meter, io.opentelemetry.api.logs.Logger otelLogger, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
+    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
         this.tracer = tracer;
         LOGGER.log(Level.FINE, () -> "Start monitoring Jenkins pipeline executions...");
     }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringRunListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringRunListener.java
@@ -26,6 +26,7 @@ import io.jenkins.plugins.opentelemetry.job.runhandler.RunHandler;
 import io.jenkins.plugins.opentelemetry.semconv.JenkinsOtelSemanticAttributes;
 import io.jenkins.plugins.opentelemetry.semconv.JenkinsSemanticMetrics;
 import io.opentelemetry.api.events.EventEmitter;
+import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Span;
@@ -86,8 +87,8 @@ public class MonitoringRunListener extends OtelContextAwareAbstractRunListener {
     }
 
     @Override
-    public void afterSdkInitialized(Meter meter, io.opentelemetry.api.logs.Logger otelLogger, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
-        super.afterSdkInitialized(meter, otelLogger, eventEmitter, tracer, configProperties);
+    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
+        super.afterSdkInitialized(meter, loggerProvider, eventEmitter, tracer, configProperties);
 
         // CAUSE HANDLERS
         List<CauseHandler> causeHandlers = new ArrayList(ExtensionList.lookup(CauseHandler.class));

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelTraceService.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelTraceService.java
@@ -16,6 +16,7 @@ import hudson.model.Run;
 import hudson.tasks.BuildStep;
 import io.jenkins.plugins.opentelemetry.OtelComponent;
 import io.opentelemetry.api.events.EventEmitter;
+import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
@@ -324,7 +325,7 @@ public class OtelTraceService implements OtelComponent {
     }
 
     @Override
-    public void afterSdkInitialized(Meter meter, io.opentelemetry.api.logs.Logger otelLogger, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
+    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
         this.tracer = tracer;
     }
 

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/log/OtelLogSenderBuildListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/log/OtelLogSenderBuildListener.java
@@ -104,7 +104,7 @@ abstract class OtelLogSenderBuildListener implements BuildListener {
         @Override
         public io.opentelemetry.api.logs.Logger getOtelLogger() {
             JenkinsJVM.checkJenkinsJVM();
-            return OpenTelemetrySdkProvider.get().getOtelLogger();
+            return OpenTelemetrySdkProvider.get().getLoggerProvider().get(GlobalOpenTelemetrySdk.INSTRUMENTATION_NAME);
         }
 
         /**

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/log/OtelLogStorageFactory.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/log/OtelLogStorageFactory.java
@@ -13,6 +13,7 @@ import io.jenkins.plugins.opentelemetry.OpenTelemetrySdkProvider;
 import io.jenkins.plugins.opentelemetry.OtelComponent;
 import io.jenkins.plugins.opentelemetry.job.MonitoringAction;
 import io.opentelemetry.api.events.EventEmitter;
+import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
@@ -97,7 +98,7 @@ public final class OtelLogStorageFactory implements LogStorageFactory, OtelCompo
     }
 
     @Override
-    public void afterSdkInitialized(Meter meter, io.opentelemetry.api.logs.Logger otelLogger, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
+    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
         this.tracer = tracer;
     }
 }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/opentelemetry/OtelContextAwareAbstractRunListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/opentelemetry/OtelContextAwareAbstractRunListener.java
@@ -12,6 +12,7 @@ import hudson.model.listeners.RunListener;
 import io.jenkins.plugins.opentelemetry.OtelComponent;
 import io.jenkins.plugins.opentelemetry.job.OtelTraceService;
 import io.opentelemetry.api.events.EventEmitter;
+import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
@@ -40,7 +41,7 @@ public abstract class OtelContextAwareAbstractRunListener extends RunListener<Ru
     }
 
     @Override
-    public void afterSdkInitialized(Meter meter, io.opentelemetry.api.logs.Logger otelLogger, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
+    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
         this.tracer = tracer;
     }
 

--- a/src/main/java/io/jenkins/plugins/opentelemetry/queue/MonitoringQueueListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/queue/MonitoringQueueListener.java
@@ -11,6 +11,7 @@ import hudson.model.queue.QueueListener;
 import io.jenkins.plugins.opentelemetry.OtelComponent;
 import io.jenkins.plugins.opentelemetry.semconv.JenkinsSemanticMetrics;
 import io.opentelemetry.api.events.EventEmitter;
+import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Tracer;
@@ -36,7 +37,7 @@ public class MonitoringQueueListener extends QueueListener implements OtelCompon
     private LongCounter timeInQueueInMillisCounter;
 
     @Override
-    public void afterSdkInitialized(Meter meter, io.opentelemetry.api.logs.Logger otelLogger, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
+    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
 
             meter.gaugeBuilder(JenkinsSemanticMetrics.JENKINS_QUEUE_WAITING)
                 .ofLongs()

--- a/src/main/java/io/jenkins/plugins/opentelemetry/security/AuditingSecurityListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/security/AuditingSecurityListener.java
@@ -14,6 +14,7 @@ import io.jenkins.plugins.opentelemetry.semconv.JenkinsSemanticMetrics;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.events.EventEmitter;
+import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Tracer;
@@ -49,7 +50,7 @@ public class AuditingSecurityListener extends SecurityListener implements OtelCo
     private EventEmitter eventEmitter;
 
     @Override
-    public void afterSdkInitialized(Meter meter, io.opentelemetry.api.logs.Logger otelLogger, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
+    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
         this.eventEmitter = eventEmitter;
 
         loginSuccessCounter =


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Fix instrumentation name (ie logger.name) in OTel logs.

Requires to change the signature of `io.jenkins.plugins.opentelemetry.OtelComponent#afterSdkInitialized(...)`


- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
