### PR TITLE
Fix ClassCircularityError during plugin initialization (#1201)

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/init/OtelJulHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/init/OtelJulHandler.java
@@ -51,15 +51,7 @@ public class OtelJulHandler extends Handler implements OpenTelemetryLifecycleLis
     protected ReconfigurableOpenTelemetry openTelemetry;
 
     public OtelJulHandler() {
-        // Constructor intentionally minimal to avoid circular class loading during initialization
-        // Context.current() call removed to fix ClassCircularityError (issue #1201)
-        // See https://github.com/jenkinsci/opentelemetry-plugin/issues/1201
-        // The original Context.current() call was added for issue #622 but caused circularity
-        try {
-            logger.log(Level.FINER, "OtelJulHandler constructor completed");
-        } catch (Exception e) {
-            logger.log(Level.WARNING, "Exception during OtelJulHandler construction", e);
-        }
+        logger.log(Level.FINER, "OtelJulHandler constructor completed");
     }
 
     /**


### PR DESCRIPTION
## Problem
Installing the OpenTelemetry plugin on Jenkins 2.516.3 causes a `ClassCircularityError` that prevents Jenkins from starting. The error occurs during garbage collection thread execution when the JVM detects circular class loading dependencies.

## Root Cause
The `OtelJulHandler` constructor calls `Context.current()` for debugging purposes. During early Jenkins initialization, this triggers a circular class loading dependency:

1. `OtelJulHandler` constructor calls `Context.current()`
2. `Context` initialization may trigger logging
3. Logging attempts to use `OtelJulHandler.publish()`
4. `publish()` triggers `BatchLogRecordProcessor` which records metrics
5. Metrics recording tries to load `RandomFixedSizeExemplarReservoir`
6. JVM detects circular dependency and throws `ClassCircularityError`

## Solution
Removed the `Context.current()` call from the constructor. This call was:
- Only used for FINER level debugging
- Not essential for plugin functionality

Closes #1201
