### PR TITLE
fix: avoid NPE when GitCheckoutStepHandler extensions is null

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/step/GitCheckoutStepHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/step/GitCheckoutStepHandler.java
@@ -101,7 +101,7 @@ public class GitCheckoutStepHandler extends AbstractGitStepHandler {
             }
 
             List<Map<String, ?>> extensions = (List<Map<String, ?>>) scm.get("extensions");
-            final Map<String, ?> cloneOption = Iterables.getFirst(extensions, null);
+            final Map<String, ?> cloneOption = extensions == null ? null : Iterables.getFirst(extensions, null);
 
             if (cloneOption != null) {
                 shallow = cloneOption.containsKey("shallow") ? (Boolean) cloneOption.get("shallow") : shallow;


### PR DESCRIPTION
## Summary
- guard `GitCheckoutStepHandler` against null `extensions` before calling `Iterables.getFirst`
- preserve existing shallow/depth behavior when clone options are absent

## Validation
- `./mvnw -Dtest=GitStepHandlerTest test`

Fixes #1170
