### PR TITLE
test: remove plugin installation

### DIFF
--- a/src/test/java/io/jenkins/plugins/opentelemetry/BaseIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/BaseIntegrationTest.java
@@ -104,14 +104,6 @@ public class BaseIntegrationTest {
         jenkinsRule.waitUntilNoActivity();
         LOGGER.log(Level.INFO, "Jenkins started");
 
-        // // Update all sites to reload available plugins.
-        // jenkinsRule.jenkins.getUpdateCenter().updateAllSites();
-
-        // // install() returns a Future for every plugin. Call get() on the Future so that this line blocks
-        // // until the operation is finished and the future is available.
-        // jenkinsRule.jenkins.getPluginManager().install(
-        //     Collections.singletonList("durable-task"), true).get(0).get();
-        // Assert.assertNotNull(jenkinsRule.jenkins.getPluginManager().getPlugin("durable-task"));
 
         ExtensionList<JenkinsControllerOpenTelemetry> jenkinsOpenTelemetries = jenkinsRule.getInstance().getExtensionList(JenkinsControllerOpenTelemetry.class);
         verify(jenkinsOpenTelemetries.size() == 1, "Number of jenkinsControllerOpenTelemetrys: %s", jenkinsOpenTelemetries.size());

--- a/src/test/java/io/jenkins/plugins/opentelemetry/BaseIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/BaseIntegrationTest.java
@@ -104,14 +104,14 @@ public class BaseIntegrationTest {
         jenkinsRule.waitUntilNoActivity();
         LOGGER.log(Level.INFO, "Jenkins started");
 
-        // Update all sites to reload available plugins.
-        jenkinsRule.jenkins.getUpdateCenter().updateAllSites();
+        // // Update all sites to reload available plugins.
+        // jenkinsRule.jenkins.getUpdateCenter().updateAllSites();
 
-        // install() returns a Future for every plugin. Call get() on the Future so that this line blocks
-        // until the operation is finished and the future is available.
-        jenkinsRule.jenkins.getPluginManager().install(
-            Collections.singletonList("durable-task"), true).get(0).get();
-        Assert.assertNotNull(jenkinsRule.jenkins.getPluginManager().getPlugin("durable-task"));
+        // // install() returns a Future for every plugin. Call get() on the Future so that this line blocks
+        // // until the operation is finished and the future is available.
+        // jenkinsRule.jenkins.getPluginManager().install(
+        //     Collections.singletonList("durable-task"), true).get(0).get();
+        // Assert.assertNotNull(jenkinsRule.jenkins.getPluginManager().getPlugin("durable-task"));
 
         ExtensionList<JenkinsControllerOpenTelemetry> jenkinsOpenTelemetries = jenkinsRule.getInstance().getExtensionList(JenkinsControllerOpenTelemetry.class);
         verify(jenkinsOpenTelemetries.size() == 1, "Number of jenkinsControllerOpenTelemetrys: %s", jenkinsOpenTelemetries.size());


### PR DESCRIPTION
We have detected a regression on windows , a couple of Integration tests fail accessing to the update center


related to https://github.com/jenkinsci/opentelemetry-plugin/pull/956