### PR TITLE
Fix infinite recursion in JUL log handler

### DIFF
--- a/src/test/java/io/jenkins/plugins/opentelemetry/init/OtelJulHandlerTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/init/OtelJulHandlerTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.init;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.jenkins.plugins.opentelemetry.api.ReconfigurableOpenTelemetry;
+import io.opentelemetry.api.logs.LogRecordBuilder;
+import io.opentelemetry.api.logs.Logger;
+import io.opentelemetry.api.logs.LoggerProvider;
+import java.lang.reflect.Field;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import org.junit.Before;
+import org.junit.Test;
+
+public class OtelJulHandlerTest {
+
+    private OtelJulHandler handler;
+    private LogRecordBuilder mockLogRecordBuilder;
+
+    @Before
+    public void setUp() throws Exception {
+        handler = new OtelJulHandler();
+
+        LoggerProvider mockProvider = mock(LoggerProvider.class);
+        Logger mockLogger = mock(Logger.class);
+        mockLogRecordBuilder = mock(LogRecordBuilder.class);
+        ReconfigurableOpenTelemetry mockOpenTelemetry = mock(ReconfigurableOpenTelemetry.class);
+
+        when(mockProvider.get(anyString())).thenReturn(mockLogger);
+        when(mockLogger.logRecordBuilder()).thenReturn(mockLogRecordBuilder);
+        when(mockLogRecordBuilder.setBody(anyString())).thenReturn(mockLogRecordBuilder);
+        when(mockLogRecordBuilder.setTimestamp(any())).thenReturn(mockLogRecordBuilder);
+        when(mockLogRecordBuilder.setSeverity(any())).thenReturn(mockLogRecordBuilder);
+        when(mockLogRecordBuilder.setSeverityText(anyString())).thenReturn(mockLogRecordBuilder);
+        when(mockLogRecordBuilder.setAllAttributes(any())).thenReturn(mockLogRecordBuilder);
+        when(mockLogRecordBuilder.setContext(any())).thenReturn(mockLogRecordBuilder);
+
+        setField(handler, "openTelemetry", mockOpenTelemetry);
+        setField(handler, "loggerProvider", mockProvider);
+    }
+
+    @Test
+    public void publish_catchesThrowable_andDisablesHandler() throws Exception {
+        doThrow(new LinkageError("boom")).when(mockLogRecordBuilder).emit();
+
+        handler.publish(new LogRecord(Level.INFO, "test"));
+        assertTrue("Handler should be disabled after crash", getDisabled(handler));
+    }
+
+    @Test
+    public void publish_preventsRecursiveLogging() throws Exception {
+        doAnswer(invocation -> {
+                    handler.publish(new LogRecord(Level.INFO, "recursive"));
+                    return null;
+                })
+                .when(mockLogRecordBuilder)
+                .emit();
+
+        handler.publish(new LogRecord(Level.INFO, "outer"));
+        verify(mockLogRecordBuilder, times(1)).emit();
+        assertFalse("Handler disabled itself, which means recursion caused an error", getDisabled(handler));
+    }
+
+    @Test
+    public void publish_noop_whenLoggerProviderNull() throws Exception {
+        setField(handler, "loggerProvider", null);
+        handler.publish(new LogRecord(Level.INFO, "test"));
+        verifyNoInteractions(mockLogRecordBuilder);
+    }
+
+    @Test
+    public void publish_noop_whenDisabled() throws Exception {
+        setField(handler, "disabled", true);
+        handler.publish(new LogRecord(Level.INFO, "test"));
+        verifyNoInteractions(mockLogRecordBuilder);
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        Field f = target.getClass().getDeclaredField(fieldName);
+        f.setAccessible(true);
+        f.set(target, value);
+    }
+
+    private static boolean getDisabled(OtelJulHandler handler) throws Exception {
+        Field f = handler.getClass().getDeclaredField("disabled");
+        f.setAccessible(true);
+        return (boolean) f.get(handler);
+    }
+}


### PR DESCRIPTION
Fixed #1201 

Fix infinite recursion and hard failures in JUL log handler by adding a thread-local recursion guard and defensive initialization. The handler now fails closed on any OpenTelemetry errors instead of risking Jenkins startup or runtime crashes, and delays registration until Jenkins and the OTel SDK are ready

### Testing done

Added unit tests covering:
- Handler disables itself when any Throwable occurs during log emission
- Thread-local recursion guard prevents re-entrant logging on the same thread
- publish() is a no-op when the handler is disabled, or the logger provider is uninitialized
- Verified that the handler registers after Jenkins startup without causing crashes or infinite recursion

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed