### PR TITLE
Bump OTel dependencies & Add GCP Resource Detector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,13 +21,10 @@
         <changelist>999999-SNAPSHOT</changelist>
         <jenkins.version>2.401.3</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <opentelemetry.version>1.36.0</opentelemetry.version>
-        <!--
-        Don't forget to bump opentelemetry-resources
-        -->
-        <opentelemetry-alpha.version>1.36.0-alpha</opentelemetry-alpha.version>
-        <opentelemetry-instrumentation-alpha.version>1.33.0-alpha</opentelemetry-instrumentation-alpha.version>
-        <opentelemetry-contrib.version>1.33.0-alpha</opentelemetry-contrib.version>
+        <opentelemetry.version>1.38.0</opentelemetry.version>
+        <opentelemetry-alpha.version>1.38.0-alpha</opentelemetry-alpha.version>
+        <opentelemetry-instrumentation-alpha.version>2.4.0-alpha</opentelemetry-instrumentation-alpha.version>
+        <opentelemetry-contrib.version>1.36.0-alpha</opentelemetry-contrib.version>
         <opentelemetry-semconv>1.25.0-alpha</opentelemetry-semconv>
         <useBeta>true</useBeta>
         <elasticstack.version>8.13.4</elasticstack.version>
@@ -89,7 +86,7 @@
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-api-events</artifactId>
+            <artifactId>opentelemetry-api-incubator</artifactId>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,18 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>io.opentelemetry.contrib</groupId>
+            <artifactId>opentelemetry-gcp-resources</artifactId>
+            <version>${opentelemetry-contrib.version}</version>
+            <exclusions>
+                <exclusion>
+                    <!-- we get okhttp from org.jenkins-ci.plugins:jackson2-api -->
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-otlp</artifactId>
             <exclusions>

--- a/src/main/java/io/jenkins/plugins/opentelemetry/OtelComponent.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/OtelComponent.java
@@ -6,7 +6,7 @@
 package io.jenkins.plugins.opentelemetry;
 
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.api.events.EventEmitter;
+import io.opentelemetry.api.incubator.events.EventLogger;
 import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.ObservableLongCounter;
@@ -33,11 +33,11 @@ public interface OtelComponent extends Comparable<OtelComponent>{
      *
      * @param meter            {@link Meter} of the newly initialized Otel SDK
      * @param loggerProvider   {@link io.opentelemetry.api.logs.Logger} of the newly initialized Otel SDK
-     * @param eventEmitter
+     * @param eventLogger
      * @param tracer           {@link Tracer} of the newly initialized Otel SDK
      * @param configProperties {@link ConfigProperties} of the newly initialized Otel SDK
      */
-    default void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {}
+    default void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventLogger eventLogger, Tracer tracer, ConfigProperties configProperties) {}
 
     /**
      * Invoked soon after the Otel SDK has been initialized.

--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/grafana/GrafanaLogsBackend.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/grafana/GrafanaLogsBackend.java
@@ -115,11 +115,12 @@ public abstract class GrafanaLogsBackend extends AbstractDescribableImpl<Grafana
             StringWriter panesAsStringWriter = new StringWriter();
             Json.createWriter(panesAsStringWriter).writeObject(panesAsJson);
 
+            // starttime and endtime are of type java.time.Instant
             String panes = URLEncoder
                 .encode(panesAsStringWriter.toString(), StandardCharsets.UTF_8)
                 .replace(START, "${").replace(END, "}")
-                .replace("--start_time--", "${" + GrafanaBackend.TemplateBindings.START_TIME + ".minusSeconds(600).atZone(java.util.TimeZone.getDefault().toZoneId()).toInstant().toEpochMilli()" + "}")
-                .replace("--end_time--", "${" + GrafanaBackend.TemplateBindings.END_TIME + ".plusSeconds(600).atZone(java.util.TimeZone.getDefault().toZoneId()).toInstant().toEpochMilli()" + "}");
+                .replace("--start_time--", "${" + GrafanaBackend.TemplateBindings.START_TIME + ".minus(1, java.time.temporal.ChronoUnit.DAYS).atZone(java.util.TimeZone.getDefault().toZoneId()).toInstant().toEpochMilli()" + "}")
+                .replace("--end_time--", "${" + GrafanaBackend.TemplateBindings.END_TIME + ".plus(1, java.time.temporal.ChronoUnit.DAYS).atZone(java.util.TimeZone.getDefault().toZoneId()).toInstant().toEpochMilli()" + "}");
 
 
             String urlTemplate = "${" + GrafanaBackend.TemplateBindings.GRAFANA_BASE_URL + "}/" +

--- a/src/main/java/io/jenkins/plugins/opentelemetry/computer/MonitoringCloudListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/computer/MonitoringCloudListener.java
@@ -12,7 +12,7 @@ import hudson.slaves.CloudProvisioningListener;
 import hudson.slaves.NodeProvisioner;
 import io.jenkins.plugins.opentelemetry.OtelComponent;
 import io.jenkins.plugins.opentelemetry.semconv.JenkinsSemanticMetrics;
-import io.opentelemetry.api.events.EventEmitter;
+import io.opentelemetry.api.incubator.events.EventLogger;
 import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
@@ -31,7 +31,7 @@ public class MonitoringCloudListener extends CloudProvisioningListener implement
     private LongCounter totalCloudCount;
 
     @Override
-    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
+    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventLogger eventLogger, Tracer tracer, ConfigProperties configProperties) {
         failureCloudCounter = meter.counterBuilder(JenkinsSemanticMetrics.JENKINS_CLOUD_AGENTS_FAILURE)
             .setDescription("Number of failed cloud agents when provisioning")
             .setUnit("1")

--- a/src/main/java/io/jenkins/plugins/opentelemetry/computer/MonitoringComputerListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/computer/MonitoringComputerListener.java
@@ -16,7 +16,7 @@ import io.jenkins.plugins.opentelemetry.OtelComponent;
 import io.jenkins.plugins.opentelemetry.semconv.JenkinsOtelSemanticAttributes;
 import io.jenkins.plugins.opentelemetry.semconv.JenkinsSemanticMetrics;
 import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.api.events.EventEmitter;
+import io.opentelemetry.api.incubator.events.EventLogger;
 import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
@@ -42,7 +42,7 @@ public class MonitoringComputerListener extends ComputerListener implements Otel
     private LongCounter failureAgentCounter;
 
     @Override
-    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
+    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventLogger eventLogger, Tracer tracer, ConfigProperties configProperties) {
         final Jenkins jenkins = Jenkins.get();
         Computer controllerComputer = jenkins.getComputer("");
         if (controllerComputer == null) {

--- a/src/main/java/io/jenkins/plugins/opentelemetry/init/DiskUsageMonitoringInitializer.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/init/DiskUsageMonitoringInitializer.java
@@ -7,10 +7,11 @@ package io.jenkins.plugins.opentelemetry.init;
 
 import com.cloudbees.simplediskusage.DiskItem;
 import com.cloudbees.simplediskusage.QuickDiskUsagePlugin;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import io.jenkins.plugins.opentelemetry.OtelComponent;
 import io.jenkins.plugins.opentelemetry.semconv.JenkinsSemanticMetrics;
-import io.opentelemetry.api.events.EventEmitter;
+import io.opentelemetry.api.incubator.events.EventLogger;
 import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Tracer;
@@ -18,7 +19,6 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import jenkins.YesNoMaybe;
 import jenkins.model.Jenkins;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.inject.Inject;
 import java.io.IOException;
 import java.util.logging.Level;
@@ -39,7 +39,7 @@ public class DiskUsageMonitoringInitializer implements OtelComponent {
     protected QuickDiskUsagePlugin quickDiskUsagePlugin;
 
     @Override
-    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
+    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventLogger eventLogger, Tracer tracer, ConfigProperties configProperties) {
             meter.gaugeBuilder(JenkinsSemanticMetrics.JENKINS_DISK_USAGE_BYTES)
                 .ofLongs()
                 .setDescription("Disk usage of first level folder in JENKINS_HOME.")

--- a/src/main/java/io/jenkins/plugins/opentelemetry/init/GitHubClientMonitoring.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/init/GitHubClientMonitoring.java
@@ -10,7 +10,7 @@ import hudson.Extension;
 import io.jenkins.plugins.opentelemetry.OtelComponent;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
-import io.opentelemetry.api.events.EventEmitter;
+import io.opentelemetry.api.incubator.events.EventLogger;
 import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Tracer;
@@ -87,7 +87,7 @@ public class GitHubClientMonitoring implements OtelComponent {
     }
 
     @Override
-    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
+    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventLogger eventLogger, Tracer tracer, ConfigProperties configProperties) {
             meter.gaugeBuilder(GITHUB_API_RATE_LIMIT_REMAINING_REQUESTS)
                 .ofLongs()
                 .setDescription("GitHub Repository API rate limit remaining requests")

--- a/src/main/java/io/jenkins/plugins/opentelemetry/init/JenkinsExecutorMonitoringInitializer.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/init/JenkinsExecutorMonitoringInitializer.java
@@ -10,7 +10,7 @@ import hudson.model.LoadStatistics;
 import io.jenkins.plugins.opentelemetry.OtelComponent;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.events.EventEmitter;
+import io.opentelemetry.api.incubator.events.EventLogger;
 import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.ObservableLongMeasurement;
@@ -25,7 +25,7 @@ import static io.jenkins.plugins.opentelemetry.semconv.JenkinsSemanticMetrics.*;
 public class JenkinsExecutorMonitoringInitializer implements OtelComponent {
 
     @Override
-    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
+    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventLogger eventLogger, Tracer tracer, ConfigProperties configProperties) {
 
         final ObservableLongMeasurement availableExecutors = meter.gaugeBuilder(JENKINS_EXECUTOR_AVAILABLE).setUnit("1").setDescription("Available executors").ofLongs().buildObserver();
         final ObservableLongMeasurement busyExecutors = meter.gaugeBuilder(JENKINS_EXECUTOR_BUSY).setUnit("1").setDescription("Busy executors").ofLongs().buildObserver();

--- a/src/main/java/io/jenkins/plugins/opentelemetry/init/JvmMonitoringInitializer.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/init/JvmMonitoringInitializer.java
@@ -8,17 +8,12 @@ package io.jenkins.plugins.opentelemetry.init;
 import hudson.Extension;
 import io.jenkins.plugins.opentelemetry.OtelComponent;
 import io.opentelemetry.api.OpenTelemetry;
-/*
- * NOTE: in instrumentation 2.x, the following classes will suffer from the following changes:
- * - io.opentelemetry.instrumentation.runtimemetrics.java8.* -> io.opentelemetry.instrumentation.runtimemetrics.java8¡.internal.Experimental*
- * - The metrics process.runtime.jvm.* are moved to jvm.* ans some are renamed see https://github.com/open-telemetry/semantic-conventions/issues/42 and related issues
- */
-import io.opentelemetry.instrumentation.runtimemetrics.java8.BufferPools;
 import io.opentelemetry.instrumentation.runtimemetrics.java8.Classes;
 import io.opentelemetry.instrumentation.runtimemetrics.java8.Cpu;
 import io.opentelemetry.instrumentation.runtimemetrics.java8.GarbageCollector;
 import io.opentelemetry.instrumentation.runtimemetrics.java8.MemoryPools;
 import io.opentelemetry.instrumentation.runtimemetrics.java8.Threads;
