### PR TITLE
Fix NullPointerException when pipeline execution is interrupted and resurrected

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/action/AbstractMonitoringAction.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/action/AbstractMonitoringAction.java
@@ -27,8 +27,8 @@ import java.util.logging.Logger;
 public abstract class AbstractMonitoringAction implements Action, OtelMonitoringAction {
     private final static Logger LOGGER = Logger.getLogger(AbstractMonitoringAction.class.getName());
 
+    @CheckForNull
     transient SpanAndScopes spanAndScopes;
-
 
     final String traceId;
     final String spanId;
@@ -50,7 +50,7 @@ public abstract class AbstractMonitoringAction implements Action, OtelMonitoring
             this.w3cTraceContext = w3cTraceContext;
         }
 
-        LOGGER.log(Level.FINE, () -> "Span " + getSpanName() + ", thread=" + spanAndScopes.scopeStartThreadName + " opened " + spanAndScopes.scopes.size() + " scopes");
+        LOGGER.log(Level.FINE, () -> "Span " + getSpanName() + Optional.ofNullable(spanAndScopes).map(sas -> ", thread=" + sas.scopeStartThreadName + " opened " + sas.scopes.size() + " scopes").orElse(", null spanAndScopes") );
     }
 
     public String getSpanName() {
@@ -65,7 +65,7 @@ public abstract class AbstractMonitoringAction implements Action, OtelMonitoring
     @Override
     @CheckForNull
     public Span getSpan() {
-        return spanAndScopes.span;
+        return spanAndScopes == null ? null : spanAndScopes.span;
     }
 
     public String getTraceId() {


### PR DESCRIPTION
Fix NullPointerException when pipeline execution is interrupted by Jenkins Controller termination and resurrected after controller restart.

Fix for
* https://github.com/jenkinsci/opentelemetry-plugin/issues/934

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
