### PR TITLE
Remove-connectionException-from-logs-when-no-OTLP-EndPoint-is-configured

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/OpenTelemetryConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/OpenTelemetryConfiguration.java
@@ -122,6 +122,8 @@ public class OpenTelemetryConfiguration {
             StringUtils.isBlank(OtelUtils.getSystemPropertyOrEnvironmentVariable("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"))) {
             // Change default of "otel.traces.exporter" from "otlp" to "none" unless "otel.exporter.otlp.endpoint" or "otel.exporter.otlp.traces.endpoint" is defined
             properties.put(OTEL_TRACES_EXPORTER.asProperty(), "none");
+            properties.put(OTEL_METRICS_EXPORTER.asProperty(), "none");
+            properties.put(OTEL_LOGS_EXPORTER.asProperty(), "none");
         }
 
         this.getTrustedCertificatesPem().ifPresent(

--- a/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginNoConfigurationIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginNoConfigurationIntegrationTest.java
@@ -1,0 +1,50 @@
+package io.jenkins.plugins.opentelemetry;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyCollectionOf;
+
+import io.jenkins.plugins.opentelemetry.api.ReconfigurableOpenTelemetry;
+import io.opentelemetry.exporter.internal.grpc.GrpcExporter;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import java.time.Duration;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.logging.Level;
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.FlagRule;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
+
+public class JenkinsOtelPluginNoConfigurationIntegrationTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Rule
+    public LoggerRule loggerRule =
+        new LoggerRule().record(GrpcExporter.class, Level.INFO).capture(50);
+
+    /**
+     * Explicitly disable the retry interceptor to make the error logs fast.
+     * See {@link io.opentelemetry.exporter.otlp.internal.OtlpConfigUtil#configureOtlpExporterBuilder(String, ConfigProperties, Consumer, BiConsumer, Consumer, Consumer, Consumer, BiConsumer, Consumer, Consumer)}
+     */
+    @Rule
+    public FlagRule<String> retryDisabled = FlagRule.systemProperty("otel.java.exporter.otlp.retry.disabled", "true");
+
+    @Test
+    public void ensureNoErrorLogWhenNoConfiguration() throws Exception {
+        // check no errors are logged
+        await().during(Duration.ofSeconds(5))
+               .atMost(Duration.ofSeconds(6))
+               .pollInterval(Duration.ofMillis(500))
+               .until(loggerRule::getMessages, emptyCollectionOf(String.class));
+
+        var properties = ReconfigurableOpenTelemetry.get().getConfig();
+        assertThat(properties.getString("otel.traces.exporter"), Matchers.is("none"));
+        assertThat(properties.getString("otel.metrics.exporter"), Matchers.is("none"));
+        assertThat(properties.getString("otel.logs.exporter"), Matchers.is("none"));
+    }
+}

--- a/src/test/java/io/jenkins/plugins/opentelemetry/OpenTelemetryConfigurationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/OpenTelemetryConfigurationTest.java
@@ -5,7 +5,6 @@
 
 package io.jenkins.plugins.opentelemetry;
 
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -13,6 +12,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class OpenTelemetryConfigurationTest {
 
@@ -103,8 +104,26 @@ public class OpenTelemetryConfigurationTest {
         String actualMetricsExporter = actualOtelProperties.get("otel.metrics.exporter");
         String actualLogsExporter = actualOtelProperties.get("otel.logs.exporter");
 
-        MatcherAssert.assertThat(actualTracesExporter, Matchers.is(expectedTracesExporter));
-        MatcherAssert.assertThat(actualMetricsExporter, Matchers.is(expectedMetricsExporter));
-        MatcherAssert.assertThat(actualLogsExporter, Matchers.is(expectedLogsExporter));
+        assertThat(actualTracesExporter, Matchers.is(expectedTracesExporter));
+        assertThat(actualMetricsExporter, Matchers.is(expectedMetricsExporter));
+        assertThat(actualLogsExporter, Matchers.is(expectedLogsExporter));
+    }
+
+    @Test
+    public void testNoEndpointConfiguredDisablesExporters() {
+        OpenTelemetryConfiguration config = new OpenTelemetryConfiguration(
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            new HashMap<>()
+        );
+        Map<String, String> properties = config.toOpenTelemetryProperties();
+
+        assertThat(properties.get("otel.traces.exporter"), Matchers.is("none"));
+        assertThat(properties.get("otel.metrics.exporter"), Matchers.is("none"));
+        assertThat(properties.get("otel.logs.exporter"), Matchers.is("none"));
     }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

When No OTLP EndPoint is configured , setting up OTEL_LOGS_EXPORTER as none to get rid of connectionException in logs . related to https://github.com/jenkinsci/opentelemetry-plugin/issues/1088

Observed one PR is raised for OTEL-API plugin . Going through this too -https://github.com/jenkinsci/opentelemetry-api-plugin/pull/45

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
