### PR TITLE
More JVM metrics

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/init/JvmMonitoringInitializer.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/init/JvmMonitoringInitializer.java
@@ -14,6 +14,8 @@ import io.opentelemetry.instrumentation.runtimemetrics.java8.GarbageCollector;
 import io.opentelemetry.instrumentation.runtimemetrics.java8.MemoryPools;
 import io.opentelemetry.instrumentation.runtimemetrics.java8.Threads;
 import io.opentelemetry.instrumentation.runtimemetrics.java8.internal.ExperimentalBufferPools;
+import io.opentelemetry.instrumentation.runtimemetrics.java8.internal.ExperimentalCpu;
+import io.opentelemetry.instrumentation.runtimemetrics.java8.internal.ExperimentalMemoryPools;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import jenkins.YesNoMaybe;
 
@@ -44,8 +46,9 @@ public class JvmMonitoringInitializer implements OpenTelemetryLifecycleListener 
         }
 
         LOGGER.log(Level.FINE, "Start monitoring Jenkins Controller JVM...");
-        // should we enable the experimental buffer pools instrumentation?
         ExperimentalBufferPools.registerObservers(jenkinsControllerOpenTelemetry);
+        ExperimentalCpu.registerObservers(jenkinsControllerOpenTelemetry);
+        ExperimentalMemoryPools.registerObservers(jenkinsControllerOpenTelemetry);
         Classes.registerObservers(jenkinsControllerOpenTelemetry);
         Cpu.registerObservers(jenkinsControllerOpenTelemetry);
         GarbageCollector.registerObservers(jenkinsControllerOpenTelemetry);


### PR DESCRIPTION
Add JVM metrics including system cpu metrics wich is a partial fix for:
* https://github.com/jenkinsci/opentelemetry-plugin/issues/883


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
