### PR TITLE
feat: add queue phase spans to build traces

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringRunListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/job/MonitoringRunListener.java
@@ -28,6 +28,8 @@ import io.jenkins.plugins.opentelemetry.api.OpenTelemetryLifecycleListener;
 import io.jenkins.plugins.opentelemetry.job.cause.CauseHandler;
 import io.jenkins.plugins.opentelemetry.job.opentelemetry.OtelContextAwareAbstractRunListener;
 import io.jenkins.plugins.opentelemetry.job.runhandler.RunHandler;
+import io.jenkins.plugins.opentelemetry.queue.QueueItemMonitoringAction;
+import io.jenkins.plugins.opentelemetry.queue.QueuePhaseRecord;
 import io.jenkins.plugins.opentelemetry.queue.RemoteSpanAction;
 import io.jenkins.plugins.opentelemetry.semconv.*;
 import io.opentelemetry.api.OpenTelemetry;
@@ -403,6 +405,15 @@ public class MonitoringRunListener extends OtelContextAwareAbstractRunListener
                 .collect(Collectors.toList());
         rootSpanBuilder.setAttribute(ExtendedJenkinsAttributes.CI_PIPELINE_RUN_CAUSE, causesDescriptions);
 
+        // QUEUE PHASES — extend root span start time back to when the build first entered the queue.
+        // Phases are appended in chronological order (see QueuePhaseRecord), so get(0) is the earliest.
+        List<QueuePhaseRecord> queuePhases = Optional.ofNullable(run.getAction(QueueItemMonitoringAction.class))
+                .map(QueueItemMonitoringAction::getPhases)
+                .orElse(Collections.emptyList());
+        if (!queuePhases.isEmpty()) {
+            rootSpanBuilder.setStartTimestamp(queuePhases.get(0).getStartMillis(), TimeUnit.MILLISECONDS);
+        }
+
         Optional<Cause> optCause = run.getCauses().stream().findFirst();
         optCause.ifPresent(cause -> {
             if (cause instanceof Cause.UpstreamCause upstreamCause) {
@@ -451,10 +462,28 @@ public class MonitoringRunListener extends OtelContextAwareAbstractRunListener
             LOGGER.log(
                     Level.FINE, () -> run.getFullDisplayName() + " - begin root " + OtelUtils.toDebugString(rootSpan));
 
+            // CREATE QUEUE PHASE SPANS as historical children of the root span
+            for (var phase : queuePhases) {
+                Span queuePhaseSpan = getTracer()
+                        .spanBuilder(phase.getPhaseName())
+                        .setParent(Context.current()) // rootSpan is already current via rootSpanScope
+                        .setStartTimestamp(phase.getStartMillis(), TimeUnit.MILLISECONDS)
+                        .startSpan();
+                if (phase.getReason() != null && !phase.getReason().isBlank()) {
+                    queuePhaseSpan.setAttribute(
+                            ExtendedJenkinsAttributes.CI_PIPELINE_RUN_QUEUE_REASON, phase.getReason());
+                }
+                if (phase.getLabel() != null && !phase.getLabel().isBlank()) {
+                    queuePhaseSpan.setAttribute(ExtendedJenkinsAttributes.JENKINS_STEP_AGENT_LABEL, phase.getLabel());
+                }
+                queuePhaseSpan.end(phase.getEndMillis(), TimeUnit.MILLISECONDS);
+                LOGGER.log(Level.FINE, () -> run.getFullDisplayName() + " - queue phase span " + phase.getPhaseName());
+            }
+
             // START initialize span
             Span startSpan = getTracer()
                     .spanBuilder(ExtendedJenkinsAttributes.JENKINS_JOB_SPAN_PHASE_START_NAME)
-                    .setParent(Context.current().with(rootSpan))
+                    .setParent(Context.current()) // rootSpan is already current via rootSpanScope
                     .startSpan();
             LOGGER.log(Level.FINE, () -> run.getFullDisplayName() + " - begin " + OtelUtils.toDebugString(startSpan));
 

--- a/src/main/java/io/jenkins/plugins/opentelemetry/queue/MonitoringQueueListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/queue/MonitoringQueueListener.java
@@ -5,12 +5,17 @@
 
 package io.jenkins.plugins.opentelemetry.queue;
 
+import static io.jenkins.plugins.opentelemetry.semconv.ExtendedJenkinsAttributes.JENKINS_JOB_SPAN_PHASE_QUEUE_BLOCKED_NAME;
+import static io.jenkins.plugins.opentelemetry.semconv.ExtendedJenkinsAttributes.JENKINS_JOB_SPAN_PHASE_QUEUE_BUILDABLE_NAME;
+import static io.jenkins.plugins.opentelemetry.semconv.ExtendedJenkinsAttributes.JENKINS_JOB_SPAN_PHASE_QUEUE_WAITING_NAME;
 import static io.jenkins.plugins.opentelemetry.semconv.ExtendedJenkinsAttributes.STATUS;
 import static io.jenkins.plugins.opentelemetry.semconv.JenkinsMetrics.*;
 import static io.jenkins.plugins.opentelemetry.semconv.JenkinsMetrics.JENKINS_QUEUE_COUNT;
 
 import hudson.Extension;
+import hudson.model.Label;
 import hudson.model.Queue;
+import hudson.model.queue.CauseOfBlockage;
 import hudson.model.queue.QueueListener;
 import io.jenkins.plugins.opentelemetry.JenkinsControllerOpenTelemetry;
 import io.jenkins.plugins.opentelemetry.api.OpenTelemetryLifecycleListener;
@@ -166,6 +171,83 @@ public class MonitoringQueueListener extends QueueListener implements OpenTeleme
                         spanContext.getTraceState().asMap()));
                 LOGGER.log(Level.FINE, () -> "attach RemoteSpanAction to " + wi);
             }
+        }
+        // Items can re-enter waiting state (BlockedItem → WaitingItem), so reuse existing action if present
+        var action = wi.getAction(QueueItemMonitoringAction.class);
+        if (action == null) {
+            action = new QueueItemMonitoringAction();
+            wi.addAction(action);
+        }
+        action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_WAITING_NAME, wi.getWhy());
+        LOGGER.log(Level.FINE, () -> "start queue waiting phase for " + wi);
+    }
+
+    @Override
+    public void onLeaveWaiting(Queue.WaitingItem wi) {
+        var action = wi.getAction(QueueItemMonitoringAction.class);
+        if (action != null) {
+            action.endCurrentPhase();
+            LOGGER.log(Level.FINE, () -> "end queue waiting phase for " + wi);
+        }
+    }
+
+    @Override
+    public void onEnterBlocked(Queue.BlockedItem bi) {
+        var action = bi.getAction(QueueItemMonitoringAction.class);
+        if (action != null) {
+            var causeOfBlockage = bi.getCauseOfBlockage();
+            var reason = causeOfBlockage != null ? causeOfBlockage.getShortDescription() : bi.getWhy();
+            var label = labelFromCause(causeOfBlockage);
+            action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_BLOCKED_NAME, reason, label);
+            LOGGER.log(Level.FINE, () -> "start queue blocked phase for " + bi);
+        }
+    }
+
+    @Override
+    public void onLeaveBlocked(Queue.BlockedItem bi) {
+        var action = bi.getAction(QueueItemMonitoringAction.class);
+        if (action != null) {
+            action.endCurrentPhase();
+            LOGGER.log(Level.FINE, () -> "end queue blocked phase for " + bi);
+        }
+    }
+
+    @Override
+    public void onEnterBuildable(Queue.BuildableItem bi) {
+        var action = bi.getAction(QueueItemMonitoringAction.class);
+        if (action != null) {
+            Label assignedLabel = bi.getAssignedLabel();
+            var label = assignedLabel != null ? assignedLabel.getName() : null;
+            action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_BUILDABLE_NAME, bi.getWhy(), label);
+            LOGGER.log(Level.FINE, () -> "start queue buildable phase for " + bi);
+        }
+    }
+
+    /**
+     * Extracts a human-readable label/node name from a {@link CauseOfBlockage} for cases where the
+     * blockage is tied to a specific label or node (busy, offline, not accepting tasks).
+     */
+    private static String labelFromCause(CauseOfBlockage cause) {
+        if (cause instanceof CauseOfBlockage.BecauseLabelIsBusy c) {
+            return c.label.getName();
+        } else if (cause instanceof CauseOfBlockage.BecauseLabelIsOffline c) {
+            return c.label.getName();
+        } else if (cause instanceof CauseOfBlockage.BecauseNodeIsBusy c) {
+            return c.node.getDisplayName();
+        } else if (cause instanceof CauseOfBlockage.BecauseNodeIsOffline c) {
+            return c.node.getDisplayName();
+        } else if (cause instanceof CauseOfBlockage.BecauseNodeIsNotAcceptingTasks c) {
+            return c.node.getDisplayName();
+        }
+        return null;
+    }
+
+    @Override
+    public void onLeaveBuildable(Queue.BuildableItem bi) {
+        var action = bi.getAction(QueueItemMonitoringAction.class);
+        if (action != null) {
+            action.endCurrentPhase();
+            LOGGER.log(Level.FINE, () -> "end queue buildable phase for " + bi);
         }
     }
 }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/queue/QueueItemMonitoringAction.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/queue/QueueItemMonitoringAction.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.queue;
+
+import hudson.model.InvisibleAction;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Tracks queue state phase transitions for a build.
+ *
+ * Attached to a {@link hudson.model.Queue.WaitingItem} and automatically propagated to the resulting
+ * {@link hudson.model.Run} by Jenkins' executor action-copying mechanism, so it is available in
+ * {@code MonitoringRunListener._onInitialize()} via {@code run.getAction(QueueItemMonitoringAction.class)}.
+ *
+ * Jenkins copies action references (not deep copies) when items transition between queue states
+ * (WaitingItem → BlockedItem → BuildableItem), so the same instance is shared across all state objects.
+ *
+ * <p>Note: {@link #endCurrentPhase()} is guaranteed to be called before
+ * {@code _onInitialize} reads the phases because {@code Queue.maintain()} calls
+ * {@code onLeaveBuildable} while holding the Queue lock, before releasing it to let the executor
+ * thread proceed.
+ */
+public class QueueItemMonitoringAction extends InvisibleAction {
+
+    private final List<QueuePhaseRecord> phases = new ArrayList<>();
+    private String currentPhaseName;
+    private String currentPhaseReason;
+    private String currentPhaseLabel;
+    private long currentPhaseStartMillis;
+
+    public synchronized void startPhase(String name, String reason) {
+        startPhase(name, reason, null);
+    }
+
+    public synchronized void startPhase(String name, String reason, String label) {
+        // Close any phase that wasn't properly ended (e.g. unexpected state transitions
+        // caused by third-party plugins calling Queue.cancel() outside the normal callbacks)
+        if (currentPhaseName != null) {
+            endCurrentPhase();
+        }
+        currentPhaseName = name;
+        currentPhaseReason = reason;
+        currentPhaseLabel = label;
+        currentPhaseStartMillis = System.currentTimeMillis();
+    }
+
+    public synchronized void endCurrentPhase() {
+        if (currentPhaseName == null) {
+            return;
+        }
+        long endMillis = System.currentTimeMillis();
+        // Collapse repeated consecutive phases with the same name/reason/label into one span.
+        // Jenkins calls onEnterBlocked/onLeaveBlocked on every Queue.maintain() tick, so the
+        // same blockage reason can produce hundreds of records without this guard.
+        if (!phases.isEmpty()) {
+            var last = phases.get(phases.size() - 1);
+            if (Objects.equals(last.getPhaseName(), currentPhaseName)
+                    && Objects.equals(last.getReason(), currentPhaseReason)
+                    && Objects.equals(last.getLabel(), currentPhaseLabel)) {
+                last.extendEnd(endMillis);
+                currentPhaseName = null;
+                currentPhaseReason = null;
+                currentPhaseLabel = null;
+                currentPhaseStartMillis = 0;
+                return;
+            }
+        }
+        phases.add(new QueuePhaseRecord(
+                currentPhaseName, currentPhaseReason, currentPhaseLabel, currentPhaseStartMillis, endMillis));
+        currentPhaseName = null;
+        currentPhaseReason = null;
+        currentPhaseLabel = null;
+        currentPhaseStartMillis = 0;
+    }
+
+    /** Returns completed phases only; any currently open phase is not included. */
+    public synchronized List<QueuePhaseRecord> getPhases() {
+        return Collections.unmodifiableList(phases);
+    }
+}

--- a/src/main/java/io/jenkins/plugins/opentelemetry/queue/QueuePhaseRecord.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/queue/QueuePhaseRecord.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.queue;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Immutable record of a single completed queue state phase for a build.
+ *
+ * <p>Phases are appended in chronological order, so {@code phases.get(0).startMillis()} is always
+ * the earliest timestamp.
+ */
+public class QueuePhaseRecord {
+
+    // Non-final so XStream can populate fields via reflection
+    private String phaseName;
+    private String reason;
+    private String label;
+    private long startMillis;
+    private long endMillis;
+
+    /** Required by XStream for deserialization. */
+    private QueuePhaseRecord() {}
+
+    public QueuePhaseRecord(
+            @NonNull String phaseName,
+            @Nullable String reason,
+            @Nullable String label,
+            long startMillis,
+            long endMillis) {
+        this.phaseName = phaseName;
+        this.reason = reason;
+        this.label = label;
+        this.startMillis = startMillis;
+        this.endMillis = endMillis;
+    }
+
+    @NonNull
+    public String getPhaseName() {
+        return phaseName;
+    }
+
+    @Nullable
+    public String getReason() {
+        return reason;
+    }
+
+    @Nullable
+    public String getLabel() {
+        return label;
+    }
+
+    public long getStartMillis() {
+        return startMillis;
+    }
+
+    public long getEndMillis() {
+        return endMillis;
+    }
+
+    /** Extends the end timestamp when merging a repeated consecutive phase. */
+    void extendEnd(long endMillis) {
+        this.endMillis = endMillis;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/opentelemetry/semconv/ExtendedJenkinsAttributes.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/semconv/ExtendedJenkinsAttributes.java
@@ -89,6 +89,8 @@ public final class ExtendedJenkinsAttributes extends JenkinsAttributes {
     public static final AttributeKey<String> CI_PIPELINE_RUN_URL = AttributeKey.stringKey("ci.pipeline.run.url");
 
     public static final AttributeKey<String> CI_PIPELINE_RUN_USER = AttributeKey.stringKey("ci.pipeline.run.user");
+    public static final AttributeKey<String> CI_PIPELINE_RUN_QUEUE_REASON =
+            AttributeKey.stringKey("ci.pipeline.run.queue.reason");
 
     public static final AttributeKey<List<String>> CI_PIPELINE_RUN_AXIS_NAMES =
             AttributeKey.stringArrayKey("ci.pipeline.axis.names");
@@ -172,6 +174,9 @@ public final class ExtendedJenkinsAttributes extends JenkinsAttributes {
      */
     public static final String CI_PIPELINE_RUN_ROOT_SPAN_NAME_PREFIX = "BUILD ";
 
+    public static final String JENKINS_JOB_SPAN_PHASE_QUEUE_WAITING_NAME = "Phase: Queue - Waiting";
+    public static final String JENKINS_JOB_SPAN_PHASE_QUEUE_BLOCKED_NAME = "Phase: Queue - Blocked";
+    public static final String JENKINS_JOB_SPAN_PHASE_QUEUE_BUILDABLE_NAME = "Phase: Queue - Buildable";
     public static final String JENKINS_JOB_SPAN_PHASE_START_NAME = "Phase: Start";
     public static final String JENKINS_JOB_SPAN_PHASE_RUN_NAME = "Phase: Run";
     public static final String JENKINS_JOB_SPAN_PHASE_FINALIZE_NAME = "Phase: Finalise";

--- a/src/test/java/io/jenkins/plugins/opentelemetry/BaseIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/BaseIntegrationTest.java
@@ -11,6 +11,7 @@ import static java.util.Optional.of;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.cloudbees.hudson.plugins.folder.computed.FolderComputation;
+import com.cloudbees.simplediskusage.QuickDiskUsagePlugin;
 import com.github.rutledgepaulv.prune.Tree;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
@@ -130,6 +131,9 @@ public class BaseIntegrationTest {
     public void afterEach() throws Exception {
         jenkinsRule.waitUntilNoActivity();
 
+        // Let any in-flight disk-usage refresh finish before JenkinsRule deletes JENKINS_HOME (see method doc).
+        quiesceDiskUsagePlugin();
+
         // Reset the executor service BEFORE other cleanup
         // to avoid stale Context wrapping in subsequent tests
         try {
@@ -164,6 +168,43 @@ public class BaseIntegrationTest {
     // This only works if no scrape is currently in progress (use high scrape period for tests).
     protected void forceMetricsExport() {
         jenkinsControllerOpenTelemetry.getMetricReader().forceFlush();
+    }
+
+    /**
+     * Forces the {@link QuickDiskUsagePlugin} background refresh to completion at teardown.
+     *
+     * <p>The plugin computes disk usage on a single-threaded executor and, when finished, persists
+     * {@code cloudbees-disk-usage-simple.xml} into JENKINS_HOME (via {@link hudson.Plugin#save()}).
+     * Our OTel disk-usage gauge polls {@code getDirectoriesUsages()}, which can trigger that refresh.
+     * If the resulting write lands while {@code JenkinsRule.after()} is deleting the temporary
+     * JENKINS_HOME, deletion fails with {@code DirectoryNotEmptyException} ("These files still exist:
+     * cloudbees-disk-usage-simple.xml") and the otherwise-passing test is reported as failed.
+     *
+     * <p>By forcing a refresh and waiting for it to complete here — before {@code JenkinsRule.after()}
+     * runs — we both flush any in-flight write and bump {@code lastRunEnd} to "now", so the plugin's
+     * 15-minute quiet period suppresses any further refresh during teardown.
+     */
+    private void quiesceDiskUsagePlugin() {
+        QuickDiskUsagePlugin diskUsage = jenkinsRule.getInstance().getPlugin(QuickDiskUsagePlugin.class);
+        if (diskUsage == null) {
+            return;
+        }
+        try {
+            long previousRunEnd = diskUsage.getLastRunEnd();
+            diskUsage.refreshData();
+            long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30);
+            // Wait until a refresh that started after our trigger has fully completed: isRunning() clears
+            // and lastRunEnd advances. Checking lastRunEnd covers the window where the task is queued on
+            // the single-thread executor but isRunning() has not yet flipped to true.
+            while (System.currentTimeMillis() < deadline
+                    && (diskUsage.isRunning() || diskUsage.getLastRunEnd() == previousRunEnd)) {
+                Thread.sleep(50);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Failed to quiesce disk usage plugin before teardown", e);
+        }
     }
 
     protected void checkChainOfSpans(Tree<SpanDataWrapper> spanTree, String... expectedSpanNames) {

--- a/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginFreestyleIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginFreestyleIntegrationTest.java
@@ -61,7 +61,9 @@ public class JenkinsOtelPluginFreestyleIntegrationTest extends BaseIntegrationTe
         checkChainOfSpans(spans, "Phase: Start", rootSpanName);
         checkChainOfSpans(spans, "shell", "Phase: Run", rootSpanName);
         checkChainOfSpans(spans, "Phase: Finalise", rootSpanName);
-        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(5L));
+        // Queue phase spans: every build goes through at least Phase: Queue - Buildable
+        checkChainOfSpans(spans, ExtendedJenkinsAttributes.JENKINS_JOB_SPAN_PHASE_QUEUE_BUILDABLE_NAME, rootSpanName);
+        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(7L));
 
         assertFreestyleJobMetadata(build, spans);
         assertBuildStepMetadata(spans, "shell", JENKINS_CORE);
@@ -84,7 +86,7 @@ public class JenkinsOtelPluginFreestyleIntegrationTest extends BaseIntegrationTe
         checkChainOfSpans(spans, "shell", "Phase: Run", rootSpanName);
         checkChainOfSpans(spans, "shell", "Phase: Run", rootSpanName);
         checkChainOfSpans(spans, "Phase: Finalise", rootSpanName);
-        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(6L));
+        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(8L));
 
         assertFreestyleJobMetadata(build, spans);
         assertBuildStepMetadata(spans, "shell", JENKINS_CORE);
@@ -105,7 +107,7 @@ public class JenkinsOtelPluginFreestyleIntegrationTest extends BaseIntegrationTe
         checkChainOfSpans(spans, "Phase: Start", rootSpanName);
         checkChainOfSpans(spans, "shell", "Phase: Run", rootSpanName);
         checkChainOfSpans(spans, "Phase: Finalise", rootSpanName);
-        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(5L));
+        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(7L));
 
         assertFreestyleJobMetadata(build, spans);
         assertBuildStepMetadata(spans, "shell", JENKINS_CORE);
@@ -130,7 +132,7 @@ public class JenkinsOtelPluginFreestyleIntegrationTest extends BaseIntegrationTe
         checkChainOfSpans(spans, "shell", "Phase: Run", rootSpanName);
         checkChainOfSpans(spans, "archiveArtifacts", "Phase: Run", rootSpanName);
         checkChainOfSpans(spans, "Phase: Finalise", rootSpanName);
-        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(6L));
+        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(8L));
 
         assertFreestyleJobMetadata(build, spans);
         assertBuildStepMetadata(spans, "shell", JENKINS_CORE);
@@ -155,7 +157,7 @@ public class JenkinsOtelPluginFreestyleIntegrationTest extends BaseIntegrationTe
             checkChainOfSpans(spans, "Phase: Start", rootSpanName);
             checkChainOfSpans(spans, "shell", "Phase: Run", rootSpanName);
             checkChainOfSpans(spans, "Phase: Finalise", rootSpanName);
-            MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(5L));
+            MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(7L));
 
             assertFreestyleJobMetadata(build, spans);
             assertBuildStepMetadata(spans, "shell", JENKINS_CORE);
@@ -205,7 +207,7 @@ public class JenkinsOtelPluginFreestyleIntegrationTest extends BaseIntegrationTe
             checkChainOfSpans(spans, "Phase: Start", rootSpanName);
             checkChainOfSpans(spans, "ant", "Phase: Run", rootSpanName);
             checkChainOfSpans(spans, "Phase: Finalise", rootSpanName);
-            MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(5L));
+            MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(7L));
 
             assertFreestyleJobMetadata(build, spans);
             assertBuildStepMetadata(spans, "ant", "ant");

--- a/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginIntegrationTest.java
@@ -82,7 +82,7 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
         checkChainOfSpans(
                 spans, "shell-2", "Stage: ze-stage2", ExtendedJenkinsAttributes.AGENT_UI, "Phase: Run", rootSpanName);
         checkChainOfSpans(spans, "Phase: Finalise", rootSpanName);
-        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(10L));
+        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(11L));
 
         forceMetricsExport();
         Map<String, MetricData> exportedMetrics = InMemoryMetricExporterUtils.getLastExportedMetricByMetricName(
@@ -144,7 +144,7 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
             jenkinsRule.assertBuildStatus(Result.SUCCESS, pipeline.scheduleBuild2(0));
 
             final Tree<SpanDataWrapper> spans = getBuildTrace();
-            MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(8L));
+            MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(9L));
         }
     }
 
@@ -181,7 +181,7 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
                 "Stage: foo",
                 "Phase: Run");
         checkChainOfSpans(spans, "Phase: Finalise", rootSpanName);
-        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(7L));
+        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(8L));
 
         Optional<Tree.Node<SpanDataWrapper>> executorNodeAllocation =
                 spans.breadthFirstSearchNodes(node -> (ExtendedJenkinsAttributes.AGENT_ALLOCATION_UI)
@@ -247,7 +247,7 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
                 spans, "shell-1", "Stage: ze-stage1", ExtendedJenkinsAttributes.AGENT_UI, "Phase: Run", rootSpanName);
         checkChainOfSpans(
                 spans, "shell-2", "Stage: ze-stage2", ExtendedJenkinsAttributes.AGENT_UI, "Phase: Run", rootSpanName);
-        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(10L));
+        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(11L));
 
         Optional<Tree.Node<SpanDataWrapper>> stageNode = spans.breadthFirstSearchNodes(
                 node -> "Stage: ze-stage1".equals(node.getData().spanData.getName()));
@@ -285,7 +285,7 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
         final Tree<SpanDataWrapper> spans = getBuildTrace();
         checkChainOfSpans(spans, "shell-1", "Stage: ze-stage1", ExtendedJenkinsAttributes.AGENT_UI, "Phase: Run");
         checkChainOfSpans(spans, "shell-2", "Stage: ze-stage2", ExtendedJenkinsAttributes.AGENT_UI, "Phase: Run");
-        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(11L));
+        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(12L));
 
         Optional<Tree.Node<SpanDataWrapper>> shellNode = spans.breadthFirstSearchNodes(
                 node -> "shell-1".equals(node.getData().spanData.getName()));
@@ -322,7 +322,7 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
         checkChainOfSpans(spans, "shell-1", "Stage: ze-stage1", ExtendedJenkinsAttributes.AGENT_UI, "Phase: Run");
         checkChainOfSpans(spans, "shell-2", "Stage: ze-stage2", ExtendedJenkinsAttributes.AGENT_UI, "Phase: Run");
         checkChainOfSpans(spans, "error", "Stage: ze-stage2", ExtendedJenkinsAttributes.AGENT_UI, "Phase: Run");
-        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(11L));
+        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(12L));
     }
 
     @Test
@@ -364,7 +364,7 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
                 "Stage: trigger-child-pipeline",
                 ExtendedJenkinsAttributes.AGENT_UI,
                 "Phase: Run");
-        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(15L));
+        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(17L));
     }
 
     @Test
@@ -410,7 +410,7 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
                 "Stage: ze-parallel-stage",
                 ExtendedJenkinsAttributes.AGENT_UI,
                 "Phase: Run");
-        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(13L));
+        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(14L));
 
         Optional<Tree.Node<SpanDataWrapper>> branchNode =
                 spans.breadthFirstSearchNodes(node -> "Parallel branch: parallelBranch1"
@@ -477,7 +477,7 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
                 "Stage: foo",
                 ExtendedJenkinsAttributes.AGENT_UI,
                 "Phase: Run");
-        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(8L));
+        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(9L));
 
         Optional<Tree.Node<SpanDataWrapper>> gitNode =
                 spans.breadthFirstSearchNodes(node -> "git: github.com/octocat/Hello-World"
@@ -515,7 +515,7 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
                 "Stage: foo",
                 ExtendedJenkinsAttributes.AGENT_UI,
                 "Phase: Run");
-        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(8L));
+        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(9L));
 
         Optional<Tree.Node<SpanDataWrapper>> checkoutNode =
                 spans.breadthFirstSearchNodes(node -> "checkout: github.com/octocat/Hello-World"
@@ -554,7 +554,7 @@ public class JenkinsOtelPluginIntegrationTest extends BaseIntegrationTest {
                 "Stage: foo",
                 ExtendedJenkinsAttributes.AGENT_UI,
                 "Phase: Run");
-        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(8L));
+        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(9L));
 
         Optional<Tree.Node<SpanDataWrapper>> checkoutNode =
                 spans.breadthFirstSearchNodes(node -> "checkout: github.com/octocat/Hello-World"

--- a/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginMBPIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginMBPIntegrationTest.java
@@ -67,7 +67,7 @@ public class JenkinsOtelPluginMBPIntegrationTest extends BaseIntegrationTest {
         // TODO: support the chain of spans for the checkout step (it uses some random folder name in the tests
         checkChainOfSpans(spans, "Stage: Declarative: Checkout SCM", ExtendedJenkinsAttributes.AGENT_UI, "Phase: Run");
         checkChainOfSpans(spans, "Phase: Finalise", rootSpanName);
-        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(9L));
+        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(10L));
 
         List<SpanDataWrapper> root = spans.byDepth().get(0);
         Attributes attributes = root.get(0).spanData.getAttributes();

--- a/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginMatrixIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/JenkinsOtelPluginMatrixIntegrationTest.java
@@ -14,8 +14,8 @@ import hudson.matrix.MatrixProject;
 import hudson.matrix.TextAxis;
 import io.jenkins.plugins.opentelemetry.semconv.ExtendedJenkinsAttributes;
 import org.apache.commons.lang3.SystemUtils;
-import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 public class JenkinsOtelPluginMatrixIntegrationTest extends BaseIntegrationTest {
@@ -38,11 +38,18 @@ public class JenkinsOtelPluginMatrixIntegrationTest extends BaseIntegrationTest 
 
         Tree<SpanDataWrapper> spans = getBuildTrace();
 
-        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(20L));
-        // TODO deeper checkChainOfSpans
+        // Baseline: 5 runs (1 parent + 4 sub-builds) × 4 spans each = 20. Each run also adds
+        // queue phase spans: the parent gets Phase: Queue - Waiting only (no Buildable in the test JVM),
+        // while each sub-build gets both Waiting and Buildable, giving 1 + 4×2 = 9 extra spans.
+        MatcherAssert.assertThat(spans.cardinality(), Matchers.greaterThanOrEqualTo(20L));
+
+        // Matrix parent traverses the Waiting queue state
+        checkChainOfSpans(spans, ExtendedJenkinsAttributes.JENKINS_JOB_SPAN_PHASE_QUEUE_WAITING_NAME, rootSpanName);
+        // Each sub-build traverses Waiting then Buildable; verify Buildable for at least one
         checkChainOfSpans(
                 spans,
-                ExtendedJenkinsAttributes.CI_PIPELINE_RUN_ROOT_SPAN_NAME_PREFIX + "test-matrix-1/execution",
+                ExtendedJenkinsAttributes.JENKINS_JOB_SPAN_PHASE_QUEUE_BUILDABLE_NAME,
+                ExtendedJenkinsAttributes.CI_PIPELINE_RUN_ROOT_SPAN_NAME_PREFIX + jobName + "/execution",
                 rootSpanName);
 
         assertMatrixJobMetadata(build, spans);

--- a/src/test/java/io/jenkins/plugins/opentelemetry/job/step/SetSpanAttributesStepTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/job/step/SetSpanAttributesStepTest.java
@@ -115,6 +115,6 @@ public class SetSpanAttributesStepTest extends BaseIntegrationTest {
             MatcherAssert.assertThat(actualBuildTool, CoreMatchers.is("junit"));
         }
 
-        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(8L));
+        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(9L));
     }
 }

--- a/src/test/java/io/jenkins/plugins/opentelemetry/job/step/StepResultTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/job/step/StepResultTest.java
@@ -201,6 +201,6 @@ public class StepResultTest extends BaseIntegrationTest {
             MatcherAssert.assertThat(actualStageResult, CoreMatchers.is("ABORTED"));
         }
 
-        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(15L));
+        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(16L));
     }
 }

--- a/src/test/java/io/jenkins/plugins/opentelemetry/job/step/WithSpanAttributeStepTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/job/step/WithSpanAttributeStepTest.java
@@ -105,6 +105,6 @@ public class WithSpanAttributeStepTest extends BaseIntegrationTest {
             MatcherAssert.assertThat(actualBuildTool, CoreMatchers.is("maven"));
         }
 
-        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(8L));
+        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(9L));
     }
 }

--- a/src/test/java/io/jenkins/plugins/opentelemetry/job/step/WithSpanAttributesStepTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/job/step/WithSpanAttributesStepTest.java
@@ -239,7 +239,7 @@ public class WithSpanAttributesStepTest extends BaseIntegrationTest {
                     "attribute is not set on closed child span", actualBuildTool6, CoreMatchers.nullValue());
         }
 
-        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(11L));
+        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(12L));
     }
 
     /*
@@ -405,7 +405,7 @@ public class WithSpanAttributesStepTest extends BaseIntegrationTest {
             MatcherAssert.assertThat(actualBuildTool2, CoreMatchers.is("h"));
         }
 
-        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(13L));
+        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(14L));
     }
 
     @Test
@@ -466,7 +466,7 @@ public class WithSpanAttributesStepTest extends BaseIntegrationTest {
             MatcherAssert.assertThat(actualBuildTool2, CoreMatchers.is("maven"));
         }
 
-        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(8L));
+        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(9L));
     }
 
     @Test
@@ -547,7 +547,7 @@ public class WithSpanAttributesStepTest extends BaseIntegrationTest {
             MatcherAssert.assertThat(actualPipelineType4, CoreMatchers.is("release"));
         }
 
-        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(8L));
+        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(9L));
     }
 
     @Test
@@ -589,7 +589,7 @@ public class WithSpanAttributesStepTest extends BaseIntegrationTest {
         checkChainOfSpans(spans, "Phase: Run", rootSpanName);
         checkChainOfSpans(spans, "Phase: Finalise", rootSpanName);
 
-        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(4L));
+        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(5L));
     }
 
     @Test
@@ -678,6 +678,6 @@ public class WithSpanAttributesStepTest extends BaseIntegrationTest {
             MatcherAssert.assertThat(actualBuildTool4, CoreMatchers.nullValue());
         }
 
-        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(8L));
+        MatcherAssert.assertThat(spans.cardinality(), CoreMatchers.is(9L));
     }
 }

--- a/src/test/java/io/jenkins/plugins/opentelemetry/queue/QueueItemMonitoringActionTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/queue/QueueItemMonitoringActionTest.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.queue;
+
+import static io.jenkins.plugins.opentelemetry.semconv.ExtendedJenkinsAttributes.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.thoughtworks.xstream.XStream;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class QueueItemMonitoringActionTest {
+
+    // ── happy path ───────────────────────────────────────────────────────────
+
+    @Test
+    void getPhases_emptyBeforeAnyPhaseStarts() {
+        var action = new QueueItemMonitoringAction();
+        assertThat(action.getPhases().isEmpty(), is(true));
+    }
+
+    @Test
+    void singlePhaseRecordedWithCorrectFields() {
+        var action = new QueueItemMonitoringAction();
+        long before = System.currentTimeMillis();
+        action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_WAITING_NAME, "Quiet period", null);
+        action.endCurrentPhase();
+        long after = System.currentTimeMillis();
+
+        var phases = action.getPhases();
+        assertThat(phases.size(), is(1));
+        var p = phases.get(0);
+        assertThat(p.getPhaseName(), is(JENKINS_JOB_SPAN_PHASE_QUEUE_WAITING_NAME));
+        assertThat(p.getReason(), is("Quiet period"));
+        assertThat(p.getLabel(), is(nullValue()));
+        assertTrue(p.getStartMillis() >= before && p.getStartMillis() <= after);
+        assertTrue(p.getEndMillis() >= p.getStartMillis());
+    }
+
+    @Test
+    void labelStoredAndReturnedPerPhase() {
+        var action = new QueueItemMonitoringAction();
+        action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_BUILDABLE_NAME, "Waiting", "linux");
+        action.endCurrentPhase();
+
+        assertThat(action.getPhases().get(0).getLabel(), is("linux"));
+    }
+
+    @Test
+    void multipleSequentialPhasesAllRecorded() {
+        var action = new QueueItemMonitoringAction();
+
+        action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_WAITING_NAME, "quiet period", null);
+        action.endCurrentPhase();
+        action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_BLOCKED_NAME, "lock held", "linux");
+        action.endCurrentPhase();
+        action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_BUILDABLE_NAME, "waiting for executor", "linux");
+        action.endCurrentPhase();
+
+        var phases = action.getPhases();
+        assertThat(phases.size(), is(3));
+        assertThat(phases.get(0).getPhaseName(), is(JENKINS_JOB_SPAN_PHASE_QUEUE_WAITING_NAME));
+        assertThat(phases.get(1).getPhaseName(), is(JENKINS_JOB_SPAN_PHASE_QUEUE_BLOCKED_NAME));
+        assertThat(phases.get(2).getPhaseName(), is(JENKINS_JOB_SPAN_PHASE_QUEUE_BUILDABLE_NAME));
+    }
+
+    @Test
+    void phasesAreInChronologicalOrder() {
+        var action = new QueueItemMonitoringAction();
+        action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_WAITING_NAME, null, null);
+        action.endCurrentPhase();
+        action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_BUILDABLE_NAME, null, null);
+        action.endCurrentPhase();
+
+        var phases = action.getPhases();
+        assertTrue(phases.get(0).getStartMillis() <= phases.get(1).getStartMillis());
+    }
+
+    // ── edge cases ───────────────────────────────────────────────────────────
+
+    @Test
+    void endCurrentPhase_noopWhenNoPhaseOpen() {
+        var action = new QueueItemMonitoringAction();
+        assertDoesNotThrow(action::endCurrentPhase);
+        assertThat(action.getPhases().isEmpty(), is(true));
+    }
+
+    @Test
+    void getPhases_doesNotIncludeOpenPhase() {
+        var action = new QueueItemMonitoringAction();
+        action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_WAITING_NAME, null, null);
+        // phase started but not ended
+        assertThat(action.getPhases().isEmpty(), is(true));
+    }
+
+    @Test
+    void startPhase_whenPhaseAlreadyOpen_closesItAndStartsNew() {
+        var action = new QueueItemMonitoringAction();
+        action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_WAITING_NAME, "first", null);
+        // start a second phase without ending the first — simulates a missed onLeave callback
+        action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_BLOCKED_NAME, "second", null);
+
+        // The first phase must have been auto-closed
+        var phases = action.getPhases();
+        assertThat(phases.size(), is(1));
+        assertThat(phases.get(0).getPhaseName(), is(JENKINS_JOB_SPAN_PHASE_QUEUE_WAITING_NAME));
+
+        action.endCurrentPhase();
+        assertThat(action.getPhases().size(), is(2));
+        assertThat(action.getPhases().get(1).getPhaseName(), is(JENKINS_JOB_SPAN_PHASE_QUEUE_BLOCKED_NAME));
+    }
+
+    @Test
+    void getPhases_returnsUnmodifiableLiveView() {
+        var action = new QueueItemMonitoringAction();
+        action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_WAITING_NAME, null, null);
+        action.endCurrentPhase();
+
+        List<QueuePhaseRecord> view = action.getPhases();
+        assertThat(view.size(), is(1));
+
+        // Adding more phases is visible through the live view — callers that need a snapshot
+        // must copy the list themselves.
+        action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_BUILDABLE_NAME, null, null);
+        action.endCurrentPhase();
+        assertThat(view.size(), is(2));
+
+        // The view is unmodifiable — mutations must go through the action's own methods
+        assertThrows(UnsupportedOperationException.class, () -> view.add(new QueuePhaseRecord("x", null, null, 0, 0)));
+    }
+
+    // ── phase collapsing ─────────────────────────────────────────────────────
+
+    @Test
+    void consecutiveIdenticalPhasesCollapsedIntoOne() {
+        var action = new QueueItemMonitoringAction();
+        action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_BLOCKED_NAME, "Jenkins recovering", "linux");
+        action.endCurrentPhase();
+        action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_BLOCKED_NAME, "Jenkins recovering", "linux");
+        action.endCurrentPhase();
+        action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_BLOCKED_NAME, "Jenkins recovering", "linux");
+        action.endCurrentPhase();
+
+        assertThat(action.getPhases().size(), is(1));
+        assertThat(action.getPhases().get(0).getPhaseName(), is(JENKINS_JOB_SPAN_PHASE_QUEUE_BLOCKED_NAME));
+    }
+
+    @Test
+    void collapsedPhaseSpansFromFirstStartToLastEnd() throws InterruptedException {
+        var action = new QueueItemMonitoringAction();
+        action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_BLOCKED_NAME, "Jenkins recovering", null);
+        long firstStart = action.getPhases().isEmpty() ? -1 : 0; // open phase not yet recorded
+        action.endCurrentPhase();
+        long startAfterFirst = action.getPhases().get(0).getStartMillis();
+
+        Thread.sleep(5);
+        action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_BLOCKED_NAME, "Jenkins recovering", null);
+        action.endCurrentPhase();
+        long endAfterSecond = action.getPhases().get(0).getEndMillis();
+
+        var phases = action.getPhases();
+        assertThat(phases.size(), is(1));
+        assertThat(phases.get(0).getStartMillis(), is(startAfterFirst));
+        assertTrue(endAfterSecond > startAfterFirst);
+    }
+
+    @Test
+    void differentReasonNotCollapsed() {
+        var action = new QueueItemMonitoringAction();
+        action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_BLOCKED_NAME, "reason-A", null);
+        action.endCurrentPhase();
+        action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_BLOCKED_NAME, "reason-B", null);
+        action.endCurrentPhase();
+
+        assertThat(action.getPhases().size(), is(2));
+    }
+
+    @Test
+    void differentLabelNotCollapsed() {
+        var action = new QueueItemMonitoringAction();
+        action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_BLOCKED_NAME, "reason", "label-A");
+        action.endCurrentPhase();
+        action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_BLOCKED_NAME, "reason", "label-B");
+        action.endCurrentPhase();
+
+        assertThat(action.getPhases().size(), is(2));
+    }
+
+    @Test
+    void differentPhaseNameNotCollapsed() {
+        var action = new QueueItemMonitoringAction();
+        action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_BLOCKED_NAME, "reason", null);
+        action.endCurrentPhase();
+        action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_WAITING_NAME, "reason", null);
+        action.endCurrentPhase();
+
+        assertThat(action.getPhases().size(), is(2));
+    }
+
+    @Test
+    void interruptedByDifferentPhaseResetsCollapsing() {
+        var action = new QueueItemMonitoringAction();
+        action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_BLOCKED_NAME, "same", null);
+        action.endCurrentPhase();
+        action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_WAITING_NAME, "other", null);
+        action.endCurrentPhase();
+        // same blocked reason again — must NOT collapse with the first blocked span
+        action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_BLOCKED_NAME, "same", null);
+        action.endCurrentPhase();
+
+        assertThat(action.getPhases().size(), is(3));
+    }
+
+    // ── XStream serialization ────────────────────────────────────────────────
+
+    @Test
+    void xstreamRoundTrip_preservesAllPhaseFields() {
+        // Regression: QueuePhaseRecord was a Java record, causing XStream's
+        // RobustReflectionConverter to throw UnsupportedOperationException on Java 17+
+        // because sun.misc.Unsafe.objectFieldOffset() rejects record classes.
+        var action = new QueueItemMonitoringAction();
+        action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_WAITING_NAME, "Quiet period", "linux");
+        action.endCurrentPhase();
+        action.startPhase(JENKINS_JOB_SPAN_PHASE_QUEUE_BUILDABLE_NAME, null, null);
+        action.endCurrentPhase();
+
+        var xstream = new XStream();
+        xstream.allowTypes(new Class[] {QueueItemMonitoringAction.class, QueuePhaseRecord.class});
+        String xml = xstream.toXML(action);
+        var roundTripped = (QueueItemMonitoringAction) xstream.fromXML(xml);
+
+        var phases = roundTripped.getPhases();
+        assertThat(phases.size(), is(2));
+
+        var first = phases.get(0);
+        assertThat(first.getPhaseName(), is(JENKINS_JOB_SPAN_PHASE_QUEUE_WAITING_NAME));
+        assertThat(first.getReason(), is("Quiet period"));
+        assertThat(first.getLabel(), is("linux"));
+        assertTrue(first.getStartMillis() > 0);
+        assertTrue(first.getEndMillis() >= first.getStartMillis());
+
+        var second = phases.get(1);
+        assertThat(second.getPhaseName(), is(JENKINS_JOB_SPAN_PHASE_QUEUE_BUILDABLE_NAME));
+        assertThat(second.getReason(), is(nullValue()));
+        assertThat(second.getLabel(), is(nullValue()));
+    }
+
+    // ── concurrency ──────────────────────────────────────────────────────────
+
+    @Test
+    void concurrentStartAndEndDoNotCorruptState() throws InterruptedException {
+        var action = new QueueItemMonitoringAction();
+        int threads = 4;
+        int iterationsPerThread = 50;
+        var latch = new CountDownLatch(1);
+        var executor = Executors.newFixedThreadPool(threads);
+
+        for (int i = 0; i < threads; i++) {
+            final int id = i;
+            executor.submit(() -> {
+                try {
+                    latch.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                for (int j = 0; j < iterationsPerThread; j++) {
+                    action.startPhase("phase-" + id, "reason", null);
+                    action.endCurrentPhase();
+                }
+            });
+        }
+
+        latch.countDown();
+        executor.shutdown();
+        assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+
+        // Every recorded phase must have a valid time range (no data corruption)
+        for (var p : action.getPhases()) {
+            assertTrue(p.getEndMillis() >= p.getStartMillis(), "phase end must be >= start: " + p.getPhaseName());
+        }
+    }
+}


### PR DESCRIPTION
Before this change, traces only covered build execution. Builds that spent time waiting in the Jenkins queue showed up with a root span whose start time matched execution start, hiding all queue latency.

This change attaches a QueueItemMonitoringAction to each queue item as it enters the WaitingItem state. The action tracks each state transition (Waiting → Blocked → Buildable) with timestamps and the reason/label for that state. When the build starts, MonitoringRunListener reads the completed phases and emits a child span per phase under the root BUILD span, using historical timestamps. The root span start time is extended back to when the item first entered the queue.

New spans:
- Phase: Queue - Waiting   (ci.pipeline.run.queue.reason, when applicable)
- Phase: Queue - Blocked   (ci.pipeline.run.queue.reason, jenkins.pipeline.step.agent.label)
- Phase: Queue - Buildable (ci.pipeline.run.queue.reason, jenkins.pipeline.step.agent.label)

<!-- Please describe your pull request here. -->

### Testing done

Added tests.
Manually verified the spans are present.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
