### PR TITLE
Fix Grafana explore URL generation and add Tempo datasource UID support

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/GrafanaBackend.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/GrafanaBackend.java
@@ -72,6 +72,7 @@ public class GrafanaBackend extends ObservabilityBackend {
     @DataBoundConstructor
     public GrafanaBackend() {}
 
+    @SuppressWarnings("unused")
     protected Object readResolve() {
         if (tempoDataSourceIdentifier != null) {
             if (tempoDataSourceUid == null || tempoDataSourceUid.equals(DEFAULT_TEMPO_DATA_SOURCE_IDENTIFIER)) {

--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/GrafanaBackend.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/GrafanaBackend.java
@@ -57,8 +57,11 @@ public class GrafanaBackend extends ObservabilityBackend {
     private String grafanaBaseUrl;
 
     private String grafanaMetricsDashboard;
-    private String tempoDataSourceIdentifier = DEFAULT_TEMPO_DATA_SOURCE_IDENTIFIER;
-    private String tempoDataSourceUid;
+
+    @Deprecated
+    private String tempoDataSourceIdentifier;
+
+    private String tempoDataSourceUid = DEFAULT_TEMPO_DATA_SOURCE_IDENTIFIER;
 
     private String grafanaOrgId = DEFAULT_GRAFANA_ORG_ID;
 
@@ -68,6 +71,16 @@ public class GrafanaBackend extends ObservabilityBackend {
 
     @DataBoundConstructor
     public GrafanaBackend() {}
+
+    protected Object readResolve() {
+        if (tempoDataSourceIdentifier != null) {
+            if (tempoDataSourceUid == null || tempoDataSourceUid.equals(DEFAULT_TEMPO_DATA_SOURCE_IDENTIFIER)) {
+                this.tempoDataSourceUid = tempoDataSourceIdentifier;
+            }
+            this.tempoDataSourceIdentifier = null;
+        }
+        return this;
+    }
 
     @Nullable
     @Override
@@ -127,15 +140,13 @@ public class GrafanaBackend extends ObservabilityBackend {
         GrafanaBackend that = (GrafanaBackend) o;
         return Objects.equals(grafanaOrgId, that.grafanaOrgId)
                 && Objects.equals(grafanaBaseUrl, that.grafanaBaseUrl)
-                && Objects.equals(tempoDataSourceIdentifier, that.tempoDataSourceIdentifier)
                 && Objects.equals(tempoDataSourceUid, that.tempoDataSourceUid)
                 && Objects.equals(tempoQueryType, that.tempoQueryType);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(
-                grafanaBaseUrl, tempoDataSourceIdentifier, tempoDataSourceUid, grafanaOrgId, tempoQueryType);
+        return Objects.hash(grafanaBaseUrl, tempoDataSourceUid, grafanaOrgId, tempoQueryType);
     }
 
     @Override
@@ -157,11 +168,9 @@ public class GrafanaBackend extends ObservabilityBackend {
                 TemplateBindings.GRAFANA_ORG_ID,
                 String.valueOf(this.getGrafanaOrgId()),
                 TemplateBindings.GRAFANA_TEMPO_DATASOURCE_IDENTIFIER,
-                this.getTempoDataSourceIdentifier(),
+                this.getTempoDataSourceUid(),
                 TemplateBindings.GRAFANA_TEMPO_DATASOURCE_UID,
-                StringUtils.isNotBlank(this.getTempoDataSourceUid())
-                        ? this.getTempoDataSourceUid()
-                        : this.getTempoDataSourceIdentifier(),
+                this.getTempoDataSourceUid(),
                 TemplateBindings.GRAFANA_TEMPO_QUERY_TYPE,
                 this.getTempoQueryType());
 
@@ -192,12 +201,12 @@ public class GrafanaBackend extends ObservabilityBackend {
         this.grafanaBaseUrl = grafanaBaseUrl;
     }
 
-    @DataBoundSetter
+    @Deprecated
     public String getTempoDataSourceIdentifier() {
         return tempoDataSourceIdentifier;
     }
 
-    @DataBoundSetter
+    @Deprecated
     public void setTempoDataSourceIdentifier(String tempoDataSourceIdentifier) {
         this.tempoDataSourceIdentifier = tempoDataSourceIdentifier;
     }
@@ -270,6 +279,11 @@ public class GrafanaBackend extends ObservabilityBackend {
         }
 
         public String getDefaultTempoDataSourceIdentifier() {
+            return DEFAULT_TEMPO_DATA_SOURCE_IDENTIFIER;
+        }
+
+        @SuppressWarnings("unused")
+        public String getDefaultTempoDataSourceUid() {
             return DEFAULT_TEMPO_DATA_SOURCE_IDENTIFIER;
         }
 

--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/GrafanaBackend.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/GrafanaBackend.java
@@ -72,15 +72,13 @@ public class GrafanaBackend extends ObservabilityBackend {
     @DataBoundConstructor
     public GrafanaBackend() {}
 
-    @SuppressWarnings("unused")
-    protected Object readResolve() {
+    protected void readResolve() {
         if (tempoDataSourceIdentifier != null) {
             if (tempoDataSourceUid == null || tempoDataSourceUid.equals(DEFAULT_TEMPO_DATA_SOURCE_IDENTIFIER)) {
                 this.tempoDataSourceUid = tempoDataSourceIdentifier;
             }
             this.tempoDataSourceIdentifier = null;
         }
-        return this;
     }
 
     @Nullable
@@ -283,7 +281,6 @@ public class GrafanaBackend extends ObservabilityBackend {
             return DEFAULT_TEMPO_DATA_SOURCE_IDENTIFIER;
         }
 
-        @SuppressWarnings("unused")
         public String getDefaultTempoDataSourceUid() {
             return DEFAULT_TEMPO_DATA_SOURCE_IDENTIFIER;
         }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/GrafanaBackend.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/GrafanaBackend.java
@@ -58,6 +58,7 @@ public class GrafanaBackend extends ObservabilityBackend {
 
     private String grafanaMetricsDashboard;
     private String tempoDataSourceIdentifier = DEFAULT_TEMPO_DATA_SOURCE_IDENTIFIER;
+    private String tempoDataSourceUid;
 
     private String grafanaOrgId = DEFAULT_GRAFANA_ORG_ID;
 
@@ -71,14 +72,15 @@ public class GrafanaBackend extends ObservabilityBackend {
     @Nullable
     @Override
     public String getTraceVisualisationUrlTemplate() {
-        return "${" + TemplateBindings.GRAFANA_BASE_URL + "}" + "/explore?orgId="
+        return "${" + TemplateBindings.GRAFANA_BASE_URL + "}" + "/explore?schemaVersion=1&orgId="
                 + "${"
-                + TemplateBindings.GRAFANA_ORG_ID + "}" + "&left=%7B%22datasource%22:%22"
+                + TemplateBindings.GRAFANA_ORG_ID + "}" + "&panes=%7B%22pane1%22:%7B%22datasource%22:%22"
                 + "${"
-                + TemplateBindings.GRAFANA_TEMPO_DATASOURCE_IDENTIFIER + "}"
+                + TemplateBindings.GRAFANA_TEMPO_DATASOURCE_UID + "}"
                 + "%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22tempo%22,%22uid%22:%22"
                 + "${"
-                + TemplateBindings.GRAFANA_TEMPO_DATASOURCE_IDENTIFIER + "}" + "%22%7D,%22queryType%22:%22${"
+                + TemplateBindings.GRAFANA_TEMPO_DATASOURCE_UID + "}"
+                + "%22%7D,%22queryType%22:%22${"
                 + TemplateBindings.GRAFANA_TEMPO_QUERY_TYPE + "}%22,%22query%22:%22" + "${traceId}"
                 + "%22%7D%5D,%22range%22:%7B%22from%22:%22"
                 + "${"
@@ -88,7 +90,7 @@ public class GrafanaBackend extends ObservabilityBackend {
                 + "${"
                 + TemplateBindings.START_TIME
                 + ".plusSeconds(600).atZone(java.util.TimeZone.getDefault().toZoneId()).toInstant().toEpochMilli()}"
-                + "%22%7D%7D";
+                + "%22%7D%7D%7D";
     }
 
     /**
@@ -126,12 +128,14 @@ public class GrafanaBackend extends ObservabilityBackend {
         return Objects.equals(grafanaOrgId, that.grafanaOrgId)
                 && Objects.equals(grafanaBaseUrl, that.grafanaBaseUrl)
                 && Objects.equals(tempoDataSourceIdentifier, that.tempoDataSourceIdentifier)
+                && Objects.equals(tempoDataSourceUid, that.tempoDataSourceUid)
                 && Objects.equals(tempoQueryType, that.tempoQueryType);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(grafanaBaseUrl, tempoDataSourceIdentifier, grafanaOrgId, tempoQueryType);
+        return Objects.hash(
+                grafanaBaseUrl, tempoDataSourceIdentifier, tempoDataSourceUid, grafanaOrgId, tempoQueryType);
     }
 
     @Override
@@ -144,12 +148,22 @@ public class GrafanaBackend extends ObservabilityBackend {
     @Override
     public Map<String, Object> getBindings() {
         Map<String, Object> bindings = Map.of(
-                TemplateBindings.BACKEND_NAME, getName(),
-                TemplateBindings.BACKEND_24_24_ICON_URL, "/plugin/opentelemetry/images/24x24/grafana.png",
-                TemplateBindings.GRAFANA_BASE_URL, this.getGrafanaBaseUrl(),
-                TemplateBindings.GRAFANA_ORG_ID, String.valueOf(this.getGrafanaOrgId()),
-                TemplateBindings.GRAFANA_TEMPO_DATASOURCE_IDENTIFIER, this.getTempoDataSourceIdentifier(),
-                TemplateBindings.GRAFANA_TEMPO_QUERY_TYPE, this.getTempoQueryType());
+                TemplateBindings.BACKEND_NAME,
+                getName(),
+                TemplateBindings.BACKEND_24_24_ICON_URL,
+                "/plugin/opentelemetry/images/24x24/grafana.png",
+                TemplateBindings.GRAFANA_BASE_URL,
+                this.getGrafanaBaseUrl(),
+                TemplateBindings.GRAFANA_ORG_ID,
+                String.valueOf(this.getGrafanaOrgId()),
+                TemplateBindings.GRAFANA_TEMPO_DATASOURCE_IDENTIFIER,
+                this.getTempoDataSourceIdentifier(),
+                TemplateBindings.GRAFANA_TEMPO_DATASOURCE_UID,
+                StringUtils.isNotBlank(this.getTempoDataSourceUid())
+                        ? this.getTempoDataSourceUid()
+                        : this.getTempoDataSourceIdentifier(),
+                TemplateBindings.GRAFANA_TEMPO_QUERY_TYPE,
+                this.getTempoQueryType());
 
         if (grafanaLogsBackend instanceof TemplateBindingsProvider) {
             Map<String, Object> logsBackendBindings = ((TemplateBindingsProvider) grafanaLogsBackend).getBindings();
@@ -186,6 +200,15 @@ public class GrafanaBackend extends ObservabilityBackend {
     @DataBoundSetter
     public void setTempoDataSourceIdentifier(String tempoDataSourceIdentifier) {
         this.tempoDataSourceIdentifier = tempoDataSourceIdentifier;
+    }
+
+    public String getTempoDataSourceUid() {
+        return tempoDataSourceUid;
+    }
+
+    @DataBoundSetter
+    public void setTempoDataSourceUid(String tempoDataSourceUid) {
+        this.tempoDataSourceUid = tempoDataSourceUid;
     }
 
     @DataBoundSetter
@@ -280,6 +303,7 @@ public class GrafanaBackend extends ObservabilityBackend {
     public interface TemplateBindings extends ObservabilityBackend.TemplateBindings {
         String GRAFANA_BASE_URL = "grafanaBaseUrl";
         String GRAFANA_TEMPO_DATASOURCE_IDENTIFIER = "grafanaTempoDatasourceIdentifier";
+        String GRAFANA_TEMPO_DATASOURCE_UID = "grafanaTempoDatasourceUid";
         String GRAFANA_LOKI_DATASOURCE_IDENTIFIER = "grafanaLokiDatasourceIdentifier";
         String GRAFANA_ORG_ID = "grafanaOrgId";
         String GRAFANA_TEMPO_QUERY_TYPE = "grafanaTempoQueryType";

--- a/src/main/resources/io/jenkins/plugins/opentelemetry/backend/GrafanaBackend/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/opentelemetry/backend/GrafanaBackend/config.jelly
@@ -26,6 +26,10 @@
                  description="Identifier of the Tempo datasource in which the Jenkins pipeline build traces are stored.">
             <f:textbox default="${descriptor.defaultTempoDataSourceIdentifier}"/>
         </f:entry>
+        <f:entry title="Tempo data source UID" field="tempoDataSourceUid"
+                 description="The unique identifier (UUID) of the Tempo datasource in Grafana.">
+            <f:textbox />
+        </f:entry>
         <f:entry title="Tempo Query Type" field="tempoQueryType"
                  description="Query type passed to Tempo, used when searching for the specific trace.">
             <f:select default="${descriptor.defaultTempoQueryType}"/>

--- a/src/main/resources/io/jenkins/plugins/opentelemetry/backend/GrafanaBackend/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/opentelemetry/backend/GrafanaBackend/config.jelly
@@ -22,13 +22,9 @@
         <p>
             <strong>Grafana</strong>
         </p>
-        <f:entry title="Tempo data source identifier" field="tempoDataSourceIdentifier"
-                 description="Identifier of the Tempo datasource in which the Jenkins pipeline build traces are stored.">
-            <f:textbox default="${descriptor.defaultTempoDataSourceIdentifier}"/>
-        </f:entry>
         <f:entry title="Tempo data source UID" field="tempoDataSourceUid"
                  description="The unique identifier (UUID) of the Tempo datasource in Grafana.">
-            <f:textbox />
+            <f:textbox default="${descriptor.defaultTempoDataSourceUid}"/>
         </f:entry>
         <f:entry title="Tempo Query Type" field="tempoQueryType"
                  description="Query type passed to Tempo, used when searching for the specific trace.">

--- a/src/test/java/io/jenkins/plugins/opentelemetry/backend/GrafanaBackendTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/backend/GrafanaBackendTest.java
@@ -22,7 +22,6 @@ public class GrafanaBackendTest {
         GrafanaBackend grafanaBackend = new GrafanaBackend();
         grafanaBackend.setGrafanaBaseUrl("https://cleclerc.grafana.net");
         grafanaBackend.setGrafanaOrgId("1");
-        grafanaBackend.setTempoDataSourceIdentifier("grafanacloud-traces");
         grafanaBackend.setTempoDataSourceUid("my-awesome-custom-uid");
         grafanaBackend.setTempoQueryType("traceql");
 
@@ -46,6 +45,7 @@ public class GrafanaBackendTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testTraceUrlFallbackToIdentifier() {
         GrafanaBackend grafanaBackend = new GrafanaBackend();
         grafanaBackend.setGrafanaBaseUrl("https://cleclerc.grafana.net");
@@ -78,14 +78,12 @@ public class GrafanaBackendTest {
         GrafanaBackend backend1 = new GrafanaBackend();
         backend1.setGrafanaBaseUrl("http://grafana");
         backend1.setGrafanaOrgId("1");
-        backend1.setTempoDataSourceIdentifier("tempo");
         backend1.setTempoDataSourceUid("tempo-uid");
         backend1.setTempoQueryType("traceql");
 
         GrafanaBackend backend2 = new GrafanaBackend();
         backend2.setGrafanaBaseUrl("http://grafana");
         backend2.setGrafanaOrgId("1");
-        backend2.setTempoDataSourceIdentifier("tempo");
         backend2.setTempoDataSourceUid("tempo-uid");
         backend2.setTempoQueryType("traceql");
 

--- a/src/test/java/io/jenkins/plugins/opentelemetry/backend/GrafanaBackendTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/backend/GrafanaBackendTest.java
@@ -5,16 +5,47 @@
 
 package io.jenkins.plugins.opentelemetry.backend;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import org.junit.jupiter.api.Test;
 
 public class GrafanaBackendTest {
 
     @Test
     public void testTraceUrl() {
+        GrafanaBackend grafanaBackend = new GrafanaBackend();
+        grafanaBackend.setGrafanaBaseUrl("https://cleclerc.grafana.net");
+        grafanaBackend.setGrafanaOrgId("1");
+        grafanaBackend.setTempoDataSourceIdentifier("grafanacloud-traces");
+        grafanaBackend.setTempoDataSourceUid("my-awesome-custom-uid");
+        grafanaBackend.setTempoQueryType("traceql");
+
+        LocalDateTime buildTime =
+                LocalDateTime.parse("2023-02-05 23:31:52.610", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS"));
+
+        Map<String, Object> bindings = new HashMap<>();
+        bindings.put("serviceName", "jenkins");
+        bindings.put("rootSpanName", "BUILD my-app");
+        bindings.put("traceId", "f464e1f32444443d3fc00fdb19e5c124");
+        bindings.put("spanId", "00799ea60984f33f");
+        bindings.put("startTime", buildTime);
+
+        String actualUrl = grafanaBackend.getTraceVisualisationUrl(bindings);
+        System.out.println(actualUrl);
+
+        assertTrue(Objects.requireNonNull(actualUrl).contains("schemaVersion=1"), "URL must contain schemaVersion=1");
+        assertTrue(actualUrl.contains("panes="), "URL must use 'panes' instead of 'left'");
+        assertTrue(actualUrl.contains("my-awesome-custom-uid"), "URL must contain the new Tempo UID");
+        assertTrue(actualUrl.contains("f464e1f32444443d3fc00fdb19e5c124"), "URL must contain the exact traceId");
+    }
+
+    @Test
+    public void testTraceUrlFallbackToIdentifier() {
         GrafanaBackend grafanaBackend = new GrafanaBackend();
         grafanaBackend.setGrafanaBaseUrl("https://cleclerc.grafana.net");
         grafanaBackend.setGrafanaOrgId("1");
@@ -31,7 +62,13 @@ public class GrafanaBackendTest {
         bindings.put("spanId", "00799ea60984f33f");
         bindings.put("startTime", buildTime);
 
-        String actualTraceVisualisationUrl = grafanaBackend.getTraceVisualisationUrl(bindings);
-        System.out.println(actualTraceVisualisationUrl);
+        String actualUrl = grafanaBackend.getTraceVisualisationUrl(bindings);
+
+        assertTrue(Objects.requireNonNull(actualUrl).contains("schemaVersion=1"), "URL must contain schemaVersion=1");
+        assertTrue(actualUrl.contains("panes="), "URL must use 'panes' instead of 'left'");
+        assertTrue(
+                actualUrl.contains("grafanacloud-traces"),
+                "URL must fall back to the tempoDataSourceIdentifier when UID is missing");
+        assertTrue(actualUrl.contains("f464e1f32444443d3fc00fdb19e5c124"), "URL must contain the exact traceId");
     }
 }

--- a/src/test/java/io/jenkins/plugins/opentelemetry/backend/GrafanaBackendTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/backend/GrafanaBackendTest.java
@@ -118,10 +118,7 @@ public class GrafanaBackendTest {
     public void testDescriptorDefaultTempoDataSourceUid() {
         GrafanaBackend.DescriptorImpl descriptor = new GrafanaBackend.DescriptorImpl();
 
-        assertEquals(
-            "grafanacloud-traces",
-            descriptor.getDefaultTempoDataSourceUid()
-        );
+        assertEquals("grafanacloud-traces", descriptor.getDefaultTempoDataSourceUid());
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/opentelemetry/backend/GrafanaBackendTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/backend/GrafanaBackendTest.java
@@ -5,6 +5,7 @@
 
 package io.jenkins.plugins.opentelemetry.backend;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDateTime;
@@ -70,5 +71,25 @@ public class GrafanaBackendTest {
                 actualUrl.contains("grafanacloud-traces"),
                 "URL must fall back to the tempoDataSourceIdentifier when UID is missing");
         assertTrue(actualUrl.contains("f464e1f32444443d3fc00fdb19e5c124"), "URL must contain the exact traceId");
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        GrafanaBackend backend1 = new GrafanaBackend();
+        backend1.setGrafanaBaseUrl("http://grafana");
+        backend1.setGrafanaOrgId("1");
+        backend1.setTempoDataSourceIdentifier("tempo");
+        backend1.setTempoDataSourceUid("tempo-uid");
+        backend1.setTempoQueryType("traceql");
+
+        GrafanaBackend backend2 = new GrafanaBackend();
+        backend2.setGrafanaBaseUrl("http://grafana");
+        backend2.setGrafanaOrgId("1");
+        backend2.setTempoDataSourceIdentifier("tempo");
+        backend2.setTempoDataSourceUid("tempo-uid");
+        backend2.setTempoQueryType("traceql");
+
+        assertEquals(backend1, backend2);
+        assertEquals(backend1.hashCode(), backend2.hashCode());
     }
 }

--- a/src/test/java/io/jenkins/plugins/opentelemetry/backend/GrafanaBackendTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/backend/GrafanaBackendTest.java
@@ -90,4 +90,46 @@ public class GrafanaBackendTest {
         assertEquals(backend1, backend2);
         assertEquals(backend1.hashCode(), backend2.hashCode());
     }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testReadResolveMigratesIdentifierToUid() {
+        GrafanaBackend backend = new GrafanaBackend();
+
+        backend.setTempoDataSourceIdentifier("old-datasource-id");
+        backend.readResolve();
+
+        assertEquals("old-datasource-id", backend.getTempoDataSourceUid());
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testReadResolveDoesNotOverrideExistingUid() {
+        GrafanaBackend backend = new GrafanaBackend();
+
+        backend.setTempoDataSourceIdentifier("old-id");
+        backend.setTempoDataSourceUid("new-uid");
+        backend.readResolve();
+
+        assertEquals("new-uid", backend.getTempoDataSourceUid());
+    }
+
+    @Test
+    public void testDescriptorDefaultTempoDataSourceUid() {
+        GrafanaBackend.DescriptorImpl descriptor = new GrafanaBackend.DescriptorImpl();
+
+        assertEquals(
+            "grafanacloud-traces",
+            descriptor.getDefaultTempoDataSourceUid()
+        );
+    }
+
+    @Test
+    public void testDescriptorDefaults() {
+        GrafanaBackend.DescriptorImpl descriptor = new GrafanaBackend.DescriptorImpl();
+
+        assertEquals("grafanacloud-traces", descriptor.getDefaultTempoDataSourceUid());
+        assertEquals("1", descriptor.getDefaultGrafanaOrgId());
+        assertEquals("traceql", descriptor.getDefaultTempoQueryType());
+    }
 }


### PR DESCRIPTION
Fixes #829

Adds optional support for a Tempo datasource UID (tempoDataSourceUid) to prevent Grafana from dropping the query when rewriting explore URLs. If the UID is not configured, the plugin falls back to the existing tempoDataSourceIdentifier to preserve backward compatibility.

### Testing done

- Added unit tests in GrafanaBackendTest to verify the generated Grafana Explore URL.
- Verified that the URL now uses the modern schemaVersion=1&panes format instead of the legacy left parameter.
- Confirmed that the configured tempoDataSourceUid is used in the generated URL when provided.
- Verified backward compatibility by ensuring the plugin falls back to tempoDataSourceIdentifier when the UID is not set.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
