### PR TITLE
feat: Add system property override for service.instance.id

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
@@ -253,11 +253,13 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
         // use same Jenkins instance identifier as the Jenkins Support Core plugin. No need to add the complexity of the
         // instance-identity-plugin
         // https://github.com/jenkinsci/support-core-plugin/blob/support-core-2.81/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java#L401
-        configurationProperties.put(
-                ServiceIncubatingAttributes.SERVICE_INSTANCE_ID.getKey(),
-                Jenkins.get().getLegacyInstanceId());
-        properties.forEach(
-                (k, v) -> configurationProperties.put(Objects.toString(k, "#null#"), Objects.toString(v, "#null#")));
+        // Allow override via system property for environments like CloudBees CI HA where multiple replicas need unique IDs
+        String serviceInstanceId = System.getProperty("io.jenkins.plugins.opentelemetry.service.instance.id");
+        if (serviceInstanceId == null || serviceInstanceId.trim().isEmpty()) {
+            serviceInstanceId = Jenkins.get().getLegacyInstanceId();
+        }
+        configurationProperties.put(ResourceAttributes.SERVICE_INSTANCE_ID.getKey(), serviceInstanceId);
+        properties.forEach((k, v) -> configurationProperties.put(Objects.toString(k, "#null#"), Objects.toString(v, "#null#")));
 
         return new OpenTelemetryConfiguration(
                 Optional.ofNullable(this.getEndpoint()),

--- a/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/JenkinsOpenTelemetryPluginConfiguration.java
@@ -253,13 +253,15 @@ public class JenkinsOpenTelemetryPluginConfiguration extends GlobalConfiguration
         // use same Jenkins instance identifier as the Jenkins Support Core plugin. No need to add the complexity of the
         // instance-identity-plugin
         // https://github.com/jenkinsci/support-core-plugin/blob/support-core-2.81/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java#L401
-        // Allow override via system property for environments like CloudBees CI HA where multiple replicas need unique IDs
+        // Allow override via system property for environments like CloudBees CI HA where multiple replicas need unique
+        // IDs
         String serviceInstanceId = System.getProperty("io.jenkins.plugins.opentelemetry.service.instance.id");
         if (serviceInstanceId == null || serviceInstanceId.trim().isEmpty()) {
             serviceInstanceId = Jenkins.get().getLegacyInstanceId();
         }
-        configurationProperties.put(ResourceAttributes.SERVICE_INSTANCE_ID.getKey(), serviceInstanceId);
-        properties.forEach((k, v) -> configurationProperties.put(Objects.toString(k, "#null#"), Objects.toString(v, "#null#")));
+        configurationProperties.put(ServiceIncubatingAttributes.SERVICE_INSTANCE_ID.getKey(), serviceInstanceId);
+        properties.forEach(
+                (k, v) -> configurationProperties.put(Objects.toString(k, "#null#"), Objects.toString(v, "#null#")));
 
         return new OpenTelemetryConfiguration(
                 Optional.ofNullable(this.getEndpoint()),

--- a/src/test/java/io/jenkins/plugins/opentelemetry/ServiceInstanceIdConfigurationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/ServiceInstanceIdConfigurationTest.java
@@ -1,0 +1,161 @@
+package io.jenkins.plugins.opentelemetry;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+
+import hudson.ExtensionList;
+import io.jenkins.plugins.opentelemetry.semconv.JenkinsOtelSemanticAttributes;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.resources.Resource;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import jenkins.model.Jenkins;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+/**
+ * Integration tests for service.instance.id configuration override via system property.
+ * Tests the ability to programmatically override service.instance.id for environments
+ * like CloudBees CI HA where multiple controller replicas need unique instance IDs.
+ *
+ * @see <a href="https://github.com/jenkinsci/opentelemetry-plugin/issues/1154">Issue #1154</a>
+ */
+@WithJenkins
+@Issue("JENKINS-1154")
+public class ServiceInstanceIdConfigurationTest {
+
+    private static final String SYSTEM_PROPERTY_NAME = "io.jenkins.plugins.opentelemetry.service.instance.id";
+    private JenkinsOpenTelemetryPluginConfiguration plugin;
+    private InMemoryMetricExporterProvider inMemoryMetricExporter;
+
+    @Before
+    public void setup() {
+        plugin = ExtensionList.lookupSingleton(JenkinsOpenTelemetryPluginConfiguration.class);
+        inMemoryMetricExporter = ExtensionList.lookupSingleton(InMemoryMetricExporterProvider.class);
+        plugin.setServiceName("test-service");
+        plugin.setServiceNamespace("test-namespace");
+    }
+
+    @After
+    public void teardown() {
+        // Clean up system property after each test to prevent interference
+        System.clearProperty(SYSTEM_PROPERTY_NAME);
+        if (inMemoryMetricExporter != null) {
+            inMemoryMetricExporter.reset();
+        }
+    }
+
+    /**
+     * Test that when no system property is set, service.instance.id uses Jenkins.getLegacyInstanceId()
+     * This ensures backward compatibility with existing deployments.
+     */
+    @Test
+    public void testDefaultServiceInstanceIdUsesLegacyId() {
+        // Arrange: Ensure system property is not set
+        System.clearProperty(SYSTEM_PROPERTY_NAME);
+        String expectedInstanceId = Jenkins.get().getLegacyInstanceId();
+
+        // Act: Trigger metric export by running a Jenkins job or operation
+        plugin.configure();
+
+        // Wait for metrics to be exported
+        await().atMost(5, TimeUnit.SECONDS).until(() -> !inMemoryMetricExporter.getFinishedMetricItems().isEmpty());
+
+        // Assert: Verify service.instance.id matches legacy instance ID
+        String actualInstanceId = getServiceInstanceIdFromLastExportedMetric();
+        assertThat("service.instance.id should use Jenkins.getLegacyInstanceId() when no system property is set",
+                   actualInstanceId, is(expectedInstanceId));
+    }
+
+    /**
+     * Test that service.instance.id can be overridden via system property.
+     * This enables CloudBees CI HA replicas to have unique instance IDs.
+     */
+    @Test
+    public void testServiceInstanceIdCanBeOverriddenViaSystemProperty() {
+        // Arrange: Set custom instance ID via system property
+        String customInstanceId = "custom-ha-replica-01";
+        System.setProperty(SYSTEM_PROPERTY_NAME, customInstanceId);
+
+        // Act: Trigger metric export
+        plugin.configure();
+
+        // Wait for metrics to be exported
+        await().atMost(5, TimeUnit.SECONDS).until(() -> !inMemoryMetricExporter.getFinishedMetricItems().isEmpty());
+
+        // Assert: Verify service.instance.id uses the custom value
+        String actualInstanceId = getServiceInstanceIdFromLastExportedMetric();
+        assertThat("service.instance.id should use system property value when set",
+                   actualInstanceId, is(customInstanceId));
+    }
+
+    /**
+     * Test that empty system property value falls back to legacy instance ID.
+     * This ensures robustness against misconfiguration.
+     */
+    @Test
+    public void testEmptySystemPropertyFallsBackToLegacyId() {
+        // Arrange: Set system property to empty string
+        System.setProperty(SYSTEM_PROPERTY_NAME, "");
+        String expectedInstanceId = Jenkins.get().getLegacyInstanceId();
+
+        // Act: Trigger metric export
+        plugin.configure();
+
+        // Wait for metrics to be exported
+        await().atMost(5, TimeUnit.SECONDS).until(() -> !inMemoryMetricExporter.getFinishedMetricItems().isEmpty());
+
+        // Assert: Verify service.instance.id falls back to legacy ID
+        String actualInstanceId = getServiceInstanceIdFromLastExportedMetric();
+        assertThat("service.instance.id should fall back to Jenkins.getLegacyInstanceId() when system property is empty",
+                   actualInstanceId, is(expectedInstanceId));
+    }
+
+    /**
+     * Test that whitespace-only system property value falls back to legacy instance ID.
+     * This validates the trim().isEmpty() logic in the implementation.
+     */
+    @Test
+    public void testWhitespaceSystemPropertyFallsBackToLegacyId() {
+        // Arrange: Set system property to whitespace-only string
+        System.setProperty(SYSTEM_PROPERTY_NAME, "   ");
+        String expectedInstanceId = Jenkins.get().getLegacyInstanceId();
+
+        // Act: Trigger metric export
+        plugin.configure();
+
+        // Wait for metrics to be exported
+        await().atMost(5, TimeUnit.SECONDS).until(() -> !inMemoryMetricExporter.getFinishedMetricItems().isEmpty());
+
+        // Assert: Verify service.instance.id falls back to legacy ID
+        String actualInstanceId = getServiceInstanceIdFromLastExportedMetric();
+        assertThat("service.instance.id should fall back to Jenkins.getLegacyInstanceId() when system property is whitespace-only",
+                   actualInstanceId, is(expectedInstanceId));
+    }
+
+    /**
+     * Helper method to extract service.instance.id from the last exported metric.
+     * Inspects the Resource attributes of the most recent metric export.
+     *
+     * @return The service.instance.id value from the last exported metric, or null if not found
+     */
+    private String getServiceInstanceIdFromLastExportedMetric() {
+        List<InMemoryMetricExporter.FinishedMetricItem> metrics = inMemoryMetricExporter.getFinishedMetricItems();
+        assertThat("At least one metric should be exported", metrics, notNullValue());
+        assertThat("Metrics list should not be empty", !metrics.isEmpty());
+
+        // Get the last exported metric
+        InMemoryMetricExporter.FinishedMetricItem lastMetric = metrics.get(metrics.size() - 1);
+        Resource resource = lastMetric.getResource();
+        Attributes attributes = resource.getAttributes();
+
+        // Extract service.instance.id from resource attributes
+        return attributes.get(io.opentelemetry.semconv.ResourceAttributes.SERVICE_INSTANCE_ID);
+    }
+}

--- a/src/test/java/io/jenkins/plugins/opentelemetry/ServiceInstanceIdConfigurationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/ServiceInstanceIdConfigurationTest.java
@@ -6,11 +6,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 
 import hudson.ExtensionList;
-import io.jenkins.plugins.opentelemetry.semconv.JenkinsOtelSemanticAttributes;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.resources.Resource;
-import java.util.Collections;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricExporterProvider;
+import io.opentelemetry.semconv.incubating.ServiceIncubatingAttributes;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import jenkins.model.Jenkins;
 import org.junit.After;
@@ -32,12 +34,10 @@ public class ServiceInstanceIdConfigurationTest {
 
     private static final String SYSTEM_PROPERTY_NAME = "io.jenkins.plugins.opentelemetry.service.instance.id";
     private JenkinsOpenTelemetryPluginConfiguration plugin;
-    private InMemoryMetricExporterProvider inMemoryMetricExporter;
 
     @Before
     public void setup() {
         plugin = ExtensionList.lookupSingleton(JenkinsOpenTelemetryPluginConfiguration.class);
-        inMemoryMetricExporter = ExtensionList.lookupSingleton(InMemoryMetricExporterProvider.class);
         plugin.setServiceName("test-service");
         plugin.setServiceNamespace("test-namespace");
     }
@@ -46,8 +46,8 @@ public class ServiceInstanceIdConfigurationTest {
     public void teardown() {
         // Clean up system property after each test to prevent interference
         System.clearProperty(SYSTEM_PROPERTY_NAME);
-        if (inMemoryMetricExporter != null) {
-            inMemoryMetricExporter.reset();
+        if (InMemoryMetricExporterProvider.LAST_CREATED_INSTANCE != null) {
+            InMemoryMetricExporterProvider.LAST_CREATED_INSTANCE.reset();
         }
     }
 
@@ -61,11 +61,11 @@ public class ServiceInstanceIdConfigurationTest {
         System.clearProperty(SYSTEM_PROPERTY_NAME);
         String expectedInstanceId = Jenkins.get().getLegacyInstanceId();
 
-        // Act: Trigger metric export by running a Jenkins job or operation
-        plugin.configure();
+        // Act: Configure the OpenTelemetry SDK
+        plugin.configureOpenTelemetrySdk();
 
         // Wait for metrics to be exported
-        await().atMost(5, TimeUnit.SECONDS).until(() -> !inMemoryMetricExporter.getFinishedMetricItems().isEmpty());
+        await().atMost(5, TimeUnit.SECONDS).until(() -> !InMemoryMetricExporterProvider.LAST_CREATED_INSTANCE.getFinishedMetricItems().isEmpty());
 
         // Assert: Verify service.instance.id matches legacy instance ID
         String actualInstanceId = getServiceInstanceIdFromLastExportedMetric();
@@ -83,11 +83,11 @@ public class ServiceInstanceIdConfigurationTest {
         String customInstanceId = "custom-ha-replica-01";
         System.setProperty(SYSTEM_PROPERTY_NAME, customInstanceId);
 
-        // Act: Trigger metric export
-        plugin.configure();
+        // Act: Configure the OpenTelemetry SDK
+        plugin.configureOpenTelemetrySdk();
 
         // Wait for metrics to be exported
-        await().atMost(5, TimeUnit.SECONDS).until(() -> !inMemoryMetricExporter.getFinishedMetricItems().isEmpty());
+        await().atMost(5, TimeUnit.SECONDS).until(() -> !InMemoryMetricExporterProvider.LAST_CREATED_INSTANCE.getFinishedMetricItems().isEmpty());
 
         // Assert: Verify service.instance.id uses the custom value
         String actualInstanceId = getServiceInstanceIdFromLastExportedMetric();
@@ -105,11 +105,11 @@ public class ServiceInstanceIdConfigurationTest {
         System.setProperty(SYSTEM_PROPERTY_NAME, "");
         String expectedInstanceId = Jenkins.get().getLegacyInstanceId();
 
-        // Act: Trigger metric export
-        plugin.configure();
+        // Act: Configure the OpenTelemetry SDK
+        plugin.configureOpenTelemetrySdk();
 
         // Wait for metrics to be exported
-        await().atMost(5, TimeUnit.SECONDS).until(() -> !inMemoryMetricExporter.getFinishedMetricItems().isEmpty());
+        await().atMost(5, TimeUnit.SECONDS).until(() -> !InMemoryMetricExporterProvider.LAST_CREATED_INSTANCE.getFinishedMetricItems().isEmpty());
 
         // Assert: Verify service.instance.id falls back to legacy ID
         String actualInstanceId = getServiceInstanceIdFromLastExportedMetric();
@@ -127,11 +127,11 @@ public class ServiceInstanceIdConfigurationTest {
         System.setProperty(SYSTEM_PROPERTY_NAME, "   ");
         String expectedInstanceId = Jenkins.get().getLegacyInstanceId();
 
-        // Act: Trigger metric export
-        plugin.configure();
+        // Act: Configure the OpenTelemetry SDK
+        plugin.configureOpenTelemetrySdk();
 
         // Wait for metrics to be exported
-        await().atMost(5, TimeUnit.SECONDS).until(() -> !inMemoryMetricExporter.getFinishedMetricItems().isEmpty());
+        await().atMost(5, TimeUnit.SECONDS).until(() -> !InMemoryMetricExporterProvider.LAST_CREATED_INSTANCE.getFinishedMetricItems().isEmpty());
 
         // Assert: Verify service.instance.id falls back to legacy ID
         String actualInstanceId = getServiceInstanceIdFromLastExportedMetric();
@@ -146,16 +146,16 @@ public class ServiceInstanceIdConfigurationTest {
      * @return The service.instance.id value from the last exported metric, or null if not found
      */
     private String getServiceInstanceIdFromLastExportedMetric() {
-        List<InMemoryMetricExporter.FinishedMetricItem> metrics = inMemoryMetricExporter.getFinishedMetricItems();
+        List<MetricData> metrics = InMemoryMetricExporterProvider.LAST_CREATED_INSTANCE.getFinishedMetricItems();
         assertThat("At least one metric should be exported", metrics, notNullValue());
         assertThat("Metrics list should not be empty", !metrics.isEmpty());
 
         // Get the last exported metric
-        InMemoryMetricExporter.FinishedMetricItem lastMetric = metrics.get(metrics.size() - 1);
+        MetricData lastMetric = metrics.get(metrics.size() - 1);
         Resource resource = lastMetric.getResource();
         Attributes attributes = resource.getAttributes();
 
         // Extract service.instance.id from resource attributes
-        return attributes.get(io.opentelemetry.semconv.ResourceAttributes.SERVICE_INSTANCE_ID);
+        return attributes.get(ServiceIncubatingAttributes.SERVICE_INSTANCE_ID);
     }
 }

--- a/src/test/java/io/jenkins/plugins/opentelemetry/ServiceInstanceIdConfigurationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/ServiceInstanceIdConfigurationTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package io.jenkins.plugins.opentelemetry;
 
 import static org.awaitility.Awaitility.await;
@@ -5,7 +9,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 
-import hudson.ExtensionList;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.resources.Resource;
@@ -13,11 +17,13 @@ import io.opentelemetry.sdk.testing.exporter.InMemoryMetricExporterProvider;
 import io.opentelemetry.semconv.incubating.ServiceIncubatingAttributes;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 /**
@@ -30,18 +36,33 @@ import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 @WithJenkins
 @Issue("JENKINS-1154")
 public class ServiceInstanceIdConfigurationTest {
+    static {
+        OpenTelemetryConfiguration.TESTING_INMEMORY_MODE = true;
+    }
 
     private static final String SYSTEM_PROPERTY_NAME = "io.jenkins.plugins.opentelemetry.service.instance.id";
+    private JenkinsRule jenkinsRule;
     private JenkinsOpenTelemetryPluginConfiguration plugin;
 
-    @Before
-    public void setup() {
-        plugin = ExtensionList.lookupSingleton(JenkinsOpenTelemetryPluginConfiguration.class);
+    @BeforeEach()
+    public void setUp() {
+        GlobalOpenTelemetry.resetForTest();
+    }
+
+    @BeforeEach
+    public void setup(JenkinsRule rule) {
+        this.jenkinsRule = rule;
+        plugin = GlobalConfiguration.all().get(JenkinsOpenTelemetryPluginConfiguration.class);
+        if (plugin == null) {
+            // If the configuration doesn't exist, create one
+            plugin = new JenkinsOpenTelemetryPluginConfiguration();
+            jenkinsRule.jenkins.getDescriptorByType(JenkinsOpenTelemetryPluginConfiguration.class);
+        }
         plugin.setServiceName("test-service");
         plugin.setServiceNamespace("test-namespace");
     }
 
-    @After
+    @AfterEach
     public void teardown() {
         // Clean up system property after each test to prevent interference
         System.clearProperty(SYSTEM_PROPERTY_NAME);

--- a/src/test/java/io/jenkins/plugins/opentelemetry/ServiceInstanceIdConfigurationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/ServiceInstanceIdConfigurationTest.java
@@ -12,7 +12,6 @@ import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricExporterProvider;
 import io.opentelemetry.semconv.incubating.ServiceIncubatingAttributes;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import jenkins.model.Jenkins;
 import org.junit.After;
@@ -65,12 +64,16 @@ public class ServiceInstanceIdConfigurationTest {
         plugin.configureOpenTelemetrySdk();
 
         // Wait for metrics to be exported
-        await().atMost(5, TimeUnit.SECONDS).until(() -> !InMemoryMetricExporterProvider.LAST_CREATED_INSTANCE.getFinishedMetricItems().isEmpty());
+        await().atMost(5, TimeUnit.SECONDS).until(() -> !InMemoryMetricExporterProvider.LAST_CREATED_INSTANCE
+                .getFinishedMetricItems()
+                .isEmpty());
 
         // Assert: Verify service.instance.id matches legacy instance ID
         String actualInstanceId = getServiceInstanceIdFromLastExportedMetric();
-        assertThat("service.instance.id should use Jenkins.getLegacyInstanceId() when no system property is set",
-                   actualInstanceId, is(expectedInstanceId));
+        assertThat(
+                "service.instance.id should use Jenkins.getLegacyInstanceId() when no system property is set",
+                actualInstanceId,
+                is(expectedInstanceId));
     }
 
     /**
@@ -87,12 +90,16 @@ public class ServiceInstanceIdConfigurationTest {
         plugin.configureOpenTelemetrySdk();
 
         // Wait for metrics to be exported
-        await().atMost(5, TimeUnit.SECONDS).until(() -> !InMemoryMetricExporterProvider.LAST_CREATED_INSTANCE.getFinishedMetricItems().isEmpty());
+        await().atMost(5, TimeUnit.SECONDS).until(() -> !InMemoryMetricExporterProvider.LAST_CREATED_INSTANCE
+                .getFinishedMetricItems()
+                .isEmpty());
 
         // Assert: Verify service.instance.id uses the custom value
         String actualInstanceId = getServiceInstanceIdFromLastExportedMetric();
-        assertThat("service.instance.id should use system property value when set",
-                   actualInstanceId, is(customInstanceId));
+        assertThat(
+                "service.instance.id should use system property value when set",
+                actualInstanceId,
+                is(customInstanceId));
     }
 
     /**
@@ -109,12 +116,16 @@ public class ServiceInstanceIdConfigurationTest {
         plugin.configureOpenTelemetrySdk();
 
         // Wait for metrics to be exported
-        await().atMost(5, TimeUnit.SECONDS).until(() -> !InMemoryMetricExporterProvider.LAST_CREATED_INSTANCE.getFinishedMetricItems().isEmpty());
+        await().atMost(5, TimeUnit.SECONDS).until(() -> !InMemoryMetricExporterProvider.LAST_CREATED_INSTANCE
+                .getFinishedMetricItems()
+                .isEmpty());
 
         // Assert: Verify service.instance.id falls back to legacy ID
         String actualInstanceId = getServiceInstanceIdFromLastExportedMetric();
-        assertThat("service.instance.id should fall back to Jenkins.getLegacyInstanceId() when system property is empty",
-                   actualInstanceId, is(expectedInstanceId));
+        assertThat(
+                "service.instance.id should fall back to Jenkins.getLegacyInstanceId() when system property is empty",
+                actualInstanceId,
+                is(expectedInstanceId));
     }
 
     /**
@@ -131,12 +142,16 @@ public class ServiceInstanceIdConfigurationTest {
         plugin.configureOpenTelemetrySdk();
 
         // Wait for metrics to be exported
-        await().atMost(5, TimeUnit.SECONDS).until(() -> !InMemoryMetricExporterProvider.LAST_CREATED_INSTANCE.getFinishedMetricItems().isEmpty());
+        await().atMost(5, TimeUnit.SECONDS).until(() -> !InMemoryMetricExporterProvider.LAST_CREATED_INSTANCE
+                .getFinishedMetricItems()
+                .isEmpty());
 
         // Assert: Verify service.instance.id falls back to legacy ID
         String actualInstanceId = getServiceInstanceIdFromLastExportedMetric();
-        assertThat("service.instance.id should fall back to Jenkins.getLegacyInstanceId() when system property is whitespace-only",
-                   actualInstanceId, is(expectedInstanceId));
+        assertThat(
+                "service.instance.id should fall back to Jenkins.getLegacyInstanceId() when system property is whitespace-only",
+                actualInstanceId,
+                is(expectedInstanceId));
     }
 
     /**


### PR DESCRIPTION
## Summary

Add ability to override `service.instance.id` via system property for CloudBees CI high availability scenarios where multiple controller replicas need unique instance identifiers.

## Changes

- **UPDATE**: `JenkinsOpenTelemetryPluginConfiguration.java`
  - Add system property check: `io.jenkins.plugins.opentelemetry.service.instance.id`
  - Fall back to `Jenkins.getLegacyInstanceId()` when property not set
  - Maintain 100% backward compatibility

- **NEW**: `ServiceInstanceIdConfigurationTest.java`
  - Integration test for default behavior (backward compatibility)
  - Integration test for system property override
  - Edge case tests (empty string, whitespace-only values)
  - Uses Jenkins Test Harness and InMemoryMetricExporter

## Testing

- 4 integration tests using Jenkins Test Harness
- Tests validate both default and override behaviors
- Edge cases covered (empty/whitespace values)

## Additional Information

- **Property name**: `io.jenkins.plugins.opentelemetry.service.instance.id`
- **Usage**: Set via JVM system property (e.g., `-Dio.jenkins.plugins.opentelemetry.service.instance.id=replica-01`)
- **No configuration UI changes needed**
- **No breaking changes**

Closes #1154