### PR TITLE
Use plugin BOM more widely in pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -399,7 +399,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ant</artifactId>
-            <version>513.vde9e7b_a_0da_0f</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -302,7 +302,6 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>apache-httpcomponents-client-5-api</artifactId>
-            <version>5.5-150.veb_76e719855b_</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -416,7 +416,6 @@
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>maven-plugin</artifactId>
-            <version>3.26</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -350,7 +350,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>job-dsl</artifactId>
-            <version>1.93</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -99,9 +99,8 @@
                 <version>1.1.7</version>
             </dependency>
             <dependency>
-                <groupId>com.jayway.jsonpath</groupId>
-                <artifactId>json-path</artifactId>
-                <version>2.9.0</version>
+                <groupId>io.jenkins.plugins</groupId>
+                <artifactId>json-path-api</artifactId>
             </dependency>
             <dependency>
                 <groupId>io.prometheus</groupId>
@@ -269,7 +268,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jackson2-api</artifactId>
-            <version>2.19.0-404.vb_b_0fd2fea_e10</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Use plugin BOM more widely in pom file

Rely on plugin BOM for Jackson 2 API version so that the plugin is not using a Jackson 2 API plugin version that has been suspended from distribution.  This is an important change and is needed before the next release of the OpenTelemetry plugin.

More details are available at:

* https://github.com/jenkinsci/bom/pull/5114
* https://github.com/fabric8io/kubernetes-client/issues/7036
* https://github.com/fabric8io/kubernetes-client/issues/7106
* [JENKINS-75712](https://issues.jenkins.io/browse/JENKINS-75712)

Switches to use the JSON Path API plugin rather than including JSON Path API directly.

Additional changes that will reduce version updates.

- Rely on plugin BOM for Job DSL plugin version
- Rely on plugin BOM for ant plugin version
- Rely on plugin BOM for maven plugin version
- Rely on plugin BOM for httpcomponents 5 API plugin version

### Testing done

Confirmed that versions of affected dependencies remain the same before and after this change, with the exception of Jackson 2 API version.  The Jackson 2 API version returns to a 2.18.3-x version since the 2.19.0 version of the plugin has been suspended from distribution by the Jenkins update center.

Confirmed that automated tests pass on my Linux with JDK 21.0.7

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
