### PR TITLE
Fix the unit of some OTel metrics

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/computer/MonitoringComputerListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/computer/MonitoringComputerListener.java
@@ -72,21 +72,21 @@ public class MonitoringComputerListener extends ComputerListener implements Open
         meter.gaugeBuilder(JenkinsSemanticMetrics.JENKINS_AGENTS_OFFLINE)
             .ofLongs()
             .setDescription("Number of offline agents")
-            .setUnit("1")
+            .setUnit("{agents}")
             .buildWithCallback(valueObserver -> valueObserver.record(this.getOfflineAgentsCount()));
         meter.gaugeBuilder(JenkinsSemanticMetrics.JENKINS_AGENTS_ONLINE)
             .ofLongs()
             .setDescription("Number of online agents")
-            .setUnit("1")
+            .setUnit("{agents}")
             .buildWithCallback(valueObserver -> valueObserver.record(this.getOnlineAgentsCount()));
         meter.gaugeBuilder(JenkinsSemanticMetrics.JENKINS_AGENTS_TOTAL)
             .ofLongs()
             .setDescription("Number of agents")
-            .setUnit("1")
+            .setUnit("{agents}")
             .buildWithCallback(valueObserver -> valueObserver.record(this.getAgentsCount()));
         failureAgentCounter = meter.counterBuilder(JenkinsSemanticMetrics.JENKINS_AGENTS_LAUNCH_FAILURE)
             .setDescription("Number of ComputerLauncher failures")
-            .setUnit("1")
+            .setUnit("{agents}")
             .build();
 
         LOGGER.log(Level.FINE, () -> "Start monitoring Jenkins agents management...");

