### PR TITLE
feat: enable releases from GitHub

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,7 @@ updates:
         patterns:
             - "io.opentelemetry*"
             - "opentelemetry*"
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+        interval: monthly

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,19 @@
+# Note: additional setup is required, see https://www.jenkins.io/redirect/continuous-delivery-of-plugins
+
+name: cd
+on:
+  workflow_dispatch:
+  check_run:
+    types:
+      - completed
+
+permissions:
+  checks: read
+  contents: write
+
+jobs:
+  maven-cd:
+    uses: jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml@v1
+    secrets:
+      MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+      MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,3 @@
 -Pconsume-incrementals
 -Pmight-produce-incrementals
+-Dchangelist.format=%d.v%s

--- a/pom.xml
+++ b/pom.xml
@@ -14,11 +14,11 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>opentelemetry</artifactId>
-    <version>${revision}${changelist}</version>
+    <version>${revision}.${changelist}</version>
     <packaging>hpi</packaging>
     <properties>
-        <revision>2.19.1</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <revision>2</revision>
+        <changelist>999999-SNAPSHOT</changelist>
         <jenkins.version>2.401.3</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <opentelemetry.version>1.33.0</opentelemetry.version>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <version>${revision}.${changelist}</version>
     <packaging>hpi</packaging>
     <properties>
-        <revision>2</revision>
+        <revision>3</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <jenkins.version>2.401.3</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>


### PR DESCRIPTION
Allow to make automatic releases directly from GitHub Actions

https://www.jenkins.io/doc/developer/publishing/releasing-cd/

related to https://github.com/jenkins-infra/repository-permissions-updater/pull/3720 and https://github.com/jenkins-infra/repository-permissions-updater/pull/3719/