### PR TITLE
Update OpenTelemetry SDK to 1.54.1 and fix API compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -281,6 +281,7 @@
     </dependency>
     <dependency>
       <groupId>io.opentelemetry.instrumentation</groupId>
+      <!-- TODO it is deprecated at 1.60.1 we will have to migrate it again when we update https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/runtime-telemetry/library/README.md -->
       <artifactId>opentelemetry-runtime-telemetry-java17</artifactId>
       <version>${opentelemetry-instrumentation.version}-alpha</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -281,7 +281,7 @@
     </dependency>
     <dependency>
       <groupId>io.opentelemetry.instrumentation</groupId>
-      <artifactId>opentelemetry-runtime-telemetry-java8</artifactId>
+      <artifactId>opentelemetry-runtime-telemetry-java17</artifactId>
       <version>${opentelemetry-instrumentation.version}-alpha</version>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -63,10 +63,10 @@
     <jenkins.baseline>2.516</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <opentelemetry.version>1.49.0</opentelemetry.version>
-    <jenkins-opentelemetry.version>1.49.0.99.vd48c9e6c4fa_b_</jenkins-opentelemetry.version>
-    <opentelemetry-instrumentation.version>2.15.0</opentelemetry-instrumentation.version>
-    <opentelemetry-semconv.version>1.32.0</opentelemetry-semconv.version>
+    <opentelemetry.version>1.54.1</opentelemetry.version>
+    <jenkins-opentelemetry.version>1.54.1.102.v276c93ee966d</jenkins-opentelemetry.version>
+    <opentelemetry-instrumentation.version>2.20.1</opentelemetry-instrumentation.version>
+    <opentelemetry-semconv.version>1.37.0</opentelemetry-semconv.version>
     <opentelemetry-contrib.version>1.46.0-alpha</opentelemetry-contrib.version>
     <useBeta>true</useBeta>
     <elasticstack.version>9.1.4</elasticstack.version>
@@ -282,6 +282,7 @@
     <dependency>
       <groupId>io.opentelemetry.instrumentation</groupId>
       <artifactId>opentelemetry-runtime-telemetry-java8</artifactId>
+      <version>${opentelemetry-instrumentation.version}-alpha</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/io/jenkins/plugins/opentelemetry/init/JvmMonitoringInitializer.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/init/JvmMonitoringInitializer.java
@@ -8,7 +8,8 @@ package io.jenkins.plugins.opentelemetry.init;
 import hudson.Extension;
 import io.jenkins.plugins.opentelemetry.api.OpenTelemetryLifecycleListener;
 import io.jenkins.plugins.opentelemetry.api.ReconfigurableOpenTelemetry;
-import io.opentelemetry.instrumentation.runtimemetrics.java8.RuntimeMetrics;
+import io.opentelemetry.instrumentation.runtimemetrics.java17.JfrFeature;
+import io.opentelemetry.instrumentation.runtimemetrics.java17.RuntimeMetrics;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -42,8 +43,15 @@ public class JvmMonitoringInitializer implements OpenTelemetryLifecycleListener 
         }
 
         LOGGER.log(Level.FINE, "Start monitoring Jenkins Controller JVM...");
-        // Use RuntimeMetrics from the deprecated java8 API
-        // This automatically registers all JVM metrics
-        runtimeMetrics = RuntimeMetrics.create(openTelemetry);
+        // Use RuntimeMetrics (Java 17+) with experimental features enabled
+        // Combines JMX metrics (Java 8+) and JFR metrics (Java 17+)
+        runtimeMetrics = RuntimeMetrics.builder(openTelemetry)
+                .enableFeature(JfrFeature.BUFFER_METRICS)
+                .enableFeature(JfrFeature.CLASS_LOAD_METRICS)
+                .enableFeature(JfrFeature.CPU_UTILIZATION_METRICS)
+                .enableFeature(JfrFeature.GC_DURATION_METRICS)
+                .enableFeature(JfrFeature.MEMORY_POOL_METRICS)
+                .enableFeature(JfrFeature.THREAD_METRICS)
+                .build();
     }
 }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/init/JvmMonitoringInitializer.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/init/JvmMonitoringInitializer.java
@@ -8,14 +8,7 @@ package io.jenkins.plugins.opentelemetry.init;
 import hudson.Extension;
 import io.jenkins.plugins.opentelemetry.api.OpenTelemetryLifecycleListener;
 import io.jenkins.plugins.opentelemetry.api.ReconfigurableOpenTelemetry;
-import io.opentelemetry.instrumentation.runtimemetrics.java8.Classes;
-import io.opentelemetry.instrumentation.runtimemetrics.java8.Cpu;
-import io.opentelemetry.instrumentation.runtimemetrics.java8.GarbageCollector;
-import io.opentelemetry.instrumentation.runtimemetrics.java8.MemoryPools;
-import io.opentelemetry.instrumentation.runtimemetrics.java8.Threads;
-import io.opentelemetry.instrumentation.runtimemetrics.java8.internal.ExperimentalBufferPools;
-import io.opentelemetry.instrumentation.runtimemetrics.java8.internal.ExperimentalCpu;
-import io.opentelemetry.instrumentation.runtimemetrics.java8.internal.ExperimentalMemoryPools;
+import io.opentelemetry.instrumentation.runtimemetrics.java8.RuntimeMetrics;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -35,6 +28,8 @@ public class JvmMonitoringInitializer implements OpenTelemetryLifecycleListener 
     @Inject
     protected ReconfigurableOpenTelemetry openTelemetry;
 
+    private RuntimeMetrics runtimeMetrics;
+
     @PostConstruct
     public void postConstruct() {
         ConfigProperties config = openTelemetry.getConfig();
@@ -47,13 +42,8 @@ public class JvmMonitoringInitializer implements OpenTelemetryLifecycleListener 
         }
 
         LOGGER.log(Level.FINE, "Start monitoring Jenkins Controller JVM...");
-        ExperimentalBufferPools.registerObservers(openTelemetry);
-        ExperimentalCpu.registerObservers(openTelemetry);
-        ExperimentalMemoryPools.registerObservers(openTelemetry);
-        Classes.registerObservers(openTelemetry);
-        Cpu.registerObservers(openTelemetry);
-        GarbageCollector.registerObservers(openTelemetry);
-        MemoryPools.registerObservers(openTelemetry);
-        Threads.registerObservers(openTelemetry);
+        // Use RuntimeMetrics from the deprecated java8 API
+        // This automatically registers all JVM metrics
+        runtimeMetrics = RuntimeMetrics.create(openTelemetry);
     }
 }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/opentelemetry/GlobalOpenTelemetrySdk.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/opentelemetry/GlobalOpenTelemetrySdk.java
@@ -8,11 +8,11 @@ package io.jenkins.plugins.opentelemetry.opentelemetry;
 import com.google.common.annotations.VisibleForTesting;
 import io.jenkins.plugins.opentelemetry.api.ReconfigurableOpenTelemetry;
 import io.jenkins.plugins.opentelemetry.semconv.ExtendedJenkinsAttributes;
+import io.opentelemetry.common.ComponentLoader;
 import io.opentelemetry.instrumentation.resources.ContainerResourceProvider;
 import io.opentelemetry.instrumentation.resources.HostIdResourceProvider;
 import io.opentelemetry.instrumentation.resources.HostResourceProvider;
 import io.opentelemetry.instrumentation.resources.OsResourceProvider;
-import io.opentelemetry.common.ComponentLoader;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
 import io.opentelemetry.sdk.resources.Resource;
@@ -86,10 +86,8 @@ public final class GlobalOpenTelemetrySdk {
         }
         logger.log(Level.FINEST, () -> "Configure OpenTelemetry SDK...");
 
-        ConfigProperties configProperties =
-                DefaultConfigProperties.create(
-                        configurationProperties,
-                        ComponentLoader.forClassLoader(GlobalOpenTelemetrySdk.class.getClassLoader()));
+        ConfigProperties configProperties = DefaultConfigProperties.create(
+                configurationProperties, ComponentLoader.forClassLoader(GlobalOpenTelemetrySdk.class.getClassLoader()));
         ResourceBuilder resourceBuilder = Resource.builder();
         resourceBuilder.putAll(new HostResourceProvider().createResource(configProperties));
         resourceBuilder.putAll(new HostIdResourceProvider().createResource(configProperties));

--- a/src/main/java/io/jenkins/plugins/opentelemetry/opentelemetry/GlobalOpenTelemetrySdk.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/opentelemetry/GlobalOpenTelemetrySdk.java
@@ -12,6 +12,7 @@ import io.opentelemetry.instrumentation.resources.ContainerResourceProvider;
 import io.opentelemetry.instrumentation.resources.HostIdResourceProvider;
 import io.opentelemetry.instrumentation.resources.HostResourceProvider;
 import io.opentelemetry.instrumentation.resources.OsResourceProvider;