--- a/src/main/java/io/jenkins/plugins/opentelemetry/init/GitHubClientMonitoring.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/init/GitHubClientMonitoring.java
@@ -98,7 +98,7 @@ public class GitHubClientMonitoring implements OpenTelemetryLifecycleListener {
         meter.gaugeBuilder(GITHUB_API_RATE_LIMIT_REMAINING_REQUESTS)
             .ofLongs()
             .setDescription("GitHub Repository API rate limit remaining requests")
-            .setUnit("1")
+            .setUnit("{requests}")
             .buildWithCallback(gauge -> {
                 logger.log(Level.FINE, () -> "Collect GitHub client API rate limit metrics");
                 reverseLookup.keySet().forEach(gitHub -> {

--- a/src/main/java/io/jenkins/plugins/opentelemetry/init/JenkinsExecutorMonitoringInitializer.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/init/JenkinsExecutorMonitoringInitializer.java
@@ -42,13 +42,13 @@ public class JenkinsExecutorMonitoringInitializer implements OpenTelemetryLifecy
         logger.log(Level.FINE, () -> "Start monitoring Jenkins controller executor pool...");
 
         Meter meter = Objects.requireNonNull(jenkinsControllerOpenTelemetry).getDefaultMeter();
-        final ObservableLongMeasurement availableExecutors = meter.gaugeBuilder(JENKINS_EXECUTOR_AVAILABLE).setUnit("1").setDescription("Available executors").ofLongs().buildObserver();
-        final ObservableLongMeasurement busyExecutors = meter.gaugeBuilder(JENKINS_EXECUTOR_BUSY).setUnit("1").setDescription("Busy executors").ofLongs().buildObserver();
-        final ObservableLongMeasurement idleExecutors = meter.gaugeBuilder(JENKINS_EXECUTOR_IDLE).setUnit("1").setDescription("Idle executors").ofLongs().buildObserver();
-        final ObservableLongMeasurement onlineExecutors = meter.gaugeBuilder(JENKINS_EXECUTOR_ONLINE).setUnit("1").setDescription("Online executors").ofLongs().buildObserver();
-        final ObservableLongMeasurement connectingExecutors = meter.gaugeBuilder(JENKINS_EXECUTOR_CONNECTING).setUnit("1").setDescription("Connecting executors").ofLongs().buildObserver();
-        final ObservableLongMeasurement definedExecutors = meter.gaugeBuilder(JENKINS_EXECUTOR_DEFINED).setUnit("1").setDescription("Defined executors").ofLongs().buildObserver();
-        final ObservableLongMeasurement queueLength = meter.gaugeBuilder(JENKINS_EXECUTOR_QUEUE).setUnit("1").setDescription("Defined executors").ofLongs().buildObserver();
+        final ObservableLongMeasurement availableExecutors = meter.gaugeBuilder(JENKINS_EXECUTOR_AVAILABLE).setUnit("${executors}").setDescription("Available executors").ofLongs().buildObserver();
+        final ObservableLongMeasurement busyExecutors = meter.gaugeBuilder(JENKINS_EXECUTOR_BUSY).setUnit("${executors}").setDescription("Busy executors").ofLongs().buildObserver();
+        final ObservableLongMeasurement idleExecutors = meter.gaugeBuilder(JENKINS_EXECUTOR_IDLE).setUnit("${executors}").setDescription("Idle executors").ofLongs().buildObserver();
+        final ObservableLongMeasurement onlineExecutors = meter.gaugeBuilder(JENKINS_EXECUTOR_ONLINE).setUnit("${executors}").setDescription("Online executors").ofLongs().buildObserver();
+        final ObservableLongMeasurement connectingExecutors = meter.gaugeBuilder(JENKINS_EXECUTOR_CONNECTING).setUnit("${executors}").setDescription("Connecting executors").ofLongs().buildObserver();
+        final ObservableLongMeasurement definedExecutors = meter.gaugeBuilder(JENKINS_EXECUTOR_DEFINED).setUnit("${executors}").setDescription("Defined executors").ofLongs().buildObserver();
+        final ObservableLongMeasurement queueLength = meter.gaugeBuilder(JENKINS_EXECUTOR_QUEUE).setUnit("${executors}").setDescription("Defined executors").ofLongs().buildObserver();
         logger.log(Level.FINER, () -> "Metrics: " + availableExecutors + ", " + busyExecutors + ", " + idleExecutors + ", " + onlineExecutors + ", " + connectingExecutors + ", " + definedExecutors + ", " + queueLength);
 
         meter.batchCallback(() -> {

--- a/src/main/java/io/jenkins/plugins/opentelemetry/init/SCMEventMonitoringInitializer.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/init/SCMEventMonitoringInitializer.java
@@ -37,22 +37,22 @@ public class SCMEventMonitoringInitializer implements OpenTelemetryLifecycleList
         Meter meter = Objects.requireNonNull(jenkinsControllerOpenTelemetry).getDefaultMeter();
         meter.counterBuilder(JenkinsSemanticMetrics.JENKINS_SCM_EVENT_POOL_SIZE)
             .setDescription("Number of threads handling SCM Events")
-            .setUnit("1")
+            .setUnit("{events}")
             .buildWithCallback(valueObserver -> valueObserver.record(SCMEvent.getEventProcessingMetrics().getPoolSize()));
 
         meter.upDownCounterBuilder(JenkinsSemanticMetrics.JENKINS_SCM_EVENT_ACTIVE_THREADS)
             .setDescription("Number of threads actively handling SCM Events")
-            .setUnit("1")
+            .setUnit("{threads}")
             .buildWithCallback(valueObserver -> valueObserver.record(SCMEvent.getEventProcessingMetrics().getActiveThreads()));
 
         meter.upDownCounterBuilder(JenkinsSemanticMetrics.JENKINS_SCM_EVENT_QUEUED_TASKS)
             .setDescription("Number of queued SCM Event tasks")
-            .setUnit("1")
+            .setUnit("{tasks}")
             .buildWithCallback(valueObserver -> valueObserver.record(SCMEvent.getEventProcessingMetrics().getQueuedTasks()));
 
         meter.counterBuilder(JenkinsSemanticMetrics.JENKINS_SCM_EVENT_COMPLETED_TASKS)
             .setDescription("Number of completed SCM Event tasks")
-            .setUnit("1")
+            .setUnit("{tasks}")
             .buildWithCallback(valueObserver -> valueObserver.record(SCMEvent.getEventProcessingMetrics().getCompletedTasks()));
 
     }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringRunListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringRunListener.java
@@ -107,37 +107,37 @@ public class MonitoringRunListener extends OtelContextAwareAbstractRunListener i
             meter.gaugeBuilder(JenkinsSemanticMetrics.CI_PIPELINE_RUN_ACTIVE)
                 .ofLongs()
                 .setDescription("Gauge of active jobs")
-                .setUnit("1")
+                .setUnit("{jobs}")
                 .buildWithCallback(valueObserver -> this.activeRun.get());
         runLaunchedCounter =
                 meter.counterBuilder(JenkinsSemanticMetrics.CI_PIPELINE_RUN_LAUNCHED)
                         .setDescription("Job launched")
-                        .setUnit("1")
+                        .setUnit("{jobs}")
                         .build();
         runStartedCounter =
                 meter.counterBuilder(JenkinsSemanticMetrics.CI_PIPELINE_RUN_STARTED)
                         .setDescription("Job started")
-                        .setUnit("1")
+                        .setUnit("{jobs}")
                         .build();
         runSuccessCounter =
                 meter.counterBuilder(JenkinsSemanticMetrics.CI_PIPELINE_RUN_SUCCESS)
                     .setDescription("Job succeed")
-                    .setUnit("1")
+                    .setUnit("{jobs}")
                     .build();
         runFailedCounter =
             meter.counterBuilder(JenkinsSemanticMetrics.CI_PIPELINE_RUN_FAILED)
                 .setDescription("Job failed")
-                .setUnit("1")
+                .setUnit("{jobs}")
                 .build();
         runAbortedCounter =
                     meter.counterBuilder(JenkinsSemanticMetrics.CI_PIPELINE_RUN_ABORTED)
                         .setDescription("Job aborted")
-                        .setUnit("1")
+                        .setUnit("{jobs}")
                         .build();
         runCompletedCounter =
                 meter.counterBuilder(JenkinsSemanticMetrics.CI_PIPELINE_RUN_COMPLETED)
                         .setDescription("Job completed")
-                        .setUnit("1")
+                        .setUnit("{jobs}")
                         .build();
 
     }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/queue/MonitoringQueueListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/queue/MonitoringQueueListener.java
@@ -57,7 +57,7 @@ public class MonitoringQueueListener extends QueueListener implements OpenTeleme
         meter.gaugeBuilder(JenkinsSemanticMetrics.JENKINS_QUEUE_WAITING)
             .ofLongs()
             .setDescription("Number of tasks in the queue with the status 'waiting', 'buildable' or 'pending'")
-            .setUnit("1")
+            .setUnit("{tasks}")
             .buildWithCallback(valueObserver -> valueObserver.record((long)
                 Optional.ofNullable(Jenkins.getInstanceOrNull()).map(j -> j.getQueue()).
                     map(q -> q.getUnblockedItems().size()).orElse(0)));
@@ -65,20 +65,20 @@ public class MonitoringQueueListener extends QueueListener implements OpenTeleme
         meter.gaugeBuilder(JenkinsSemanticMetrics.JENKINS_QUEUE_BLOCKED)
             .ofLongs()
             .setDescription("Number of blocked tasks in the queue. Note that waiting for an executor to be available is not a reason to be counted as blocked")
-            .setUnit("1")
+            .setUnit("{tasks}")
             .buildWithCallback(valueObserver -> valueObserver.record(this.blockedItemGauge.longValue()));
 
         meter.gaugeBuilder(JenkinsSemanticMetrics.JENKINS_QUEUE_BUILDABLE)
             .ofLongs()
             .setDescription("Number of tasks in the queue with the status 'buildable' or 'pending'")
-            .setUnit("1")
+            .setUnit("{tasks}")
             .buildWithCallback(valueObserver -> valueObserver.record((long)
                 Optional.ofNullable(Jenkins.getInstanceOrNull()).map(j -> j.getQueue()).
                     map(q -> q.countBuildableItems()).orElse(0)));
 
         leftItemCounter = meter.counterBuilder(JenkinsSemanticMetrics.JENKINS_QUEUE_LEFT)
             .setDescription("Total count of tasks that have been processed")
-            .setUnit("1")
+            .setUnit("{tasks}")
             .build();
         timeInQueueInMillisCounter = meter.counterBuilder(JenkinsSemanticMetrics.JENKINS_QUEUE_TIME_SPENT_MILLIS)
             .setDescription("Total time spent in queue by the tasks that have been processed")

--- a/src/main/java/io/jenkins/plugins/opentelemetry/security/AuditingSecurityListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/security/AuditingSecurityListener.java
@@ -62,18 +62,18 @@ public class AuditingSecurityListener extends SecurityListener implements OpenTe
         loginSuccessCounter =
             meter.counterBuilder(JenkinsSemanticMetrics.LOGIN_SUCCESS)
                 .setDescription("Successful logins")
-                .setUnit("1")
+                .setUnit("${logins}")
                 .build();
         loginFailureCounter =
             meter.counterBuilder(JenkinsSemanticMetrics.LOGIN_FAILURE)
                 .setDescription("Failing logins")
-                .setUnit("1")
+                .setUnit("${logins}")
                 .build();
 
         loginCounter =
             meter.counterBuilder(JenkinsSemanticMetrics.LOGIN)
                 .setDescription("Logins")
-                .setUnit("1")
+                .setUnit("${logins}")
                 .build();
 
     }


### PR DESCRIPTION
Some metrics are defined with the unit `1` which is wrong and causes improper Prometheus metric names.


| Previous Prometheus metric name | New Prometheus metric name |
| -- | -- |
| `jenkins_agents_offline_ratio`  | `jenkins_agents_online` |
| `jenkins_agents_online_ratio`  | `jenkins_agents` |
| `jenkins_agents_ratio`  | `jenkins_agents_launch_failure` |
| `jenkins_agents_launch_failure_ratio`  | `jenkins_agents_launch_failure` |
| `github_api_rate_limit_remaining_requests_ratio `  | `github_api_rate_limit_remaining_requests ` |
| `ci_pipeline_run_completed_ratio_total`  | `ci_pipeline_run_completed_total` |
| `ci_pipeline_run_failed_ratio_total`  | `ci_pipeline_run_failed_total` |
| `ci_pipeline_run_launched_ratio_total`  | `ci_pipeline_run_launched_total` |
| `ci_pipeline_run_started_ratio_total`  | `ci_pipeline_run_started_total` |
| `ci_pipeline_run_success_ratio_total`  | `ci_pipeline_run_success_total` |
| `jenkins_queue_blocked_ratio`  | `jenkins_queue_blocked` |
| `jenkins_queue_buildable_ratio `  | `jenkins_queue_buildable ` |
| `jenkins_queue_waiting_ratio`  | `jenkins_queue_waiting` |
| `jenkins_scm_event_active_threads_ratio`| `jenkins_scm_event_active_threads`|
| `jenkins_scm_event_completed_tasks_ratio_total` | `jenkins_scm_event_completed_tasks_total`|
| `jenkins_scm_event_pool_size_ratio_total` | `jenkins_scm_event_pool_size_total` |
| `jenkins_scm_event_queued_tasks_ratio ` | `jenkins_scm_event_queued_tasks`|
| `jenkins_executor_available_ratio`  | `jenkins_executor_available` |
| `jenkins_executor_busy_ratio`  | `jenkins_executor_busy` |
| `jenkins_executor_connecting_ratio`  | `jenkins_executor_connecting` |
| `jenkins_executor_defined_ratio`  | `jenkins_executor_defined` |
| `jenkins_executor_idle_ratio`  | `jenkins_executor_idle` |
| `jenkins_executor_online_ratio`  | `jenkins_online_idle` |
| `jenkins_executor_queue_ratio`  | `jenkins_queue_idle` |
| `login_ratio_total`| `login_total` |
| `login_success_ratio_total` | `login_success_total` |
| `login_failure_ratio_total` | `login_failure_total` |




### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
