### PR TITLE
Remove calls to the deprecated OTel Events Logger API

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsControllerOpenTelemetry.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsControllerOpenTelemetry.java
@@ -13,7 +13,6 @@ import hudson.ExtensionPoint;
 import io.jenkins.plugins.opentelemetry.api.ReconfigurableOpenTelemetry;
 import io.jenkins.plugins.opentelemetry.semconv.ExtendedJenkinsAttributes;
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.api.incubator.events.EventLogger;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.instrumentation.resources.ProcessResourceProvider;
@@ -44,7 +43,6 @@ public class JenkinsControllerOpenTelemetry implements ExtensionPoint {
 
     private Tracer defaultTracer;
     private Meter defaultMeter;
-    private EventLogger defaultEventLogger;
 
     public JenkinsControllerOpenTelemetry() {
         super();
@@ -60,11 +58,6 @@ public class JenkinsControllerOpenTelemetry implements ExtensionPoint {
                 .setInstrumentationVersion(opentelemetryPluginVersion)
                 .build();
 
-        this.defaultEventLogger = openTelemetry
-            .eventLoggerBuilder(ExtendedJenkinsAttributes.INSTRUMENTATION_NAME)
-            .setInstrumentationVersion(opentelemetryPluginVersion)
-            .build();
-
         this.defaultMeter = openTelemetry
             .meterBuilder(ExtendedJenkinsAttributes.INSTRUMENTATION_NAME)
             .setInstrumentationVersion(opentelemetryPluginVersion)
@@ -79,17 +72,6 @@ public class JenkinsControllerOpenTelemetry implements ExtensionPoint {
     @NonNull
     public Meter getDefaultMeter() {
         return defaultMeter;
-    }
-
-    /**
-     * Will be removed in <a
-     * href="https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.47.0">opentelemetry-api:1.47.0</a>
-     * @deprecated use {@link OpenTelemetry#getLogsBridge()}
-     */
-    @Deprecated
-    @NonNull
-    public EventLogger getDefaultEventLogger() {
-        return defaultEventLogger;
     }
 
     public boolean isLogsEnabled() {


### PR DESCRIPTION
Remove calls to the deprecated OTel Events Logger API.

We forgot in call when pushing:
- https://github.com/jenkinsci/opentelemetry-plugin/pull/1070


<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
