### PR TITLE
feat: enable keep alive

### DIFF
--- a/docs/setup-and-configuration.md
+++ b/docs/setup-and-configuration.md
@@ -184,3 +184,21 @@ When specifying configuration parameters mixing environment variables, system pr
 Note that the key-value pairs of the `OTEL_RESOURCE_ATTRIBUTES` attributes are merged across all the layers of settings.
 
 All the system properties and environment variables of the [OpenTelemetry SDK Auto Configuration Extension](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md) (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_METRICS_EXPORTER`, `OTEL_LOGS_EXPORTER`, `OTEL_RESOURCE_ATTRIBUTES`...) are supported at the exception to the settings of Zipkin exporter which is not included.
+
+## TCP Keepalive
+
+TCP Keepalive is enabled by default in the Elasticsearch connections, a keepalive is sent every 30 seconds.
+It is possible to change this behaviout by using system properties.
+To disable keepalive, set `io.jenkins.plugins.opentelemetry.backend.elastic.keepAlive.enabled` to `false`, to change the keepalive interval, set `io.jenkins.plugins.opentelemetry.backend.elastic.keepAlive.interval` to the desired value in miliseconds.
+
+The following command disables the keepalive
+
+```shell
+java -Dio.jenkins.plugins.opentelemetry.backend.elastic.keepAlive.enabled=false -jar jenkins.war
+```
+
+The following command changes the keepalive interval to 10 seconds
+
+```shell
+java -Dio.jenkins.plugins.opentelemetry.backend.elastic.keepAlive.interval=10000 -jar jenkins.war
+```

--- a/docs/setup-and-configuration.md
+++ b/docs/setup-and-configuration.md
@@ -189,16 +189,16 @@ All the system properties and environment variables of the [OpenTelemetry SDK Au
 
 TCP Keepalive is enabled by default in the Elasticsearch connections, a keepalive is sent every 30 seconds.
 It is possible to change this behaviout by using system properties.
-To disable keepalive, set `io.jenkins.plugins.opentelemetry.backend.elastic.keepAlive.enabled` to `false`, to change the keepalive interval, set `io.jenkins.plugins.opentelemetry.backend.elastic.keepAlive.interval` to the desired value in miliseconds.
+To disable keepalive, set `io.jenkins.plugins.opentelemetry.backend.elastic.ElasticsearchLogStorageRetriever.keepAlive.enabled` to `false`, to change the keepalive interval, set `io.jenkins.plugins.opentelemetry.backend.ElasticsearchLogStorageRetriever.elastic.keepAlive.interval` to the desired value in miliseconds.
 
 The following command disables the keepalive
 
 ```shell
-java -Dio.jenkins.plugins.opentelemetry.backend.elastic.keepAlive.enabled=false -jar jenkins.war
+java -Dio.jenkins.plugins.opentelemetry.backend.elastic.ElasticsearchLogStorageRetriever.keepAlive.enabled=false -jar jenkins.war
 ```
 
 The following command changes the keepalive interval to 10 seconds
 
 ```shell
-java -Dio.jenkins.plugins.opentelemetry.backend.elastic.keepAlive.interval=10000 -jar jenkins.war
+java -Dio.jenkins.plugins.opentelemetry.backend.elastic.ElasticsearchLogStorageRetriever.keepAlive.interval=10000 -jar jenkins.war
 ```


### PR DESCRIPTION
The following PR enables keepalive in the Elasticsearch connections, by default a keepalive package is sent every 30 seconds. Check the docs to know how to configure the keepalive behavior.

related to https://github.com/jenkinsci/opentelemetry-plugin/issues/649
related to https://github.com/elastic/elasticsearch/issues/65213