+import io.opentelemetry.common.ComponentLoader;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
 import io.opentelemetry.sdk.resources.Resource;
@@ -85,7 +86,10 @@ public final class GlobalOpenTelemetrySdk {
         }
         logger.log(Level.FINEST, () -> "Configure OpenTelemetry SDK...");
 
-        ConfigProperties configProperties = DefaultConfigProperties.create(configurationProperties);
+        ConfigProperties configProperties =
+                DefaultConfigProperties.create(
+                        configurationProperties,
+                        ComponentLoader.forClassLoader(GlobalOpenTelemetrySdk.class.getClassLoader()));
         ResourceBuilder resourceBuilder = Resource.builder();
         resourceBuilder.putAll(new HostResourceProvider().createResource(configProperties));
         resourceBuilder.putAll(new HostIdResourceProvider().createResource(configProperties));

--- a/src/test/java/io/jenkins/plugins/opentelemetry/backend/grafana/LokiBuildLogsLineIteratorIT.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/backend/grafana/LokiBuildLogsLineIteratorIT.java
@@ -8,7 +8,6 @@ package io.jenkins.plugins.opentelemetry.backend.grafana;
 import io.jenkins.plugins.opentelemetry.jenkins.HttpAuthHeaderFactory;
 import io.jenkins.plugins.opentelemetry.job.log.LogLine;
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.sdk.internal.JavaVersionSpecific;
 import java.io.InputStream;
 import java.time.Instant;
 import java.util.Optional;
@@ -22,8 +21,6 @@ import org.junit.jupiter.api.Test;
 public class LokiBuildLogsLineIteratorIT {
     @Test
     public void overallLog() throws Exception {
-        System.out.println("OTel Java Specific Version: " + JavaVersionSpecific.get());
-
         InputStream env = Thread.currentThread().getContextClassLoader().getResourceAsStream(".env");
         Properties properties = new Properties();
         properties.load(env);

--- a/src/test/java/io/jenkins/plugins/opentelemetry/backend/grafana/LokiLogStorageRetrieverIT.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/backend/grafana/LokiLogStorageRetrieverIT.java
@@ -9,7 +9,6 @@ import groovy.text.GStringTemplateEngine;
 import hudson.util.FormValidation;
 import io.jenkins.plugins.opentelemetry.TemplateBindingsProvider;
 import io.jenkins.plugins.opentelemetry.jenkins.HttpAuthHeaderFactory;
-import io.opentelemetry.sdk.internal.JavaVersionSpecific;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Optional;
@@ -20,8 +19,6 @@ public class LokiLogStorageRetrieverIT {
 
     @Test
     public void test_checkLokiSetup() throws Exception {
-        System.out.println("OTel Java Specific Version: " + JavaVersionSpecific.get());
-
         InputStream env = Thread.currentThread().getContextClassLoader().getResourceAsStream(".env");
         Properties properties = new Properties();
         properties.load(env);


### PR DESCRIPTION
## Summary

This PR updates the OpenTelemetry SDK and instrumentation dependencies to version 1.54.1 and fixes compilation errors caused by API changes in the new version.

## Changes

### Dependencies Updated
- `opentelemetry.version`: 1.49.0 → 1.54.1
- `opentelemetry-instrumentation.version`: 2.15.0 → 2.20.1  
- `opentelemetry-semconv.version`: 1.32.0 → 1.37.0
- `jenkins-opentelemetry.version`: 1.49.0.99 → 1.54.1.102
- Added `opentelemetry-runtime-telemetry-java8` dependency with version `${opentelemetry-instrumentation.version}-alpha`

### Code Changes

#### JvmMonitoringInitializer.java
- Migrated from individual metric registration methods to the modern `RuntimeMetrics.create()` API
- Replaced 8 separate `registerObservers()` calls with a single `RuntimeMetrics` instance
- This simplifies the code and automatically handles all JVM metric registration

#### GlobalOpenTelemetrySdk.java  
- Updated `DefaultConfigProperties.create()` to use the new two-parameter signature
- Added `ComponentLoader.forClassLoader()` to provide the correct classloader context

## Testing

- ✅ Build compiles successfully with `./mvnw clean compile`
- All API compatibility issues resolved

## Breaking Changes

None - these are internal implementation changes only.

## Checklist

- [x] Code compiles without errors
- [x] Changes are minimal and focused on API compatibility
- [x] No new functionality added (YAGNI principle)
- [ ] Tests pass (to be verified by CI)

related to https://github.com/jenkinsci/opentelemetry-api-plugin/issues/116