### PR TITLE
chore: group dependency updates for opentelemetry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      otel-dependencies:
+        patterns:
+            - "io.opentelemetry*"
+            - "opentelemetry*"


### PR DESCRIPTION
The Opentelemtry updates has interdependencies, the PRs open by dependabot ussually failed because of that. This change group all opentelemetry updates in a single PR.