+import io.opentelemetry.instrumentation.runtimemetrics.java8.internal.ExperimentalBufferPools;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import jenkins.YesNoMaybe;
 
@@ -45,7 +40,8 @@ public class JvmMonitoringInitializer implements OtelComponent {
             return;
         }
 
-        BufferPools.registerObservers(openTelemetry);
+        // should we enable the experimental buffer pools instrumentation?
+        ExperimentalBufferPools.registerObservers(openTelemetry);
         Classes.registerObservers(openTelemetry);
         Cpu.registerObservers(openTelemetry);
         GarbageCollector.registerObservers(openTelemetry);

--- a/src/main/java/io/jenkins/plugins/opentelemetry/init/OtelJulHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/init/OtelJulHandler.java
@@ -9,7 +9,7 @@ import hudson.Extension;
 import io.jenkins.plugins.opentelemetry.OtelComponent;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
-import io.opentelemetry.api.events.EventEmitter;
+import io.opentelemetry.api.incubator.events.EventLogger;
 import io.opentelemetry.api.logs.LogRecordBuilder;
 import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.logs.Severity;
@@ -24,7 +24,11 @@ import jenkins.YesNoMaybe;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.time.Instant;
-import java.util.logging.*;
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 /**
  * Inspired by https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/v1.14.0/instrumentation/java-util-logging/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jul/JavaUtilLoggingHelper.java
@@ -167,7 +171,7 @@ public class OtelJulHandler extends Handler implements OtelComponent {
     }
 
     @Override
-    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
+    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventLogger eventLogger, Tracer tracer, ConfigProperties configProperties) {
         this.loggerProvider = loggerProvider;
         this.captureExperimentalAttributes = configProperties.getBoolean("otel.instrumentation.java-util-logging.experimental-log-attributes", false);
         if (!initialized) {

--- a/src/main/java/io/jenkins/plugins/opentelemetry/init/SCMEventMonitoringInitializer.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/init/SCMEventMonitoringInitializer.java
@@ -8,7 +8,7 @@ package io.jenkins.plugins.opentelemetry.init;
 import hudson.Extension;
 import io.jenkins.plugins.opentelemetry.OtelComponent;
 import io.jenkins.plugins.opentelemetry.semconv.JenkinsSemanticMetrics;
-import io.opentelemetry.api.events.EventEmitter;
+import io.opentelemetry.api.incubator.events.EventLogger;
 import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Tracer;
@@ -28,7 +28,7 @@ public class SCMEventMonitoringInitializer implements OtelComponent {
     private final static Logger logger = Logger.getLogger(SCMEventMonitoringInitializer.class.getName());
 
     @Override
-    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
+    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventLogger eventLogger, Tracer tracer, ConfigProperties configProperties) {
 
             meter.counterBuilder(JenkinsSemanticMetrics.JENKINS_SCM_EVENT_POOL_SIZE)
                 .setDescription("Number of threads handling SCM Events")

--- a/src/main/java/io/jenkins/plugins/opentelemetry/init/ServletFilterInitializer.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/init/ServletFilterInitializer.java
@@ -11,7 +11,7 @@ import io.jenkins.plugins.opentelemetry.OtelComponent;
 import io.jenkins.plugins.opentelemetry.semconv.JenkinsOtelSemanticAttributes;
 import io.jenkins.plugins.opentelemetry.servlet.StaplerInstrumentationServletFilter;
 import io.jenkins.plugins.opentelemetry.servlet.TraceContextServletFilter;
-import io.opentelemetry.api.events.EventEmitter;
+import io.opentelemetry.api.incubator.events.EventLogger;
 import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Tracer;
@@ -38,7 +38,7 @@ public class ServletFilterInitializer implements OtelComponent {
     TraceContextServletFilter traceContextServletFilter;
 
     @Override
-    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
+    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventLogger eventLogger, Tracer tracer, ConfigProperties configProperties) {
 
         boolean jenkinsRemoteSpanEnabled = Optional.ofNullable(configProperties.getBoolean(JenkinsOtelSemanticAttributes.OTEL_INSTRUMENTATION_JENKINS_REMOTE_SPAN_ENABLED)).orElse(false);
 

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringBuildStepListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringBuildStepListener.java
@@ -6,6 +6,7 @@
 package io.jenkins.plugins.opentelemetry.job;
 
 import com.google.errorprone.annotations.MustBeClosed;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.AbortException;
 import hudson.Extension;
 import hudson.model.AbstractBuild;
@@ -16,7 +17,7 @@ import io.jenkins.plugins.opentelemetry.JenkinsOpenTelemetryPluginConfiguration;
 import io.jenkins.plugins.opentelemetry.OtelComponent;
 import io.jenkins.plugins.opentelemetry.OtelUtils;
 import io.jenkins.plugins.opentelemetry.semconv.JenkinsOtelSemanticAttributes;
-import io.opentelemetry.api.events.EventEmitter;
+import io.opentelemetry.api.incubator.events.EventLogger;
 import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Span;
@@ -28,7 +29,6 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import jenkins.YesNoMaybe;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.inject.Inject;
 import java.util.Objects;
 import java.util.logging.Level;
@@ -130,7 +130,7 @@ public class MonitoringBuildStepListener extends BuildStepListener implements Ot
     }
 
     @Override
-    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
+    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventLogger eventLogger, Tracer tracer, ConfigProperties configProperties) {
         this.tracer = Objects.requireNonNull(tracer, "Provided tracer is null");
     }
 

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java
@@ -26,7 +26,7 @@ import io.jenkins.plugins.opentelemetry.job.step.WithSpanAttributeStep;
 import io.jenkins.plugins.opentelemetry.job.step.WithSpanAttributesStep;
 import io.jenkins.plugins.opentelemetry.semconv.JenkinsOtelSemanticAttributes;
 import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.api.events.EventEmitter;
+import io.opentelemetry.api.incubator.events.EventLogger;
 import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Span;
@@ -459,7 +459,7 @@ public class MonitoringPipelineListener extends AbstractPipelineListener impleme
     }
 
     @Override
-    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
+    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventLogger eventLogger, Tracer tracer, ConfigProperties configProperties) {
         this.tracer = tracer;
         LOGGER.log(Level.FINE, () -> "Start monitoring Jenkins pipeline executions...");
     }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringRunListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringRunListener.java
@@ -27,7 +27,7 @@ import io.jenkins.plugins.opentelemetry.job.runhandler.RunHandler;
 import io.jenkins.plugins.opentelemetry.queue.RemoteSpanAction;
 import io.jenkins.plugins.opentelemetry.semconv.JenkinsOtelSemanticAttributes;
 import io.jenkins.plugins.opentelemetry.semconv.JenkinsSemanticMetrics;
-import io.opentelemetry.api.events.EventEmitter;
+import io.opentelemetry.api.incubator.events.EventLogger;
 import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
@@ -89,8 +89,8 @@ public class MonitoringRunListener extends OtelContextAwareAbstractRunListener {
     }
 
     @Override
-    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
-        super.afterSdkInitialized(meter, loggerProvider, eventEmitter, tracer, configProperties);
+    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventLogger eventLogger, Tracer tracer, ConfigProperties configProperties) {
+        super.afterSdkInitialized(meter, loggerProvider, eventLogger, tracer, configProperties);
 
         // CAUSE HANDLERS
         List<CauseHandler> causeHandlers = new ArrayList(ExtensionList.lookup(CauseHandler.class));

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/log/OtelLogStorageFactory.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/log/OtelLogStorageFactory.java
@@ -14,7 +14,7 @@ import hudson.model.Run;
 import io.jenkins.plugins.opentelemetry.OpenTelemetrySdkProvider;
 import io.jenkins.plugins.opentelemetry.OtelComponent;
 import io.jenkins.plugins.opentelemetry.job.OtelTraceService;
-import io.opentelemetry.api.events.EventEmitter;
+import io.opentelemetry.api.incubator.events.EventLogger;
 import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Tracer;
@@ -102,7 +102,7 @@ public final class OtelLogStorageFactory implements LogStorageFactory, OtelCompo
     }
 
     @Override
-    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
+    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventLogger eventLogger, Tracer tracer, ConfigProperties configProperties) {
         this.tracer = tracer;
     }
 }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/opentelemetry/OtelContextAwareAbstractRunListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/opentelemetry/OtelContextAwareAbstractRunListener.java
@@ -7,11 +7,15 @@ package io.jenkins.plugins.opentelemetry.job.opentelemetry;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Launcher;
-import hudson.model.*;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.Environment;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
 import io.jenkins.plugins.opentelemetry.OtelComponent;
 import io.jenkins.plugins.opentelemetry.job.OtelTraceService;
-import io.opentelemetry.api.events.EventEmitter;
+import io.opentelemetry.api.incubator.events.EventLogger;
 import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Span;
@@ -40,7 +44,7 @@ public abstract class OtelContextAwareAbstractRunListener extends RunListener<Ru
     }
 
     @Override
-    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
+    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventLogger eventLogger, Tracer tracer, ConfigProperties configProperties) {
         this.tracer = tracer;
     }
 

--- a/src/main/java/io/jenkins/plugins/opentelemetry/opentelemetry/GlobalOpenTelemetrySdk.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/opentelemetry/GlobalOpenTelemetrySdk.java
@@ -9,7 +9,7 @@ import io.jenkins.plugins.opentelemetry.semconv.JenkinsOtelSemanticAttributes;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
-import io.opentelemetry.api.events.GlobalEventEmitterProvider;
+import io.opentelemetry.api.incubator.events.GlobalEventLoggerProvider;
 import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.MeterProvider;
@@ -242,7 +242,7 @@ public final class GlobalOpenTelemetrySdk {
             logger.log(Level.FINE, "Shutdown OpenTelemetry..."); // TODO dump config details
             CompletableResultCode result = openTelemetrySdk.shutdown();
             GlobalOpenTelemetry.resetForTest();
-            GlobalEventEmitterProvider.resetForTest();
+            GlobalEventLoggerProvider.resetForTest();
 
             return result;
         }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/queue/MonitoringQueueListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/queue/MonitoringQueueListener.java
@@ -12,7 +12,7 @@ import io.jenkins.plugins.opentelemetry.OpenTelemetrySdkProvider;
 import io.jenkins.plugins.opentelemetry.OtelComponent;
 import io.jenkins.plugins.opentelemetry.semconv.JenkinsOtelSemanticAttributes;
 import io.jenkins.plugins.opentelemetry.semconv.JenkinsSemanticMetrics;
-import io.opentelemetry.api.events.EventEmitter;
+import io.opentelemetry.api.incubator.events.EventLogger;
 import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
@@ -43,7 +43,7 @@ public class MonitoringQueueListener extends QueueListener implements OtelCompon
     private ConfigProperties configProperties;
 
     @Override
-    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventEmitter eventEmitter, Tracer tracer, ConfigProperties configProperties) {
+    public void afterSdkInitialized(Meter meter, LoggerProvider loggerProvider, EventLogger eventLogger, Tracer tracer, ConfigProperties configProperties) {
 
             meter.gaugeBuilder(JenkinsSemanticMetrics.JENKINS_QUEUE_WAITING)
                 .ofLongs()


### PR DESCRIPTION
1. Add GCP Resource Detector
1. Bumps the otel-dependencies group with 6 updates in the / directory:

| Package | From | To |
| --- | --- | --- |
| [io.opentelemetry:opentelemetry-bom](https://github.com/open-telemetry/opentelemetry-java) | `1.36.0` | `1.38.0` |
| [io.opentelemetry:opentelemetry-bom-alpha](https://github.com/open-telemetry/opentelemetry-java) | `1.36.0-alpha` | `1.38.0-alpha` |
| [io.opentelemetry.semconv:opentelemetry-semconv](https://github.com/open-telemetry/semantic-conventions-java) | `1.23.1-alpha` | `1.25.0-alpha` |
| [io.opentelemetry.instrumentation:opentelemetry-resources](https://github.com/open-telemetry/opentelemetry-java-instrumentation) | `1.33.0-alpha` | `2.4.0-alpha` |
| [io.opentelemetry.instrumentation:opentelemetry-runtime-telemetry-java8](https://github.com/open-telemetry/opentelemetry-java-instrumentation) | `1.33.0-alpha` | `2.4.0-alpha` |
| [io.opentelemetry.contrib:opentelemetry-aws-resources](https://github.com/open-telemetry/opentelemetry-java-contrib) | `1.33.0-alpha` | `1.36.0-alpha` |


ℹ️ Adopt the new Event API now located in `io.opentelemetry:opentelemetry-api-incubator`: `io.opentelemetry.api.events.EventEmitter`-> `io.opentelemetry.api.incubator.events.EventLogger` ...
ℹ️ Bump JVM metrics from 1.x to 2.x, there may be metric name changes

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

### Dependabot initial message

Bumps the otel-dependencies group with 6 updates in the / directory:

| Package | From | To |
| --- | --- | --- |
| [io.opentelemetry:opentelemetry-bom](https://github.com/open-telemetry/opentelemetry-java) | `1.36.0` | `1.38.0` |
| [io.opentelemetry:opentelemetry-bom-alpha](https://github.com/open-telemetry/opentelemetry-java) | `1.36.0-alpha` | `1.38.0-alpha` |
| [io.opentelemetry.semconv:opentelemetry-semconv](https://github.com/open-telemetry/semantic-conventions-java) | `1.23.1-alpha` | `1.25.0-alpha` |
| [io.opentelemetry.instrumentation:opentelemetry-resources](https://github.com/open-telemetry/opentelemetry-java-instrumentation) | `1.33.0-alpha` | `2.4.0-alpha` |
| [io.opentelemetry.instrumentation:opentelemetry-runtime-telemetry-java8](https://github.com/open-telemetry/opentelemetry-java-instrumentation) | `1.33.0-alpha` | `2.4.0-alpha` |
| [io.opentelemetry.contrib:opentelemetry-aws-resources](https://github.com/open-telemetry/opentelemetry-java-contrib) | `1.33.0-alpha` | `1.36.0-alpha` |


Updates `io.opentelemetry:opentelemetry-bom` from 1.36.0 to 1.38.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/open-telemetry/opentelemetry-java/releases">io.opentelemetry:opentelemetry-bom's releases</a>.</em></p>
<blockquote>
<h2>Version 1.38.0</h2>
<h3>API</h3>
<ul>
<li>Stabilize synchronous gauge (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6419">#6419</a>)</li>
</ul>
<h4>Incubator</h4>
<ul>
<li>Add put(AttributeKey<!-- raw HTML omitted -->, T) overload to EventBuilder (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6331">#6331</a>)</li>
</ul>
<h4>Baggage</h4>
<ul>
<li>Baggage filters space-only keys (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6431">#6431</a>)</li>
</ul>
<h3>SDK</h3>
<ul>
<li>Add experimental scope config to enable / disable scopes (i.e. meter, logger, tracer) (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6375">#6375</a>)</li>
</ul>
<h4>Traces</h4>
<ul>
<li>Add ReadableSpan#getAttributes (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6382">#6382</a>)</li>
<li>Use standard ArrayList size rather than max number of links for initial span links allocation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6252">#6252</a>)</li>
</ul>
<h4>Metrics</h4>
<ul>
<li>Use low precision Clock#now when computing timestamp for exemplars (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6417">#6417</a>)</li>
<li>Update invalid instrument name log message now that forward slash <code>/</code> is valid (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6343">#6343</a>)</li>
</ul>
<h4>Exporters</h4>
<ul>
<li>Introduce low allocation OTLP marshalers. If using autoconfigure, opt in via <code>OTEL_JAVA_EXPERIMENTAL_EXPORTER_MEMORY_MODE=REUSABLE_DATA</code>.
<ul>
<li>Low allocation OTLP logs marshaler (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6429">#6429</a>)</li>
<li>Low allocation OTLP metrics marshaler (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6422">#6422</a>)</li>
<li>Low allocation OTLP trace marshaler (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6410">#6410</a>)</li>
<li>Add memory mode support to OTLP exporters (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6430">#6430</a>)</li>
<li>Marshal span status description without allocation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6423">#6423</a>)</li>
<li>Add private constructors for stateless marshalers (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6434">#6434</a>)</li>
</ul>
</li>
<li>Mark opentelemetry-exporter-sender-jdk stable (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6357">#6357</a>)</li>
<li>PrometheusHttpServer prevent concurrent reads when reusable memory mode (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6371">#6371</a>)</li>
<li>Ignore TLS components (SSLContext, TrustManager, KeyManager) if plain HTTP protocol is used for exporting (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6329">#6329</a>)</li>
<li>Add is_remote_parent span flags to OTLP exported Spans and SpanLinks (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6388">#6388</a>)</li>
<li>Add missing fields to OTLP metric exporters <code>toString()</code> (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6402">#6402</a>)</li>
</ul>
<h4>Extensions</h4>
<ul>
<li>Rename otel.config.file to otel.experimental.config.file for autoconfigure (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6396">#6396</a>)</li>
</ul>
<h3>OpenCensus Shim</h3>
<ul>
<li>Fix opencensus shim spanBuilderWithRemoteParent behavior (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6415">#6415</a>)</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/open-telemetry/opentelemetry-java/blob/main/CHANGELOG.md">io.opentelemetry:opentelemetry-bom's changelog</a>.</em></p>
<blockquote>
<h2>Version 1.38.0 (2024-05-10)</h2>
<h3>API</h3>
<ul>
<li>Stabilize synchronous gauge
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6419">#6419</a>)</li>
</ul>
<h4>Incubator</h4>
<ul>
<li>Add put(AttributeKey<!-- raw HTML omitted -->, T) overload to EventBuilder
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6331">#6331</a>)</li>
</ul>
<h4>Baggage</h4>
<ul>
<li>Baggage filters space-only keys
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6431">#6431</a>)</li>
</ul>
<h3>SDK</h3>
<ul>
<li>Add experimental scope config to enable / disable scopes (i.e. meter, logger, tracer)
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6375">#6375</a>)</li>
</ul>
<h4>Traces</h4>
<ul>
<li>Add ReadableSpan#getAttributes
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6382">#6382</a>)</li>
<li>Use standard ArrayList size rather than max number of links for initial span links allocation
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6252">#6252</a>)</li>
</ul>
<h4>Metrics</h4>
<ul>
<li>Use low precision Clock#now when computing timestamp for exemplars
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6417">#6417</a>)</li>
<li>Update invalid instrument name log message now that forward slash <code>/</code> is valid
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6343">#6343</a>)</li>
</ul>
<h4>Exporters</h4>
<ul>
<li>Introduce low allocation OTLP marshalers. If using autoconfigure, opt in
via <code>OTEL_JAVA_EXPERIMENTAL_EXPORTER_MEMORY_MODE=REUSABLE_DATA</code>.
<ul>
<li>Low allocation OTLP logs marshaler
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6429">#6429</a>)</li>
<li>Low allocation OTLP metrics marshaler
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6422">#6422</a>)</li>
<li>Low allocation OTLP trace marshaler
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6410">#6410</a>)</li>
<li>Add memory mode support to OTLP exporters
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6430">#6430</a>)</li>
<li>Marshal span status description without allocation
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6423">#6423</a>)</li>
</ul>
</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/open-telemetry/opentelemetry-java/commit/30d16eb3d393f85d99175a62ed246e369e25b906"><code>30d16eb</code></a> [release/v1.38.x] Prepare release 1.38.0 (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/issues/6446">#6446</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java/commit/67fcea3846eb18753935c35edd0b94e32df563df"><code>67fcea3</code></a> Prepare for 1.38.0 release (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/issues/6441">#6441</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java/commit/a855e1296eec307f8f52e90089c2edf92f4825b3"><code>a855e12</code></a> Mention branch protection ordering (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/issues/6406">#6406</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java/commit/c7d472ad367fa7140f695e9942ba4268f21f0672"><code>c7d472a</code></a> Stabilize synchronous gauge (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/issues/6419">#6419</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java/commit/ca798212a262c414efd2d729d2abe52765e0b3f5"><code>ca79821</code></a> Restrict space-only keys (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/issues/6431">#6431</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java/commit/0d2d67efe4b2bd9c75e15349adda53dafcf1f09b"><code>0d2d67e</code></a> Add memory mode support to OTLP exporters (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/issues/6430">#6430</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java/commit/715211e98b65c21a2d0ef74d8113f297ece430b0"><code>715211e</code></a> Low allocation OTLP logs marshaler (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/issues/6429">#6429</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java/commit/529730606442c0be1472e070f163e9e40c07a99f"><code>5297306</code></a> Add Lauri to approvers (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/issues/6440">#6440</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java/commit/417f82c3ca24defe833aa9ca43522d586dc464ff"><code>417f82c</code></a> Update dependency org.testcontainers:testcontainers-bom to v1.19.8 (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/issues/6437">#6437</a>)</li>
<li><a href="https://github.com/open-telemetry/opentelemetry-java/commit/af46b5e4a9824f080717e175abec884827c20b48"><code>af46b5e</code></a> change variable name (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/issues/6439">#6439</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/open-telemetry/opentelemetry-java/compare/v1.36.0...v1.38.0">compare view</a></li>
</ul>
</details>
<br />

Updates `io.opentelemetry:opentelemetry-bom-alpha` from 1.36.0-alpha to 1.38.0-alpha
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/open-telemetry/opentelemetry-java/releases">io.opentelemetry:opentelemetry-bom-alpha's releases</a>.</em></p>
<blockquote>
<h2>Version 1.37.0</h2>
<p><strong>NOTICE:</strong> This release contains a significant restructuring of the experimental event API and the API incubator artifact. Please read the notes in the <code>API -&gt; Incubator</code> section carefully.</p>
<h3>API</h3>
<ul>
<li>Promote <code>Span#addLink</code> to stable API (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6317">#6317</a>)</li>
</ul>
<h4>Incubator</h4>
<ul>
<li>BREAKING: Rename <code>opentelemetry-extension-incubator</code> to <code>opentelemetry-api-incubator</code>, merge <code>opentelemetry-api-events</code> into <code>opentelemetry-api-incubator</code>. (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6289">#6289</a>)</li>
<li>BREAKING: Remove domain from event api. <code>EventEmitterProvider#setEventDomain</code> has been removed. The <code>event.name</code> field should now be namespaced to avoid collisions. See <a href="https://opentelemetry.io/docs/specs/semconv/general/events/">Semantic Conventions for Event Attributes</a> for more details. (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6253">#6253</a>)</li>
<li>BREAKING: Rename <code>EventEmitter</code> and related classes to <code>EventLogger</code>. (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6316">#6316</a>)</li>
<li>BREAKING: Refactor Event API to reflect spec changes. Restructure API to put fields in the <code>AnyValue</code> log record body. Add setters for timestamp, context, and severity. Set default severity to <code>INFO=9</code>. (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6318">#6318</a>)</li>
</ul>
<h3>SDK</h3>
<ul>
<li>Add <code>get{Signal}Exporter</code> methods to <code>Simple{Signal}Processor</code>, <code>Batch{Signal}Processor</code>. (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6078">#6078</a>)</li>
</ul>
<h4>Metrics</h4>
<ul>
<li>Use synchronized instead of reentrant lock in explicit bucket histogram (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6309">#6309</a>)</li>
</ul>
<h4>Exporters</h4>
<ul>
<li>Fix typo in OTLP javadoc (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6311">#6311</a>)</li>
<li>Add <code>PrometheusHttpServer#toBuilder()</code> (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6333">#6333</a>)</li>
<li>Bugfix: Use <code>getPrometheusName</code> for Otel2PrometheusConverter map keys to avoid metric name conflicts (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6308">#6308</a>)</li>
</ul>
<h4>Extensions</h4>
<ul>
<li>Add Metric exporter REUSABLE_DATA memory mode configuration options, including autoconfigure support via env var <code>OTEL_JAVA_EXPERIMENTAL_EXPORTER_MEMORY_MODE=REUSABLE_DATA</code>. (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6304">#6304</a>)</li>
<li>Add autoconfigure console alias for logging exporter (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6027">#6027</a>)</li>
<li>Update jaeger autoconfigure docs to point to OTLP (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6307">#6307</a>)</li>
<li>Add <code>ServiceInstanceIdResourceProvider</code> implementation for generating <code>service.instance.id</code> UUID if not already provided by user. Included in <code>opentelemetry-sdk-extension-incubator</code>. (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6226">#6226</a>)</li>
<li>Add GCP resource detector to list of resource providers in autoconfigure docs (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6336">#6336</a>)</li>
</ul>
<h3>Tooling</h3>
<ul>
<li>Check for Java 17 toolchain and fail if not found (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6303">#6303</a>)</li>
</ul>
<h3>🙇 Thank you</h3>
<p>This release was possible thanks to the following contributors who shared their brilliant ideas and awesome pull requests:</p>
<p><a href="https://github.com/asafm"><code>@​asafm</code></a>
<a href="https://github.com/bogdandrutu"><code>@​bogdandrutu</code></a>
<a href="https://github.com/breedx-splk"><code>@​breedx-splk</code></a>
<a href="https://github.com/brunobat"><code>@​brunobat</code></a>
<a href="https://github.com/helpermethod"><code>@​helpermethod</code></a>
<a href="https://github.com/jack-berg"><code>@​jack-berg</code></a></p>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/open-telemetry/opentelemetry-java/blob/main/CHANGELOG.md">io.opentelemetry:opentelemetry-bom-alpha's changelog</a>.</em></p>
<blockquote>
<h1>Changelog</h1>
<h2>Unreleased</h2>
<h2>Version 1.38.0 (2024-05-10)</h2>
<h3>API</h3>
<ul>
<li>Stabilize synchronous gauge
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6419">#6419</a>)</li>
</ul>
<h4>Incubator</h4>
<ul>
<li>Add put(AttributeKey<!-- raw HTML omitted -->, T) overload to EventBuilder
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6331">#6331</a>)</li>
</ul>
<h4>Baggage</h4>
<ul>
<li>Baggage filters space-only keys
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6431">#6431</a>)</li>
</ul>
<h3>SDK</h3>
<ul>
<li>Add experimental scope config to enable / disable scopes (i.e. meter, logger, tracer)
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6375">#6375</a>)</li>
</ul>
<h4>Traces</h4>
<ul>
<li>Add ReadableSpan#getAttributes
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6382">#6382</a>)</li>
<li>Use standard ArrayList size rather than max number of links for initial span links allocation
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6252">#6252</a>)</li>
</ul>
<h4>Metrics</h4>
<ul>
<li>Use low precision Clock#now when computing timestamp for exemplars
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6417">#6417</a>)</li>
<li>Update invalid instrument name log message now that forward slash <code>/</code> is valid
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6343">#6343</a>)</li>
</ul>
<h4>Exporters</h4>
<ul>
<li>Introduce low allocation OTLP marshalers. If using autoconfigure, opt in
via <code>OTEL_JAVA_EXPERIMENTAL_EXPORTER_MEMORY_MODE=REUSABLE_DATA</code>.
<ul>
<li>Low allocation OTLP logs marshaler
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6429">#6429</a>)</li>
<li>Low allocation OTLP metrics marshaler
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6422">#6422</a>)</li>
<li>Low allocation OTLP trace marshaler
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java/pull/6410">#6410</a>)</li>
</ul>
</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li>See full diff in <a href="https://github.com/open-telemetry/opentelemetry-java/commits">compare view</a></li>
</ul>
</details>
<br />

Updates `io.opentelemetry.semconv:opentelemetry-semconv` from 1.23.1-alpha to 1.25.0-alpha
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/open-telemetry/semantic-conventions-java/releases">io.opentelemetry.semconv:opentelemetry-semconv's releases</a>.</em></p>
<blockquote>
<h2>Version 1.24.0</h2>
<p><strong>NOTICE:</strong> This release contains a significant restructuring of this repository and the generated classes as we evolve it towards a first stable artifact (although there is no stable artifact as of this release). Please read the notes carefully and refer to the PRs and associated issues for more details. Additionally, the <a href="https://github.com/open-telemetry/semantic-conventions-java/blob/HEAD/README.md">README</a> contains useful information that should be reviewed.</p>
<ul>
<li>BREAKING: Split out incubating artifact. This repo now publishes <code>io.opentelemetry.semconv:opentelemetry-semconv:{{version}}</code> for semantic conventions which are stable (the artifact itself is not yet stable but we aim to stabilize eventually), and <code>io.opentelemetry.semconv:opentelemetry-semconv-incubating:{{version}}</code> for semantic conventions which are incubating (experimental) (this artifact will always have the <code>-alpha</code> designation). As a part of this restructuring, old attributes which were removed from <a href="https://github.com/open-telemetry/semantic-conventions">semantic-conventions</a> (without being deprecated there) have been removed. (<a href="https://redirect.github.com/open-telemetry/semantic-conventions-java/pull/41">#41</a>)</li>
<li>BREAKING: Generate classes by root namespace. Where previously all attributes were contained in two classes, <code>ResourceAttributes</code> and <code>SemanticAttributes</code>, they are now organized by their root namespace. For example, the <code>http.request.header</code> attribute lives in <code>HttpAttributes</code>. (<a href="https://redirect.github.com/open-telemetry/semantic-conventions-java/pull/45">#45</a>)</li>
<li>Fix typo in readme (<a href="https://redirect.github.com/open-telemetry/semantic-conventions-java/pull/42">#42</a>)</li>
<li>Encode semconv version in build dir to fix build cache (<a href="https://redirect.github.com/open-telemetry/semantic-conventions-java/pull/51">#51</a>)</li>
<li>Cleanup enum generation (<a href="https://redirect.github.com/open-telemetry/semantic-conventions-java/pull/52">#52</a>)</li>
<li>Update readme to reflect new artifact strategy (<a href="https://redirect.github.com/open-telemetry/semantic-conventions-java/pull/53">#53</a>)</li>
<li>Use build-tools release 0.24.0 (<a href="https://redirect.github.com/open-telemetry/semantic-conventions-java/pull/55">#55</a>)</li>
<li>Exclude namespaces that aren't useful in jvm environments (<a href="https://redirect.github.com/open-telemetry/semantic-conventions-java/pull/54">#54</a>)</li>
<li>Update to <code>semantic-conventions</code> 1.24.0 (<a href="https://redirect.github.com/open-telemetry/semantic-conventions-java/pull/46">#46</a>)</li>
</ul>
<h3>🙇 Thank you</h3>
<p>This release was possible thanks to the following contributors who shared their brilliant ideas and awesome pull requests:</p>
<p><a href="https://github.com/arminru"><code>@​arminru</code></a>
<a href="https://github.com/breedx-splk"><code>@​breedx-splk</code></a>
<a href="https://github.com/jack-berg"><code>@​jack-berg</code></a>
<a href="https://github.com/JnRouvignac"><code>@​JnRouvignac</code></a>
<a href="https://github.com/jsuereth"><code>@​jsuereth</code></a>
<a href="https://github.com/kenfinnigan"><code>@​kenfinnigan</code></a>
<a href="https://github.com/lmolkova"><code>@​lmolkova</code></a>
<a href="https://github.com/trask"><code>@​trask</code></a></p>
</blockquote>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/open-telemetry/semantic-conventions-java/blob/main/CHANGELOG.md">io.opentelemetry.semconv:opentelemetry-semconv's changelog</a>.</em></p>
<blockquote>
<h1>Changelog</h1>
<h2>Unreleased</h2>
<h2>Version 1.25.0 (2024-04-08)</h2>
<ul>
<li>Restore and deprecate the <code>SemanticAttributes</code> and <code>ResourceAttributes</code> classes removed in 1.23.1
for easier upgrades. These will be removed prior to a stable release
of <code>io.opentelemetry.semconv:opentelemetry-semconv</code>.
(<a href="https://redirect.github.com/open-telemetry/semantic-conventions-java/pull/62">#62</a>)</li>
<li>Update to semantic-conventions 1.25.0
(<a href="https://redirect.github.com/open-telemetry/semantic-conventions-java/pull/61">#61</a>)</li>
</ul>
<h2>Version 1.24.0 (2024-03-27)</h2>
<p><strong>NOTICE:</strong> This release contains a significant restructuring of this repository and the generated
classes as we evolve it towards a first stable artifact (although there is no stable artifact as of
this release). Please read the notes carefully and refer to the PRs and associated issues for more
details. Additionally, the <a href="https://github.com/open-telemetry/semantic-conventions-java/blob/main/README.md">README</a> contains useful information that should be reviewed.</p>
<ul>
<li>BREAKING: Split out incubating artifact. This repo now
publishes <code>io.opentelemetry.semconv:opentelemetry-semconv:{{version}}</code> for semantic conventions
which are stable (the artifact itself is not yet stable but we aim to stabilize eventually),
and <code>io.opentelemetry.semconv:opentelemetry-semconv-incubating:{{version}}</code> for semantic
conventions which are incubating (experimental) (this artifact will always have the <code>-alpha</code>
designation). As a part of this restructuring, old attributes which were removed from
<a href="https://github.com/open-telemetry/semantic-conventions">semantic-conventions</a> (without being
deprecated there) have been removed.
(<a href="https://redirect.github.com/open-telemetry/semantic-conventions-java/pull/41">#41</a>)</li>
<li>BREAKING: Generate classes by root namespace. Where previously all attributes were contained in
two classes, <code>ResourceAttributes</code> and <code>SemanticAttributes</code>, they are now organized by their root
namespace. For example, the <code>http.request.header</code> attribute lives in <code>HttpAttributes</code>.
(<a href="https://redirect.github.com/open-telemetry/semantic-conventions-java/pull/45">#45</a>)</li>
<li>Fix typo in readme
(<a href="https://redirect.github.com/open-telemetry/semantic-conventions-java/pull/42">#42</a>)</li>
<li>Encode semconv version in build dir to fix build cache
(<a href="https://redirect.github.com/open-telemetry/semantic-conventions-java/pull/51">#51</a>)</li>
<li>Cleanup enum generation
(<a href="https://redirect.github.com/open-telemetry/semantic-conventions-java/pull/52">#52</a>)</li>
<li>Update readme to reflect new artifact strategy
(<a href="https://redirect.github.com/open-telemetry/semantic-conventions-java/pull/53">#53</a>)</li>
<li>Use build-tools release 0.24.0
(<a href="https://redirect.github.com/open-telemetry/semantic-conventions-java/pull/55">#55</a>)</li>
<li>Exclude namespaces that aren't useful in jvm environments
(<a href="https://redirect.github.com/open-telemetry/semantic-conventions-java/pull/54">#54</a>)</li>
<li>Update to <code>semantic-conventions</code> 1.24.0
(<a href="https://redirect.github.com/open-telemetry/semantic-conventions-java/pull/46">#46</a>)</li>
</ul>
<h2>Version 1.23.1 (2023-11-21)</h2>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li>See full diff in <a href="https://github.com/open-telemetry/semantic-conventions-java/commits">compare view</a></li>
</ul>
</details>
<br />

Updates `io.opentelemetry.instrumentation:opentelemetry-resources` from 1.33.0-alpha to 2.4.0-alpha
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases">io.opentelemetry.instrumentation:opentelemetry-resources's releases</a>.</em></p>
<blockquote>
<h2>Version 2.3.0</h2>
<p>This release targets the OpenTelemetry SDK 1.37.0.</p>
<p>Note that many artifacts have the <code>-alpha</code> suffix attached to their version number, reflecting that they are still alpha quality and will continue to have breaking changes. Please see the <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/VERSIONING.md#opentelemetry-java-instrumentation-versioning">VERSIONING.md</a> for more details.</p>
<h3>📈 Enhancements</h3>
<ul>
<li>Handle async requests in spring mvc library instrumentation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10868">#10868</a>)</li>
<li>Support statement sanitizer enabled flag in lettuce 5.1 instrumentation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10922">#10922</a>)</li>
<li>Remove AWS Active Tracing span linking (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10930">#10930</a>)</li>
<li>Make spring boot honor the standard environment variables for maps (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11000">#11000</a>)</li>
<li>Pulsar: use span links when receive telemetry is enabled (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10650">#10650</a>)</li>
<li>Rename <code>messaging.kafka.destination.partition</code> to <code>messaging.destination.partition.id</code> (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11086">#11086</a>)</li>
<li>Support <code>service.instance.id</code> in spring starter (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11071">#11071</a>)</li>
<li>Add library instrumentation for RestTemplateBuilder (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11054">#11054</a>)</li>
<li>Add cloud resource providers in spring starter (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11014">#11014</a>)</li>
</ul>
<h3>🛠️ Bug fixes</h3>
<ul>
<li>Fix disabling virtual thread context propagation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10881">#10881</a>)</li>
<li>Fix virtual thread instrumentation for jdk 21 ea versions (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10887">#10887</a>)</li>
<li>Fix spring kafka interceptor wrappers not delegating some methods (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10935">#10935</a>)</li>
<li>AWS Lambda Runtime legacy internal handlers need to be ignored from being instrumented and so traced … (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10942">#10942</a>)</li>
<li>Metro: ignore UnsupportedOperationException when updating span name (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10996">#10996</a>)</li>
<li>Fix jedis plugin for 2.7.2 (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10982">#10982</a>)</li>
<li>Fix idle in druid instrumentation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11079">#11079</a>)</li>
</ul>
<h3>🙇 Thank you</h3>
<p>This release was possible thanks to the following contributors who shared their brilliant ideas and awesome pull requests:</p>
<p><a href="https://github.com/123liuziming"><code>@​123liuziming</code></a>
<a href="https://github.com/AlchemyDing"><code>@​AlchemyDing</code></a>
<a href="https://github.com/breedx-splk"><code>@​breedx-splk</code></a>
<a href="https://github.com/cleverchuk"><code>@​cleverchuk</code></a>
<a href="https://github.com/damienburke"><code>@​damienburke</code></a>
<a href="https://github.com/huange7"><code>@​huange7</code></a>
<a href="https://github.com/itsmykairos"><code>@​itsmykairos</code></a>
<a href="https://github.com/jack-berg"><code>@​jack-berg</code></a>
<a href="https://github.com/jaydeluca"><code>@​jaydeluca</code></a>
<a href="https://github.com/jeanbisutti"><code>@​jeanbisutti</code></a>
<a href="https://github.com/johnbley"><code>@​johnbley</code></a>
<a href="https://github.com/JonasKunz"><code>@​JonasKunz</code></a>
<a href="https://github.com/laurit"><code>@​laurit</code></a>
<a href="https://github.com/Moscagus"><code>@​Moscagus</code></a>
<a href="https://github.com/phillipdriver"><code>@​phillipdriver</code></a>
<a href="https://github.com/rapphil"><code>@​rapphil</code></a>
<a href="https://github.com/robberphex"><code>@​robberphex</code></a>
<a href="https://github.com/serkan-ozal"><code>@​serkan-ozal</code></a>
<a href="https://github.com/srinivas-bode"><code>@​srinivas-bode</code></a></p>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/CHANGELOG.md">io.opentelemetry.instrumentation:opentelemetry-resources's changelog</a>.</em></p>
<blockquote>
<h1>Changelog</h1>
<h2>Unreleased</h2>
<h2>Version 1.33.3 (2024-05-21)</h2>
<h3>📈 Enhancements</h3>
<ul>
<li>Backport: Fix the logic to get container.id resource attribute
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11333">#11333</a>)</li>
<li>Backport: Update the OpenTelemetry SDK version to 1.38.0
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11386">#11386</a>)</li>
<li>Backport: Fix a bug in undertow instrumentation related to HTTP/2
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11387">#11387</a>)</li>
<li>Backport: Fix container.id issue in some crio scenarios
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11405">#11405</a>)</li>
</ul>
<h2>Version 2.4.0 (2024-05-18)</h2>
<h3>🌟 New javaagent instrumentation</h3>
<ul>
<li>InfluxDB
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10850">#10850</a>)</li>
<li>Armeria gRPC
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11351">#11351</a>)</li>
<li>Apache ShenYu
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11260">#11260</a>)</li>
</ul>
<h3>📈 Enhancements</h3>
<ul>
<li>Instrument ConnectionSource in Akka/Pekko HTTP Servers
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11103">#11103</a>)</li>
<li>Use constant span name when using Spring AMQP AnonymousQueues
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11141">#11141</a>)</li>
<li>Add support for <code>RestClient</code> in Spring starter
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11038">#11038</a>)</li>
<li>Add support for WebFlux server in Spring starter
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11185">#11185</a>)</li>
<li>Add async operation end strategy for Kotlin coroutines flow
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11168">#11168</a>)</li>
<li>Add automatic JDBC instrumentation to the Spring starter
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11258">#11258</a>)</li>
<li>Add <code>StructuredTaskScope</code> instrumentation
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11202">#11202</a>)</li>
<li>Allow reading OTel context from reactor ContextView
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11235">#11235</a>)</li>
<li>Add spring starter r2dbc support
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11221">#11221</a>)</li>
<li>Enable instrumentation of Spring EJB clients
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11104">#11104</a>)</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li>See full diff in <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commits">compare view</a></li>
</ul>
</details>
<br />

Updates `io.opentelemetry.instrumentation:opentelemetry-runtime-telemetry-java8` from 1.33.0-alpha to 2.4.0-alpha
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases">io.opentelemetry.instrumentation:opentelemetry-runtime-telemetry-java8's releases</a>.</em></p>
<blockquote>
<h2>Version 2.3.0</h2>
<p>This release targets the OpenTelemetry SDK 1.37.0.</p>
<p>Note that many artifacts have the <code>-alpha</code> suffix attached to their version number, reflecting that they are still alpha quality and will continue to have breaking changes. Please see the <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/VERSIONING.md#opentelemetry-java-instrumentation-versioning">VERSIONING.md</a> for more details.</p>
<h3>📈 Enhancements</h3>
<ul>
<li>Handle async requests in spring mvc library instrumentation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10868">#10868</a>)</li>
<li>Support statement sanitizer enabled flag in lettuce 5.1 instrumentation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10922">#10922</a>)</li>
<li>Remove AWS Active Tracing span linking (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10930">#10930</a>)</li>
<li>Make spring boot honor the standard environment variables for maps (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11000">#11000</a>)</li>
<li>Pulsar: use span links when receive telemetry is enabled (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10650">#10650</a>)</li>
<li>Rename <code>messaging.kafka.destination.partition</code> to <code>messaging.destination.partition.id</code> (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11086">#11086</a>)</li>
<li>Support <code>service.instance.id</code> in spring starter (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11071">#11071</a>)</li>
<li>Add library instrumentation for RestTemplateBuilder (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11054">#11054</a>)</li>
<li>Add cloud resource providers in spring starter (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11014">#11014</a>)</li>
</ul>
<h3>🛠️ Bug fixes</h3>
<ul>
<li>Fix disabling virtual thread context propagation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10881">#10881</a>)</li>
<li>Fix virtual thread instrumentation for jdk 21 ea versions (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10887">#10887</a>)</li>
<li>Fix spring kafka interceptor wrappers not delegating some methods (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10935">#10935</a>)</li>
<li>AWS Lambda Runtime legacy internal handlers need to be ignored from being instrumented and so traced … (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10942">#10942</a>)</li>
<li>Metro: ignore UnsupportedOperationException when updating span name (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10996">#10996</a>)</li>
<li>Fix jedis plugin for 2.7.2 (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10982">#10982</a>)</li>
<li>Fix idle in druid instrumentation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11079">#11079</a>)</li>
</ul>
<h3>🙇 Thank you</h3>
<p>This release was possible thanks to the following contributors who shared their brilliant ideas and awesome pull requests:</p>
<p><a href="https://github.com/123liuziming"><code>@​123liuziming</code></a>
<a href="https://github.com/AlchemyDing"><code>@​AlchemyDing</code></a>
<a href="https://github.com/breedx-splk"><code>@​breedx-splk</code></a>
<a href="https://github.com/cleverchuk"><code>@​cleverchuk</code></a>
<a href="https://github.com/damienburke"><code>@​damienburke</code></a>
<a href="https://github.com/huange7"><code>@​huange7</code></a>
<a href="https://github.com/itsmykairos"><code>@​itsmykairos</code></a>
<a href="https://github.com/jack-berg"><code>@​jack-berg</code></a>
<a href="https://github.com/jaydeluca"><code>@​jaydeluca</code></a>
<a href="https://github.com/jeanbisutti"><code>@​jeanbisutti</code></a>
<a href="https://github.com/johnbley"><code>@​johnbley</code></a>
<a href="https://github.com/JonasKunz"><code>@​JonasKunz</code></a>
<a href="https://github.com/laurit"><code>@​laurit</code></a>
<a href="https://github.com/Moscagus"><code>@​Moscagus</code></a>
<a href="https://github.com/phillipdriver"><code>@​phillipdriver</code></a>
<a href="https://github.com/rapphil"><code>@​rapphil</code></a>
<a href="https://github.com/robberphex"><code>@​robberphex</code></a>
<a href="https://github.com/serkan-ozal"><code>@​serkan-ozal</code></a>
<a href="https://github.com/srinivas-bode"><code>@​srinivas-bode</code></a></p>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/CHANGELOG.md">io.opentelemetry.instrumentation:opentelemetry-runtime-telemetry-java8's changelog</a>.</em></p>
<blockquote>
<h1>Changelog</h1>
<h2>Unreleased</h2>
<h2>Version 1.33.3 (2024-05-21)</h2>
<h3>📈 Enhancements</h3>
<ul>
<li>Backport: Fix the logic to get container.id resource attribute
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11333">#11333</a>)</li>
<li>Backport: Update the OpenTelemetry SDK version to 1.38.0
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11386">#11386</a>)</li>
<li>Backport: Fix a bug in undertow instrumentation related to HTTP/2
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11387">#11387</a>)</li>
<li>Backport: Fix container.id issue in some crio scenarios
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11405">#11405</a>)</li>
</ul>
<h2>Version 2.4.0 (2024-05-18)</h2>
<h3>🌟 New javaagent instrumentation</h3>
<ul>
<li>InfluxDB
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10850">#10850</a>)</li>
<li>Armeria gRPC
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11351">#11351</a>)</li>
<li>Apache ShenYu
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11260">#11260</a>)</li>
</ul>
<h3>📈 Enhancements</h3>
<ul>
<li>Instrument ConnectionSource in Akka/Pekko HTTP Servers
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11103">#11103</a>)</li>
<li>Use constant span name when using Spring AMQP AnonymousQueues
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11141">#11141</a>)</li>
<li>Add support for <code>RestClient</code> in Spring starter
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11038">#11038</a>)</li>
<li>Add support for WebFlux server in Spring starter
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11185">#11185</a>)</li>
<li>Add async operation end strategy for Kotlin coroutines flow
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11168">#11168</a>)</li>
<li>Add automatic JDBC instrumentation to the Spring starter
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11258">#11258</a>)</li>
<li>Add <code>StructuredTaskScope</code> instrumentation
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11202">#11202</a>)</li>
<li>Allow reading OTel context from reactor ContextView
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11235">#11235</a>)</li>
<li>Add spring starter r2dbc support
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11221">#11221</a>)</li>
<li>Enable instrumentation of Spring EJB clients
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11104">#11104</a>)</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li>See full diff in <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commits">compare view</a></li>
</ul>
</details>
<br />

Updates `io.opentelemetry.instrumentation:opentelemetry-runtime-telemetry-java8` from 1.33.0-alpha to 2.4.0-alpha
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases">io.opentelemetry.instrumentation:opentelemetry-runtime-telemetry-java8's releases</a>.</em></p>
<blockquote>
<h2>Version 2.3.0</h2>
<p>This release targets the OpenTelemetry SDK 1.37.0.</p>
<p>Note that many artifacts have the <code>-alpha</code> suffix attached to their version number, reflecting that they are still alpha quality and will continue to have breaking changes. Please see the <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/VERSIONING.md#opentelemetry-java-instrumentation-versioning">VERSIONING.md</a> for more details.</p>
<h3>📈 Enhancements</h3>
<ul>
<li>Handle async requests in spring mvc library instrumentation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10868">#10868</a>)</li>
<li>Support statement sanitizer enabled flag in lettuce 5.1 instrumentation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10922">#10922</a>)</li>
<li>Remove AWS Active Tracing span linking (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10930">#10930</a>)</li>
<li>Make spring boot honor the standard environment variables for maps (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11000">#11000</a>)</li>
<li>Pulsar: use span links when receive telemetry is enabled (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10650">#10650</a>)</li>
<li>Rename <code>messaging.kafka.destination.partition</code> to <code>messaging.destination.partition.id</code> (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11086">#11086</a>)</li>
<li>Support <code>service.instance.id</code> in spring starter (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11071">#11071</a>)</li>
<li>Add library instrumentation for RestTemplateBuilder (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11054">#11054</a>)</li>
<li>Add cloud resource providers in spring starter (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11014">#11014</a>)</li>
</ul>
<h3>🛠️ Bug fixes</h3>
<ul>
<li>Fix disabling virtual thread context propagation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10881">#10881</a>)</li>
<li>Fix virtual thread instrumentation for jdk 21 ea versions (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10887">#10887</a>)</li>
<li>Fix spring kafka interceptor wrappers not delegating some methods (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10935">#10935</a>)</li>
<li>AWS Lambda Runtime legacy internal handlers need to be ignored from being instrumented and so traced … (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10942">#10942</a>)</li>
<li>Metro: ignore UnsupportedOperationException when updating span name (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10996">#10996</a>)</li>
<li>Fix jedis plugin for 2.7.2 (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10982">#10982</a>)</li>
<li>Fix idle in druid instrumentation (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11079">#11079</a>)</li>
</ul>
<h3>🙇 Thank you</h3>
<p>This release was possible thanks to the following contributors who shared their brilliant ideas and awesome pull requests:</p>
<p><a href="https://github.com/123liuziming"><code>@​123liuziming</code></a>
<a href="https://github.com/AlchemyDing"><code>@​AlchemyDing</code></a>
<a href="https://github.com/breedx-splk"><code>@​breedx-splk</code></a>
<a href="https://github.com/cleverchuk"><code>@​cleverchuk</code></a>
<a href="https://github.com/damienburke"><code>@​damienburke</code></a>
<a href="https://github.com/huange7"><code>@​huange7</code></a>
<a href="https://github.com/itsmykairos"><code>@​itsmykairos</code></a>
<a href="https://github.com/jack-berg"><code>@​jack-berg</code></a>
<a href="https://github.com/jaydeluca"><code>@​jaydeluca</code></a>
<a href="https://github.com/jeanbisutti"><code>@​jeanbisutti</code></a>
<a href="https://github.com/johnbley"><code>@​johnbley</code></a>
<a href="https://github.com/JonasKunz"><code>@​JonasKunz</code></a>
<a href="https://github.com/laurit"><code>@​laurit</code></a>
<a href="https://github.com/Moscagus"><code>@​Moscagus</code></a>
<a href="https://github.com/phillipdriver"><code>@​phillipdriver</code></a>
<a href="https://github.com/rapphil"><code>@​rapphil</code></a>
<a href="https://github.com/robberphex"><code>@​robberphex</code></a>
<a href="https://github.com/serkan-ozal"><code>@​serkan-ozal</code></a>
<a href="https://github.com/srinivas-bode"><code>@​srinivas-bode</code></a></p>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/CHANGELOG.md">io.opentelemetry.instrumentation:opentelemetry-runtime-telemetry-java8's changelog</a>.</em></p>
<blockquote>
<h1>Changelog</h1>
<h2>Unreleased</h2>
<h2>Version 1.33.3 (2024-05-21)</h2>
<h3>📈 Enhancements</h3>
<ul>
<li>Backport: Fix the logic to get container.id resource attribute
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11333">#11333</a>)</li>
<li>Backport: Update the OpenTelemetry SDK version to 1.38.0
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11386">#11386</a>)</li>
<li>Backport: Fix a bug in undertow instrumentation related to HTTP/2
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11387">#11387</a>)</li>
<li>Backport: Fix container.id issue in some crio scenarios
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11405">#11405</a>)</li>
</ul>
<h2>Version 2.4.0 (2024-05-18)</h2>
<h3>🌟 New javaagent instrumentation</h3>
<ul>
<li>InfluxDB
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/10850">#10850</a>)</li>
<li>Armeria gRPC
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11351">#11351</a>)</li>
<li>Apache ShenYu
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11260">#11260</a>)</li>
</ul>
<h3>📈 Enhancements</h3>
<ul>
<li>Instrument ConnectionSource in Akka/Pekko HTTP Servers
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11103">#11103</a>)</li>
<li>Use constant span name when using Spring AMQP AnonymousQueues
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11141">#11141</a>)</li>
<li>Add support for <code>RestClient</code> in Spring starter
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11038">#11038</a>)</li>
<li>Add support for WebFlux server in Spring starter
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11185">#11185</a>)</li>
<li>Add async operation end strategy for Kotlin coroutines flow
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11168">#11168</a>)</li>
<li>Add automatic JDBC instrumentation to the Spring starter
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11258">#11258</a>)</li>
<li>Add <code>StructuredTaskScope</code> instrumentation
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11202">#11202</a>)</li>
<li>Allow reading OTel context from reactor ContextView
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11235">#11235</a>)</li>
<li>Add spring starter r2dbc support
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11221">#11221</a>)</li>
<li>Enable instrumentation of Spring EJB clients
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11104">#11104</a>)</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li>See full diff in <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/commits">compare view</a></li>
</ul>
</details>
<br />

Updates `io.opentelemetry.contrib:opentelemetry-aws-resources` from 1.33.0-alpha to 1.36.0-alpha
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/open-telemetry/opentelemetry-java-contrib/releases">io.opentelemetry.contrib:opentelemetry-aws-resources's releases</a>.</em></p>
<blockquote>
<h2>Version 1.35.0</h2>
<p>This release targets the OpenTelemetry SDK 1.35.0.</p>
<h3>JMX metrics</h3>
<ul>
<li>Add support for newly named Tomcat MBean with Spring (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-contrib/issues/1269">#1269</a>)</li>
</ul>
<h3>Span stack traces - New 🌟</h3>
<p>This module provides a SpanProcessor that captures stack traces on spans that meet a certain criteria such as exceeding a certain duration threshold.</p>
<h3>🙇 Thank you</h3>
<p>This release was possible thanks to the following contributors who shared their brilliant ideas and awesome pull requests:</p>
<p><a href="https://github.com/breedx-splk"><code>@​breedx-splk</code></a>
<a href="https://github.com/jackshirazi"><code>@​jackshirazi</code></a>
<a href="https://github.com/jkwatson"><code>@​jkwatson</code></a>
<a href="https://github.com/JonasKunz"><code>@​JonasKunz</code></a>
<a href="https://github.com/laurit"><code>@​laurit</code></a>
<a href="https://github.com/sethAmazon"><code>@​sethAmazon</code></a>
<a href="https://github.com/SylvainJuge"><code>@​SylvainJuge</code></a>
<a href="https://github.com/trask"><code>@​trask</code></a>
<a href="https://github.com/zeitlinger"><code>@​zeitlinger</code></a></p>
<h2>Version 1.34.0</h2>
<p>This release targets the OpenTelemetry SDK 1.34.0.</p>
<h3>AWS resources</h3>
<ul>
<li>Add support for <code>cloud.account.id</code>, <code>cloud.availability_zone</code>, <code>cloud.region</code>, and <code>cloud.resource_id</code> (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-contrib/pull/1171">#1171</a>)</li>
</ul>
<h3>AWS X-Ray propagator</h3>
<ul>
<li>Add xray propagators that prioritizes xray environment variable (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-contrib/pull/1032">#1032</a>)</li>
</ul>
<h3>GCP Resources</h3>
<ul>
<li>Update docs on how to use with Java agent v2.2.0 and later (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-contrib/pull/1237">#1237</a>)</li>
</ul>
<h3>Micrometer MeterProvider</h3>
<ul>
<li>Implement Metrics incubator APIs to accept advice (<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-contrib/pull/1190">#1190</a>)</li>
</ul>
<h3>🙇 Thank you</h3>
<p>This release was possible thanks to the following contributors who shared their brilliant ideas and awesome pull requests:</p>
<p><a href="https://github.com/breedx-splk"><code>@​breedx-splk</code></a>
<a href="https://github.com/HaloFour"><code>@​HaloFour</code></a></p>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/open-telemetry/opentelemetry-java-contrib/blob/main/CHANGELOG.md">io.opentelemetry.contrib:opentelemetry-aws-resources's changelog</a>.</em></p>
<blockquote>
<h1>Changelog</h1>
<h2>Unreleased</h2>
<h2>Version 1.36.0 (2024-05-29)</h2>
<h3>AWS resources</h3>
<ul>
<li>Optimization: don't attempt detection if a cloud provider has already been detected
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-contrib/pull/1225">#1225</a>)</li>
</ul>
<h3>Baggage processor - New 🌟</h3>
<p>This module provides a SpanProcessor that stamps baggage onto spans as attributes on start.</p>
<h3>Consistent sampling</h3>
<ul>
<li>Assume random trace ID and set th-field only for sampled spans
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-contrib/pull/1278">#1278</a>)</li>
</ul>
<h3>GCP Resources</h3>
<ul>
<li>Optimization: don't attempt detection if a cloud provider has already been detected
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-contrib/pull/1225">#1225</a>)</li>
<li>Update guidance for manual instrumentation usage
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-contrib/pull/1250">#1250</a>)</li>
</ul>
<h3>JMX metrics</h3>
<ul>
<li>Remove <code>slf4j-simple</code> dependency
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-contrib/pull/1283">#1283</a>)</li>
</ul>
<h3>Maven extension</h3>
<ul>
<li>Disable metrics and logs by default
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-contrib/pull/1276">#1276</a>)</li>
<li>Migrate to current semconv
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-contrib/pull/1299">#1299</a>)</li>
<li>Migrate from Plexus to JSR 330 dependency injection APIs
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-contrib/pull/1320">#1320</a>)</li>
</ul>
<h3>Span stack trace</h3>
<ul>
<li>Enable publishing to maven central
(<a href="https://redirect.github.com/open-telemetry/opentelemetry-java-contrib/pull/1297">#1297</a>)</li>
</ul>
<h2>Version 1.35.0 (2024-04-16)</h2>
<h3>JMX metrics</h3>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li>See full diff in <a href="https://github.com/open-telemetry/opentelemetry-java-contrib/commits">compare view</a></li>
</ul>
</details>
<br />
