### PR TITLE
Reconfigure OpenTelemetry SDK when `JenkinsOpenTelemetryPluginConfiguration` is reloaded

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
@@ -163,6 +163,7 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
         load();
     }
 
+    // needed by CloudBees HA see https://github.com/jenkinsci/opentelemetry-plugin/issues/1156
     @Override
     public void load() {
         super.load();

--- a/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
@@ -164,6 +164,17 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
     }
 
     @Override
+    public void load() {
+        super.load();
+        if (currentOpenTelemetryConfiguration != null) {
+            // After reloading the XML configuration, we need to reconfigure the OTel SDK, otherwise the fields here
+            // may be out of sync with the SDK. We only do this as long as `configureOpenTelemetrySdk` has run at least
+            // once so that the first configuration happens during startup via `@Initializer` after applying CasC.
+            configureOpenTelemetrySdk();
+        }
+    }
+
+    @Override
     public boolean configure(StaplerRequest2 req, JSONObject json) throws FormException {
         LOGGER.log(Level.FINE, "Configure...");
         req.bindJSON(this, json);

--- a/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfigurationIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfigurationIntegrationTest.java
@@ -1,0 +1,66 @@
+package io.jenkins.plugins.opentelemetry;
+
+import io.jenkins.plugins.opentelemetry.semconv.JenkinsMetrics;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricExporterProvider;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricExporterUtils;
+import io.opentelemetry.semconv.ServiceAttributes;
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Map;
+import java.util.Optional;
+import jenkins.model.Jenkins;
+import org.junit.After;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.is;
+
+@WithJenkins
+public class JenkinsOpenTelemetryPluginConfigurationIntegrationTest {
+    static {
+        OpenTelemetryConfiguration.TESTING_INMEMORY_MODE = true;
+    }
+
+    @BeforeEach() public void before() {
+        GlobalOpenTelemetry.resetForTest();
+    }
+
+    @After
+    public void after() throws Exception {
+        InMemoryMetricExporterProvider.LAST_CREATED_INSTANCE.reset();
+    }
+
+    @Test
+    @Issue("https://github.com/jenkinsci/opentelemetry-plugin/issues/1156")
+    public void configLoadReconfiguresOtelSdk(JenkinsRule r) throws Exception {
+        var extension = JenkinsOpenTelemetryPluginConfiguration.get();
+        extension.setEndpoint("http://localhost:4317");
+        extension.setServiceName("name-1");
+        r.configRoundtrip();
+        // Not ideal, but Descriptor.getConfigFile is protected.
+        var configXmlPath = new File(Jenkins.get().getRootDir(), extension.getId() + ".xml").toPath();
+        var savedConfigXml = Files.readString(configXmlPath);
+
+        extension.setServiceName("name-2");
+        r.configRoundtrip();
+        await().until(() -> getServiceNameFromLastExportedMetric(JenkinsMetrics.JENKINS_QUEUE_COUNT), is("name-2"));
+
+        // Check that overwriting the config and calling Descriptor.load is enough to reconfigure the OTel SDK.
+        Files.writeString(configXmlPath, savedConfigXml);
+        extension.load();
+        await().until(() -> getServiceNameFromLastExportedMetric(JenkinsMetrics.JENKINS_QUEUE_COUNT), is("name-1"));
+    }
+
+    private static String getServiceNameFromLastExportedMetric(String metricName) {
+        Map<String, MetricData> exportedMetrics = InMemoryMetricExporterUtils.getLastExportedMetricByMetricName(
+                InMemoryMetricExporterProvider.LAST_CREATED_INSTANCE.getFinishedMetricItems());
+        var metric = Optional.ofNullable(exportedMetrics.get(metricName));
+        return metric.map(m -> m.getResource().getAttributes().get(ServiceAttributes.SERVICE_NAME)).orElse(null);
+    }
+
+}


### PR DESCRIPTION
Fixes #1156. The description of that issue goes into detail, but in short, when using CloudBees CI with HA/HS, it is important for `GlobalConfiguration` instances to have their `load` method apply the same logic that would be done if the configuration was edited in the UI and then saved.

This change should not have any effect on OSS Jenkins users in normal usage scenarios as far as I know.

### Testing done

I added a new automated test that covers the relevant logic. I also tested interactively against CloudBees CI with HA/HS.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
