### PR TITLE
fix: Fix No MonitoringAction found when open build log

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelEnvironmentContributorService.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelEnvironmentContributorService.java
@@ -4,6 +4,7 @@ import hudson.EnvVars;
 import hudson.Extension;
 import hudson.model.Run;
 import io.jenkins.plugins.opentelemetry.JenkinsOpenTelemetryPluginConfiguration;
+import io.jenkins.plugins.opentelemetry.OtelUtils;
 import io.jenkins.plugins.opentelemetry.semconv.JenkinsOtelSemanticAttributes;
 import io.jenkins.plugins.opentelemetry.semconv.OTelEnvironmentVariablesConventions;
 import io.opentelemetry.api.baggage.Baggage;
@@ -50,10 +51,8 @@ public class OtelEnvironmentContributorService {
             TextMapSetter<EnvVars> setter = (carrier, key, value) -> carrier.put(key.toUpperCase(), value);
             W3CBaggagePropagator.getInstance().inject(Context.current(), envs, setter);
         }
-        MonitoringAction monitoringAction = run.getAction(MonitoringAction.class);
-        if (monitoringAction == null) {
-            LOGGER.log(Level.FINE, () -> "MonitoringAction NOT found on run " + run);
-        } else {
+        if (OtelUtils.hasOpentelemetryData(run)) {
+            MonitoringAction monitoringAction = run.getAction(MonitoringAction.class);
             // Add visualization link as environment variables to provide visualization links in notifications (to GitHub, slack messages...)
             for (MonitoringAction.ObservabilityBackendLink link : monitoringAction.getLinks()) {
                 // Default backend link got an empty environment variable.

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/log/OtelLogStorageFactory.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/log/OtelLogStorageFactory.java
@@ -13,6 +13,7 @@ import hudson.model.Queue;
 import hudson.model.Run;
 import io.jenkins.plugins.opentelemetry.JenkinsControllerOpenTelemetry;
 import io.jenkins.plugins.opentelemetry.OpenTelemetryLifecycleListener;
+import io.jenkins.plugins.opentelemetry.OtelUtils;
 import io.jenkins.plugins.opentelemetry.job.MonitoringAction;
 import io.jenkins.plugins.opentelemetry.job.OtelTraceService;
 import io.opentelemetry.api.incubator.events.EventLogger;
@@ -87,27 +88,14 @@ public final class OtelLogStorageFactory implements LogStorageFactory, OpenTelem
         LogStorage ret = null;
         if (exec instanceof Run) {
             Run<?, ?> run = (Run<?, ?>) exec;
-            if(hasOpentelemetryData(run)){
-                logger.log(Level.FINEST, () -> "forBuild(" + run + ")");
+            if(OtelUtils.hasOpentelemetryData(run)){
+                logger.log(Level.FINEST, () -> "forExec(" + run + ")");
                 ret = new OtelLogStorage(run, getOtelTraceService(), tracer);
-            } else {
-                logger.log(Level.FINE, () -> "No Opentelemetry data for " + run);
             }
         } 
         return ret;
     }
-
-    /**
-     * Check if the run has Opentelemetry data
-     * To validate it search for the MonitoringAction in the build actions.
-     * @param run the Build
-     * @return true if the run has Opentelemetry data
-     */
-    private boolean hasOpentelemetryData(Run<?, ?> run){
-        MonitoringAction monitoringAction = run.getAction(MonitoringAction.class);
-        return monitoringAction != null;
-    }
-
+    
     /**
      * Workaround dependency injection problem. @Inject doesn't work here
      */

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/log/OtelLogStorageFactory.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/log/OtelLogStorageFactory.java
@@ -13,6 +13,7 @@ import hudson.model.Queue;
 import hudson.model.Run;
 import io.jenkins.plugins.opentelemetry.JenkinsControllerOpenTelemetry;
 import io.jenkins.plugins.opentelemetry.OpenTelemetryLifecycleListener;
+import io.jenkins.plugins.opentelemetry.job.MonitoringAction;
 import io.jenkins.plugins.opentelemetry.job.OtelTraceService;
 import io.opentelemetry.api.incubator.events.EventLogger;
 import io.opentelemetry.api.logs.LoggerProvider;
@@ -54,28 +55,57 @@ public final class OtelLogStorageFactory implements LogStorageFactory, OpenTelem
         return ExtensionList.lookupSingleton(OtelLogStorageFactory.class);
     }
 
+    /**
+     * Create a LogStorage for a given FlowExecutionOwner
+     * @param owner the FlowExecutionOwner
+     * @return the LogStorage, null if no Opentelemetry data is found, or a BrokenLogStorage if an error occurs.
+     */
     @Nullable
     @Override
     public LogStorage forBuild(@NonNull final FlowExecutionOwner owner) {
+        LogStorage ret = null;
         if (!getJenkinsControllerOpenTelemetry().isLogsEnabled()) {
             logger.log(Level.FINE, () -> "OTel Logs disabled");
-            return null;
+            return ret;
         }
-
         try {
             Queue.Executable exec = owner.getExecutable();
-            if (exec instanceof Run) {
-                Run<?, ?> run = (Run<?, ?>) exec;
-
-                logger.log(Level.FINEST, () -> "forBuild(" + run + ")");
-
-                return new OtelLogStorage(run, getOtelTraceService(), tracer);
-            } else {
-                return null;
-            }
+            ret = forExec(exec);
         } catch (IOException x) {
-            return new BrokenLogStorage(x);
+            ret = new BrokenLogStorage(x);
         }
+        return ret;
+    }
+
+    /**
+     * Create a LogStorage for a given Queve Executable
+     * @param exec the Queue Executable
+     * @return the LogStorage or null if no Opentelemetry data is found
+     */
+    @Nullable
+    private LogStorage forExec(@NonNull Queue.Executable exec){
+        LogStorage ret = null;
+        if (exec instanceof Run) {
+            Run<?, ?> run = (Run<?, ?>) exec;
+            if(hasOpentelemetryData(run)){
+                logger.log(Level.FINEST, () -> "forBuild(" + run + ")");
+                ret = new OtelLogStorage(run, getOtelTraceService(), tracer);
+            } else {
+                logger.log(Level.FINE, () -> "No Opentelemetry data for " + run);
+            }
+        } 
+        return ret;
+    }
+
+    /**
+     * Check if the run has Opentelemetry data
+     * To validate it search for the MonitoringAction in the build actions.
+     * @param run the Build
+     * @return true if the run has Opentelemetry data
+     */
+    private boolean hasOpentelemetryData(Run<?, ?> run){
+        MonitoringAction monitoringAction = run.getAction(MonitoringAction.class);
+        return monitoringAction != null;
     }
 
     /**


### PR DESCRIPTION
Fix No MonitoringAction found error while opening build log when otel.logs.exporter=otlp set and the job run when the plugin is disabled.

as described  #866 
Refactor of https://github.com/jenkinsci/opentelemetry-plugin/pull/867

<!-- Please describe your pull request here. -->

### Testing done
Configuration set
![image](https://github.com/jenkinsci/opentelemetry-plugin/assets/20593322/754e0602-250b-46cc-802c-a784833a4662)

Build no 35 is run when OpenTelemetry Plugin is disable, and on build 36 i re enable the plugin
![image](https://github.com/jenkinsci/opentelemetry-plugin/assets/20593322/b9ca16dc-49b3-4e03-8f51-f557f7cbdcb9)
Now i can see the build log on build no 35. instead an error showing"No MonitoringAction found xxx"
![image](https://github.com/jenkinsci/opentelemetry-plugin/assets/20593322/5d451330-1a9e-44eb-953e-53c56b95c94d)

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
