### PR TITLE
Fix No MonitoringAction found when open build log

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/log/OtelLogStorage.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/log/OtelLogStorage.java
@@ -52,12 +52,9 @@ class OtelLogStorage implements LogStorage {
 
     final OtelTraceService otelTraceService;
 
-    public OtelLogStorage(@NonNull Run run, @NonNull OtelTraceService otelTraceService, @NonNull Tracer tracer) {
+    public OtelLogStorage(@NonNull Run run, @NonNull OtelTraceService otelTraceService, @NonNull Tracer tracer, @NonNull MonitoringAction monitoringAction) {
         this.run = run;
-        MonitoringAction monitoringAction = Optional
-            .ofNullable(run.getAction(MonitoringAction.class))
-            .orElseThrow(() ->  new IllegalStateException("No MonitoringAction found for " + run));
-
+        
         this.runTraceContext = new RunTraceContext(
             run.getParent().getFullName(),
             run.getNumber(),

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/log/OtelLogStorageFactory.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/log/OtelLogStorageFactory.java
@@ -13,6 +13,7 @@ import hudson.model.Queue;
 import hudson.model.Run;
 import io.jenkins.plugins.opentelemetry.OpenTelemetrySdkProvider;
 import io.jenkins.plugins.opentelemetry.OtelComponent;
+import io.jenkins.plugins.opentelemetry.job.MonitoringAction;
 import io.jenkins.plugins.opentelemetry.job.OtelTraceService;
 import io.opentelemetry.api.incubator.events.EventLogger;
 import io.opentelemetry.api.logs.LoggerProvider;
@@ -70,7 +71,14 @@ public final class OtelLogStorageFactory implements LogStorageFactory, OtelCompo
 
                 logger.log(Level.FINEST, () -> "forBuild(" + run + ")");
 
-                return new OtelLogStorage(run, getOtelTraceService(), tracer);
+                MonitoringAction monitoringAction = run.getAction(MonitoringAction.class);
+                
+                if(monitoringAction != null){
+                    return new OtelLogStorage(run, getOtelTraceService(), tracer, monitoringAction);
+                } else{
+                    logger.log(Level.FINE, () -> "No MonitoringAction found for " + run);
+                    return null;
+                }
             } else {
                 return null;
             }
@@ -78,7 +86,6 @@ public final class OtelLogStorageFactory implements LogStorageFactory, OtelCompo
             return new BrokenLogStorage(x);
         }
     }
-
     /**
      * Workaround dependency injection problem. @Inject doesn't work here
      */


### PR DESCRIPTION
Fix No MonitoringAction found error while opening build log when otel.logs.exporter=otlp set and the job run when the plugin is disabled.

as described  #866 

<!-- Please describe your pull request here. -->

### Testing done
Configuration set
![image](https://github.com/jenkinsci/opentelemetry-plugin/assets/20593322/754e0602-250b-46cc-802c-a784833a4662)

Build no 35 is run when OpenTelemetry Plugin is disable, and on build 36 i re enable the plugin
![image](https://github.com/jenkinsci/opentelemetry-plugin/assets/20593322/b9ca16dc-49b3-4e03-8f51-f557f7cbdcb9)
Now i can see the build log on build no 35. instead an error showing"No MonitoringAction found xxx"
![image](https://github.com/jenkinsci/opentelemetry-plugin/assets/20593322/5d451330-1a9e-44eb-953e-53c56b95c94d)

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
