### PR TITLE
chore: remove unused method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,13 +163,13 @@
           <artifactId>jsr305</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>io.opentelemetry</groupId>
+          <artifactId>opentelemetry-api</artifactId>
+        </exclusion>
+        <exclusion>
           <!-- provided by org.jenkins-ci.plugins:apache-httpcomponents-client-5-api -->
           <groupId>org.apache.httpcomponents.client5</groupId>
           <artifactId>httpclient5</artifactId>
-        </exclusion>
-        <exclusion>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-api</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/src/test/java/io/jenkins/plugins/opentelemetry/backend/elastic/ElasticStack.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/backend/elastic/ElasticStack.java
@@ -4,35 +4,14 @@
  */
 package io.jenkins.plugins.opentelemetry.backend.elastic;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-
-import co.elastic.clients.elasticsearch.ElasticsearchClient;
-import co.elastic.clients.elasticsearch.core.BulkRequest;
-import co.elastic.clients.elasticsearch.core.BulkResponse;
-import co.elastic.clients.elasticsearch.indices.CreateIndexRequest;
-import co.elastic.clients.json.jackson.JacksonJsonpMapper;
-import co.elastic.clients.transport.rest5_client.Rest5ClientTransport;
-import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
-import co.elastic.clients.transport.rest5_client.low_level.Rest5ClientBuilder;
 import io.jenkins.plugins.opentelemetry.JenkinsOpenTelemetryPluginConfiguration;
 import io.jenkins.plugins.opentelemetry.api.ReconfigurableOpenTelemetry;
 import io.jenkins.plugins.opentelemetry.backend.ElasticBackend;
-import io.jenkins.plugins.opentelemetry.backend.ElasticBackend.TemplateBindings;
 import io.jenkins.plugins.opentelemetry.job.log.LogStorageRetriever;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.time.Duration;
-import java.util.Map;
 import jenkins.model.GlobalConfiguration;
-import org.apache.hc.client5.http.auth.AuthScope;
-import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
-import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
-import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
-import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
-import org.apache.hc.core5.http.HttpHost;
 import org.testcontainers.containers.DockerComposeContainer;
 import org.testcontainers.containers.wait.strategy.DockerHealthcheckWaitStrategy;
 
@@ -68,26 +47,6 @@ public class ElasticStack extends DockerComposeContainer<ElasticStack> {
     }
 
     /**
-     * @return the RestClientBuilder to create the Elasticsearch REST client.
-     */
-    public Rest5ClientBuilder getBuilder() {
-        UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(USER_NAME, PASSWORD.toCharArray());
-
-        BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
-        try {
-            credentialsProvider.setCredentials(new AuthScope(HttpHost.create(getEsUrl())), credentials);
-        } catch (URISyntaxException e) {
-            throw new IllegalArgumentException(e);
-        }
-        CloseableHttpAsyncClient httpclient = HttpAsyncClients.custom()
-                .setDefaultCredentialsProvider(credentialsProvider)
-                .build();
-
-        Rest5ClientBuilder builder = Rest5Client.builder(URI.create(getEsUrl())).setHttpClient(httpclient);
-        return builder;
-    }
-
-    /**
      * @return The URL to access to the Elasticsearch Docker container.
      */
     public String getEsUrl() {
@@ -109,31 +68,6 @@ public class ElasticStack extends DockerComposeContainer<ElasticStack> {
     public String getFleetUrl() {
         return "http://" + this.getServiceHost(EDOT_SERVICE, OTEL_PORT) + ":"
                 + this.getServicePort(EDOT_SERVICE, OTEL_PORT);
-    }
-
-    /**
-     * Create the index {@link #INDEX} fot testing in Elasticsearch.
-     *
-     * @throws IOException
-     */
-    public void createLogIndex() throws IOException {
-        Rest5Client restClient = getBuilder().build();
-        Rest5ClientTransport elasticsearchTransport = new Rest5ClientTransport(restClient, new JacksonJsonpMapper());
-        try (ElasticsearchClient client = new ElasticsearchClient(elasticsearchTransport)) {
-            client.indices()
-                    .create(new CreateIndexRequest.Builder().index(INDEX).build());
-
-            BulkRequest.Builder br = new BulkRequest.Builder();
-            for (int n = 0; n < 100; n++) {
-                String index = String.valueOf(n);
-                br.operations(op -> op.index(idx -> idx.index(INDEX)
-                        .document(Map.of(
-                                TemplateBindings.TRACE_ID, "foo" + index,
-                                TemplateBindings.SPAN_ID, "bar" + index))));
-            }
-            BulkResponse result = client.bulk(br.build());
-            assertFalse(result.errors());
-        }
     }
 
     public void configureElasticBackEnd() {


### PR DESCRIPTION
This pull request primarily focuses on removing unused dependencies and outdated code related to Elasticsearch client configuration and operations. The changes simplify the codebase and improve maintainability by removing redundant or unused methods and imports.

### Dependency Management:
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R165-L173): Removed and re-added the exclusion for the `opentelemetry-api` dependency to align with the project's dependency management strategy.

### Code Simplification:
* [`src/test/java/io/jenkins/plugins/opentelemetry/backend/elastic/ElasticStack.java`](diffhunk://#diff-5a1f32b6868db5d1de4f35851a2a472e6d804b5db0d2fa535611588810230ef7L7-L35): Removed unused imports related to Elasticsearch client libraries and HTTP client configurations.
* `ElasticStack` constructor: Removed the `getBuilder` method, which was responsible for creating an Elasticsearch REST client, as it is no longer used.
* `ElasticStack` class: Removed the `createLogIndex` method, which handled index creation and bulk operations for testing in Elasticsearch, as it is no longer relevant.