### PR TITLE
Fix regression: implement getLogsBridge()

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/opentelemetry/ClosingOpenTelemetry.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/opentelemetry/ClosingOpenTelemetry.java
@@ -7,6 +7,7 @@ package io.jenkins.plugins.opentelemetry.opentelemetry;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.*;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerBuilder;
@@ -84,6 +85,11 @@ public class ClosingOpenTelemetry implements OpenTelemetry, Closeable {
     @Override
     public Meter getMeter(String instrumentationScopeName) {
         return new ClosingMeter(delegate.getMeter(instrumentationScopeName));
+    }
+
+    @Override
+    public LoggerProvider getLogsBridge() {
+        return delegate.getLogsBridge();
     }
 
     @Override


### PR DESCRIPTION
Fix regression: `ClosingOpenTelemetry must implement `getLogsBridge()`.

Regression introduced in https://github.com/jenkinsci/opentelemetry-plugin/commit/bac35b6a3b5c16466d3112d967fc799e03b4f386


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
