### PR TITLE
chore: update docker compose configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,7 @@ updates:
     directory: /
     schedule:
         interval: monthly
+  - package-ecosystem: docker-compose
+    directory: /src/test/resources
+    schedule:
+        interval: monthly

--- a/demos/Makefile
+++ b/demos/Makefile
@@ -5,16 +5,16 @@ export ELASTIC_STACK_VERSION?=8.14.2
 
 .PHONY: build
 build:
-	@env docker-compose --file docker-compose.yml build
+	@env docker compose --file docker-compose.yml build
 
 .PHONY: start
 start:
-	@env docker-compose --file docker-compose.yml up --detach --no-recreate
+	@env docker compose --file docker-compose.yml up --detach --no-recreate
 
 .PHONY: stop
 stop:
-	@env docker-compose --file docker-compose.yml stop
+	@env docker compose --file docker-compose.yml stop
 
 .PHONY: clean
 clean:
-	@env docker-compose --file docker-compose.yml down -v
+	@env docker compose --file docker-compose.yml down -v

--- a/demos/README.md
+++ b/demos/README.md
@@ -43,7 +43,7 @@ If `ARM64` please read the [support for `ARM64`](#support-for-arm64) section.
 2. Start the local Jenkins master service by running:
 
    ```
-   make -C demos start-all
+   make -C demos start
    ```
 
 3. Browse to <http://localhost:8080> in your web browser.


### PR DESCRIPTION
Updates the command to use for Docker compose to `docker compose` in the demo.
Adds dependabot configuration to bump Docker images.
