### PR TITLE
Add configurable ci.pipeline.id to pipeline run metrics

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/semconv/ConfigurationKey.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/semconv/ConfigurationKey.java
@@ -52,6 +52,10 @@ public final class ConfigurationKey {
             new ConfigurationKey("otel.instrumentation.jenkins.run.metric.duration.allow_list");
     public static final ConfigurationKey OTEL_INSTRUMENTATION_JENKINS_RUN_DURATION_DENY_LIST =
             new ConfigurationKey("otel.instrumentation.jenkins.run.metric.duration.deny_list");
+    public static final ConfigurationKey OTEL_INSTRUMENTATION_JENKINS_RUN_ALLOW_LIST =
+            new ConfigurationKey("otel.instrumentation.jenkins.run.metric.allow_list");
+    public static final ConfigurationKey OTEL_INSTRUMENTATION_JENKINS_RUN_DENY_LIST =
+            new ConfigurationKey("otel.instrumentation.jenkins.run.metric.deny_list");
     /**
      * Instrument Jenkins Remoting from the Jenkins controller to Jenkins build agents
      */

--- a/src/test/java/io/jenkins/plugins/opentelemetry/job/MonitoringRunListenerTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/job/MonitoringRunListenerTest.java
@@ -6,7 +6,12 @@
 package io.jenkins.plugins.opentelemetry.job;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import hudson.model.Job;
+import hudson.model.Run;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
 import java.util.Map;
 import org.junit.Test;
@@ -101,5 +106,85 @@ public class MonitoringRunListenerTest {
                 .runDurationHistogramDenyList
                 .matcher(jobFullName)
                 .matches());
+    }
+
+    @Test
+    public void testCountersIncludePipelineIdWhenAllowed() {
+        MonitoringRunListener listener = new MonitoringRunListener();
+
+        ConfigProperties config = DefaultConfigProperties.createFromMap(
+                Map.of("otel.instrumentation.jenkins.run.metric.allow_list", ".*"));
+        listener.afterConfiguration(config);
+
+        Run<?, ?> run = mockRun("folder/job-name");
+
+        assertEquals("folder/job-name", listener.getPipelineIdForCounters(run));
+    }
+
+    @Test
+    public void testCountersCollapsePipelineIdWhenDenied() {
+        MonitoringRunListener listener = new MonitoringRunListener();
+
+        ConfigProperties config = DefaultConfigProperties.createFromMap(
+                Map.of("otel.instrumentation.jenkins.run.metric.allow_list", "team-a/.*"));
+        listener.afterConfiguration(config);
+
+        Run<?, ?> run = mockRun("team-b/job-x");
+
+        assertEquals("#other#", listener.getPipelineIdForCounters(run));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidRegexThrowsException() {
+        MonitoringRunListener listener = new MonitoringRunListener();
+
+        ConfigProperties config = DefaultConfigProperties.createFromMap(
+                Map.of("otel.instrumentation.jenkins.run.metric.allow_list", "*invalid["));
+
+        listener.afterConfiguration(config);
+    }
+
+    @Test
+    public void testDurationAllowAndDenyLists() {
+        MonitoringRunListener listener = new MonitoringRunListener();
+
+        ConfigProperties config = DefaultConfigProperties.createFromMap(Map.of(
+                "otel.instrumentation.jenkins.run.metric.duration.allow_list", "my-team/.*",
+                "otel.instrumentation.jenkins.run.metric.duration.deny_list", ".*test.*"));
+        listener.afterConfiguration(config);
+
+        String job = "my-team/my-war/test-123";
+        assertTrue(listener.runDurationHistogramAllowList.matcher(job).matches());
+        assertTrue(listener.runDurationHistogramDenyList.matcher(job).matches());
+    }
+
+    @SuppressWarnings("rawtypes")
+    private Run<?, ?> mockRun(String fullName) {
+        Job job = mock(Job.class);
+        when(job.getFullName()).thenReturn(fullName);
+
+        Run run = mock(Run.class);
+        when(run.getParent()).thenReturn(job);
+
+        return run;
+    }
+
+    @Test
+    public void testCountersAndDurationUseIndependentAllowLists() {
+        MonitoringRunListener listener = new MonitoringRunListener();
+
+        ConfigProperties config = DefaultConfigProperties.createFromMap(Map.of(
+                "otel.instrumentation.jenkins.run.metric.allow_list", "team-a/.*",
+                "otel.instrumentation.jenkins.run.metric.duration.allow_list", "team-b/.*"));
+        listener.afterConfiguration(config);
+
+        Run<?, ?> runA = mockRun("team-a/job1");
+        Run<?, ?> runB = mockRun("team-b/job2");
+
+        assertEquals("team-a/job1", listener.getPipelineIdForCounters(runA));
+        assertEquals("#other#", listener.getPipelineIdForCounters(runB));
+
+        assertEquals("#other#", listener.getPipelineIdForDuration(runA));
+        assertEquals("team-b/job2", listener.getPipelineIdForDuration(runB));
     }
 }


### PR DESCRIPTION
Add optional ci.pipeline.id to pipeline run metrics with allow/deny lists. Pipeline run counter metrics (launched, started, completed, success, failed, aborted) can now include the ci.pipeline.id attribute when explicitly enabled via configuration.

Fixed #1159 

### Testing done
- Added unit tests validating allow/deny list behavior for pipeline run metrics.
- Verified duration metrics are unaffected.
- All tests pass locally.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed