### PR TITLE
opentelemetry-resources provided by opentelemetry-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,8 @@
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
             <artifactId>opentelemetry-resources</artifactId>
+            <!-- provided by io.jenkins.plugins:opentelemetry-api -->
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>


### PR DESCRIPTION
Found the jar was duplicated and provided by `opentelemetry-api`

```
./opentelemetry/WEB-INF/lib/opentelemetry-resources-2.10.0-alpha.jar
./opentelemetry-api/WEB-INF/lib/opentelemetry-resources-2.10.0-alpha.jar
```

### Testing done

`mvn -DskipTests verify`

`mvn dependency:tree` and check the jar is provided by opentelemetry-api

```
[INFO] +- io.jenkins.plugins:opentelemetry-api:jar:1.44.1.40.v93f5f8ca_42c3:compile
[INFO] |  +- io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-incubator:jar:2.10.0-alpha:compile
[INFO] |  +- io.opentelemetry:opentelemetry-exporter-logging:jar:1.44.1:compile
[INFO] |  +- io.opentelemetry:opentelemetry-exporter-otlp:jar:1.44.1:compile
.....
[INFO] +- io.opentelemetry.instrumentation:opentelemetry-resources:jar:2.10.0-alpha:provided
```

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
