### PR TITLE
Fix NPE for GitCheckoutStepHandler

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/step/GitCheckoutStepHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/step/GitCheckoutStepHandler.java
@@ -17,6 +17,8 @@ import hudson.scm.SCM;
 import io.jenkins.plugins.opentelemetry.semconv.ExtendedJenkinsAttributes;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.Tracer;
+
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -101,6 +103,10 @@ public class GitCheckoutStepHandler extends AbstractGitStepHandler {
             }
 
             List<Map<String, ?>> extensions = (List<Map<String, ?>>) scm.get("extensions");
+            if (extensions == null) {
+                LOGGER.log(Level.FINE, "Extensions is null for node {0}, using empty list", node.getId());
+                extensions = Collections.emptyList();
+            }
             final Map<String, ?> cloneOption = Iterables.getFirst(extensions, null);
 
             if (cloneOption != null) {
@@ -109,6 +115,10 @@ public class GitCheckoutStepHandler extends AbstractGitStepHandler {
             }
 
             List<Map<String, ?>> userRemoteConfigs = (List<Map<String, ?>>) scm.get("userRemoteConfigs");
+            if (userRemoteConfigs == null) {
+                LOGGER.log(Level.FINE, "userRemoteConfigs is null for node {0}, using empty list", node.getId());
+                userRemoteConfigs = Collections.emptyList();
+            }
             final Map<String, ?> userRemoteConfig = Iterables.getFirst(userRemoteConfigs, null);
             if (userRemoteConfig == null) {
                 return addCloneAttributes(tracer.spanBuilder(stepFunctionName), shallow, depth);


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

fixes https://github.com/jenkinsci/opentelemetry-plugin/issues/1170

Reproduction Steps:

1> Create the pipeline with the below mentioned script .

```
pipeline {
    agent any
    stages {
        stage('Checkout') {
            steps {
                checkout([$class: 'GitSCM',
                    branches: [[name: '*/main']],
                    userRemoteConfigs: [[
                        url: 'https://github.com/jenkinsci/opentelemetry-plugin.git' // public repo
                    ]]
                ])
            }
        }
    }
}
```

2> Build the pipeline and observe Jenkins system logs (Manage Jenkins -> System logs)
3> NPE in GitCheckoutStepHandler

PFA logs with NPE error - https://cloudbees.slack.com/files/U07KMG8KY74/F098LJLF9NE/untitled?origin_team=T0254P92A&origin_channel=D07KMD3PYH1

RCA:

The null value of extensions in the code at this [line](https://github.com/jenkinsci/opentelemetry-plugin/blob/bf47889f1dc77a36f99890878ea8698a48a2e2e0/src/main/java/io/jenkins/plugins/opentelemetry/job/step/GitCheckoutStepHandler.java#L104) causes Iterables.getFirst() to fail. Implementing a null check and assigning extensions an empty list when it's null fixes the issue.

Impact :

The breaking code (NPE when extension is null) triggers spans for OpenTelemetry to monitor Git checkout operations in Jenkins pipelines. When this code doesn't execute correctly, we lose some (not all) critical observability metadata, including spans and traces related to Git operations.

Impacted code lines:

All the attributes in traces and span which are getting populated post this 
https://github.com/jenkinsci/opentelemetry-plugin/blob/bf47889f1dc77a36f99890878ea8698a48a2e2e0/src/main/java/io/jenkins/plugins/opentelemetry/job/step/GitCheckoutStepHandler.java#L104 and 
https://github.com/jenkinsci/opentelemetry-plugin/blob/bf47889f1dc77a36f99890878ea8698a48a2e2e0/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringPipelineListener.java#L255 are missing before RuntimeException is caught at this line
https://github.com/jenkinsci/opentelemetry-plugin/blob/bf47889f1dc77a36f99890878ea8698a48a2e2e0/src/main/java/io/jenkins/plugins/opentelemetry/job/jenkins/GraphListenerAdapterToPipelineListener.java#L292

### Testing done

Manual Testing evidence 

Post Making the change verified the logs again and NPE issue is resolved .

PFA logs without NPE error

https://cloudbees.slack.com/files/U07KMG8KY74/F098H6E32KV/untitled?origin_team=T0254P92A&origin_channel=D07KMD3PYH1

Also, Checked for other attributes which could fail Iterables.getFirst() and fixed it .

NOTE: Will add automated test case too if required . 

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
