### PR TITLE
Change `assumeTrue` import so that tests are properly skipped

### DIFF
--- a/src/test/java/io/jenkins/plugins/opentelemetry/rules/CheckIsDockerAvailable.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/rules/CheckIsDockerAvailable.java
@@ -4,7 +4,7 @@
  */
 package io.jenkins.plugins.opentelemetry.rules;
 
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import org.junit.Assume;
 
 import org.junit.rules.ExternalResource;
 import org.testcontainers.DockerClientFactory;
@@ -16,6 +16,6 @@ import org.testcontainers.DockerClientFactory;
 public class CheckIsDockerAvailable extends ExternalResource {
       @Override
   protected void before() {
-    assumeTrue(DockerClientFactory.instance().isDockerAvailable());
+    Assume.assumeTrue(DockerClientFactory.instance().isDockerAvailable());
   }
 }


### PR DESCRIPTION
I'm working on getting `opentelemetry` into the plugin BOM. The one item that is holding me back is the failing tests when trying to start Elasticsearch. This is because there is no Docker available in the BOM build infra.

I'm running into an issue when using the JUnit5 `Assumptions.assumeTrue` where it throws an exception:

```
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 9.615 s <<< FAILURE! -- in io.jenkins.plugins.opentelemetry.backend.elastic.ElasticsearchBackendITTest
[ERROR] io.jenkins.plugins.opentelemetry.backend.elastic.ElasticsearchBackendITTest -- Time elapsed: 9.615 s <<< ERROR!
org.opentest4j.TestAbortedException: Assumption failed: assumption is not true
        at io.jenkins.plugins.opentelemetry.rules.CheckIsDockerAvailable.before(CheckIsDockerAvailable.java:19)
        at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:659)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
        at java.base/java.lang.Thread.run(Thread.java:1583)
```

instead of just skipping the test.

By changing from JUnit5 `Assumptions` to JUnit4 `Assume`, the tests skip as expected.

If you accept this PR, we'll be able to get `opentelemetry` into plugin BOM.

### Testing done

* `mvn clean verify`
* `mvn clean verify -Dtest="ElasticsearchBackendITTest"`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue