### PR TITLE
Don't add a null attribute if Jenkins can't resolve Computer host name

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
@@ -348,10 +348,15 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
                 return;
             }
             if (computer.getAction(OpenTelemetryAttributesAction.class) == null) {
-                LOGGER.log(Level.WARNING, "Unexpected missing " + OpenTelemetryAttributesAction.class + " on " + computer + " fallback");
+                LOGGER.log(Level.WARNING, "Unexpected missing " + OpenTelemetryAttributesAction.class + " on " + computer + ", adding fallback");
                 String hostName = computer.getHostName();
                 OpenTelemetryAttributesAction openTelemetryAttributesAction = new OpenTelemetryAttributesAction();
-                openTelemetryAttributesAction.getAttributes().put(ResourceAttributes.HOST_NAME, hostName);
+                if (hostName != null) {
+                    // getHostName() returns null if the master cannot find the host name, e.g. due to network settings.
+                    // @see hudson.model.Computer#getHostName()
+                    openTelemetryAttributesAction.getAttributes().put(ResourceAttributes.HOST_NAME, hostName);
+                }
+                openTelemetryAttributesAction.getAttributes().put(AttributeKey.stringKey(JenkinsOtelSemanticAttributes.JENKINS_COMPUTER_NAME.getKey()), computer.getName());
                 computer.addAction(openTelemetryAttributesAction);
             }
             OpenTelemetryAttributesAction openTelemetryAttributesAction = computer.getAction(OpenTelemetryAttributesAction.class);


### PR DESCRIPTION
I've observed an error while testing using `mvn hpi:run` in a somewhat unusual network setup. It seems that Jenkins was unable to resolve a hostname for an agent in `Computer.getHostName`, and returned null. [This possibility is documented in the API](https://javadoc.jenkins.io/hudson/model/Computer.html#getHostName()).

This was attached as a span attribute, even though [attributes may not be `null`](https://opentelemetry.io/docs/concepts/signals/traces/#attributes), which caused an Exception.

Unfortunately I did not keep a copy of the exception I saw in the log listener I had attached to opentelemetry plugin, and I would rather not roll back (`mvn hpi:run` is very slow for me). I hope the two links above make the situation clear enough to accept the change regardless.

### Testing done

Testing was done with `mvn hpi:run`, configuring the plugin, and running a build.
Without this change, an error occurred.
With this change, the error no longer occurred.
I'm not sure how a testcase could be implemented, because I don't know how to force Jenkins to create a Computer with unresolvable hostname.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
