### PR TITLE
Fix missing metric `ci.pipeline.run.active`

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringRunListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringRunListener.java
@@ -74,7 +74,7 @@ public class MonitoringRunListener extends OtelContextAwareAbstractRunListener i
 
     protected static final Logger LOGGER = Logger.getLogger(MonitoringRunListener.class.getName());
 
-    private AtomicInteger activeRun;
+    private AtomicInteger activeRunGauge;
     private List<CauseHandler> causeHandlers;
     private LongCounter runLaunchedCounter;
     private LongCounter runStartedCounter;
@@ -103,12 +103,12 @@ public class MonitoringRunListener extends OtelContextAwareAbstractRunListener i
         this.runHandlers = runHandlers;
 
         // METRICS
-        activeRun = new AtomicInteger();
-            meter.gaugeBuilder(JenkinsSemanticMetrics.CI_PIPELINE_RUN_ACTIVE)
-                .ofLongs()
-                .setDescription("Gauge of active jobs")
-                .setUnit("1")
-                .buildWithCallback(valueObserver -> this.activeRun.get());
+        activeRunGauge = new AtomicInteger();
+        meter.gaugeBuilder(JenkinsSemanticMetrics.CI_PIPELINE_RUN_ACTIVE)
+            .ofLongs()
+            .setDescription("Gauge of active jobs")
+            .setUnit("1")
+            .buildWithCallback(valueObserver -> valueObserver.record(this.activeRunGauge.get()));
         runLaunchedCounter =
                 meter.counterBuilder(JenkinsSemanticMetrics.CI_PIPELINE_RUN_LAUNCHED)
                         .setDescription("Job launched")
@@ -156,7 +156,7 @@ public class MonitoringRunListener extends OtelContextAwareAbstractRunListener i
     public void _onInitialize(@NonNull Run run) {
         LOGGER.log(Level.FINE, () -> run.getFullDisplayName() + " - onInitialize");
 
-        activeRun.incrementAndGet();
+        activeRunGauge.incrementAndGet();
 
         RunHandler runHandler = getRunHandlers().stream().filter(rh -> rh.canCreateSpanBuilder(run)).findFirst()
             .orElseThrow((Supplier<RuntimeException>) () -> new IllegalStateException("No RunHandler found for run " + run.getClass() + " - " + run));
@@ -396,7 +396,7 @@ public class MonitoringRunListener extends OtelContextAwareAbstractRunListener i
                 this.runAbortedCounter.add(1);
             }
         } finally {
-            activeRun.decrementAndGet();
+            activeRunGauge.decrementAndGet();
         }
     }
 

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringRunListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringRunListener.java
@@ -107,7 +107,7 @@ public class MonitoringRunListener extends OtelContextAwareAbstractRunListener i
         meter.gaugeBuilder(JenkinsSemanticMetrics.CI_PIPELINE_RUN_ACTIVE)
             .ofLongs()
             .setDescription("Gauge of active jobs")
-            .setUnit("1")
+            .setUnit("{jobs}")
             .buildWithCallback(valueObserver -> valueObserver.record(this.activeRunGauge.get()));
         runLaunchedCounter =
                 meter.counterBuilder(JenkinsSemanticMetrics.CI_PIPELINE_RUN_LAUNCHED)


### PR DESCRIPTION
The metric `ci.pipeline.run.active` is missing.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
