### PR TITLE
chore: add spotless formating commit to ignore blame file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# spotless formatting
+7b9c6d635bb8c8ef07833607e4ed15d5b782f931


### PR DESCRIPTION
This pull request makes a small update to the `.git-blame-ignore-revs` file by adding a new commit hash to ignore spotless formatting changes.

* [`.git-blame-ignore-revs`](diffhunk://#diff-f247fbfbe928b907db42554d0b3006b28dd11c25a59be031abda73b11a2c934aR1-R2): Added commit hash `7b9c6d635bb8c8ef07833607e4ed15d5b782f931` to ignore spotless formatting changes.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
