### PR TITLE
fix: reset OtelJulHandler circuit breaker on reconfiguration

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/init/OtelJulHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/init/OtelJulHandler.java
@@ -15,6 +15,7 @@ import io.opentelemetry.api.logs.LogRecordBuilder;
 import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.semconv.ExceptionAttributes;
 import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes;
 import java.io.PrintWriter;
@@ -55,9 +56,11 @@ public class OtelJulHandler extends Handler implements OpenTelemetryLifecycleLis
     }
 
     /**
-     * Circuit breaker
+     * Circuit breaker. Latches to {@code true} on the first emit failure and is cleared by
+     * {@link #afterConfiguration(ConfigProperties)} so a reconfigure (or a transient endpoint outage that
+     * resolves before the next reconfigure) does not disable log export for the remaining life of the JVM.
      */
-    private boolean disabled = false;
+    private volatile boolean disabled = false;
 
     /**
      * Map the {@link LogRecord} data model onto the {@link io.opentelemetry.api.logs.LogRecordBuilder}. Unmapped fields include:
@@ -161,6 +164,18 @@ public class OtelJulHandler extends Handler implements OpenTelemetryLifecycleLis
 
     @Override
     public void close() throws SecurityException {}
+
+    /**
+     * Re-fetch the logger provider and clear the circuit breaker so a reconfigure (JCasC reload, endpoint
+     * recovery, etc.) resumes log export even if a prior emit failure had disabled it.
+     */
+    @Override
+    public void afterConfiguration(ConfigProperties configProperties) {
+        this.loggerProvider = openTelemetry.getLogsBridge();
+        this.captureExperimentalAttributes = configProperties.getBoolean(
+                "otel.instrumentation.java-util-logging.experimental-log-attributes", false);
+        this.disabled = false;
+    }
 
     @PostConstruct
     public void postConstruct() {

--- a/src/main/java/io/jenkins/plugins/opentelemetry/init/OtelJulHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/init/OtelJulHandler.java
@@ -21,6 +21,7 @@ import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.time.Instant;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;
 import java.util.logging.Level;
@@ -56,11 +57,21 @@ public class OtelJulHandler extends Handler implements OpenTelemetryLifecycleLis
     }
 
     /**
-     * Circuit breaker. Latches to {@code true} on the first emit failure and is cleared by
-     * {@link #afterConfiguration(ConfigProperties)} so a reconfigure (or a transient endpoint outage that
-     * resolves before the next reconfigure) does not disable log export for the remaining life of the JVM.
+     * Circuit breaker. Latches to {@code true} on an emit failure and is cleared by
+     * {@link #afterConfiguration(ConfigProperties)}, so a reconfigure (JCasC reload, endpoint URL change, etc.)
+     * resumes log export instead of leaving it disabled for the remaining life of the JVM. Recovery is not
+     * automatic: an endpoint becoming reachable again on its own does not clear this, a reconfiguration is
+     * required.
      */
     private volatile boolean disabled = false;
+
+    /**
+     * Bumped by {@link #afterConfiguration(ConfigProperties)} every time the logger provider is refreshed.
+     * {@link #publish(LogRecord)} captures this before emitting, so that a failure from a publish that was
+     * already in flight against a since-superseded provider does not re-latch {@link #disabled} on behalf of
+     * a configuration that is no longer current.
+     */
+    private final AtomicInteger generation = new AtomicInteger();
 
     /**
      * Map the {@link LogRecord} data model onto the {@link io.opentelemetry.api.logs.LogRecordBuilder}. Unmapped fields include:
@@ -75,6 +86,7 @@ public class OtelJulHandler extends Handler implements OpenTelemetryLifecycleLis
         if (disabled) {
             return;
         }
+        int publishGeneration = generation.get();
         try {
             String instrumentationName = logRecord.getLoggerName();
             if (instrumentationName == null || instrumentationName.isEmpty()) {
@@ -129,7 +141,11 @@ public class OtelJulHandler extends Handler implements OpenTelemetryLifecycleLis
             // because the OTelJulHandler is a handler of this logger, risking an infinite loop
             System.err.println("Exception sending logs to OTLP endpoint, disable OTelJulHandler");
             e.printStackTrace();
-            disabled = true;
+            // only latch the breaker if no reconfiguration happened while this publish() was in flight;
+            // otherwise this failure belongs to a provider that afterConfiguration() has already superseded
+            if (generation.get() == publishGeneration) {
+                disabled = true;
+            }
         }
     }
 
@@ -174,6 +190,7 @@ public class OtelJulHandler extends Handler implements OpenTelemetryLifecycleLis
         this.loggerProvider = openTelemetry.getLogsBridge();
         this.captureExperimentalAttributes = configProperties.getBoolean(
                 "otel.instrumentation.java-util-logging.experimental-log-attributes", false);
+        this.generation.incrementAndGet();
         this.disabled = false;
     }
 

--- a/src/main/java/io/jenkins/plugins/opentelemetry/init/OtelJulHandler.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/init/OtelJulHandler.java
@@ -182,8 +182,8 @@ public class OtelJulHandler extends Handler implements OpenTelemetryLifecycleLis
     public void close() throws SecurityException {}
 
     /**
-     * Re-fetch the logger provider and clear the circuit breaker so a reconfigure (JCasC reload, endpoint
-     * recovery, etc.) resumes log export even if a prior emit failure had disabled it.
+     * Re-fetch the logger provider and clear the circuit breaker after a reconfigure (for example, a JCasC reload
+     * or endpoint change), so log export resumes after a prior emit failure disabled it.
      */
     @Override
     public void afterConfiguration(ConfigProperties configProperties) {

--- a/src/test/java/io/jenkins/plugins/opentelemetry/init/OtelJulHandlerTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/init/OtelJulHandlerTest.java
@@ -34,7 +34,8 @@ class OtelJulHandlerTest {
     @Test
     void handlerNeverRecoversWithoutAfterConfiguration() throws Exception {
         AtomicInteger emitAttempts = new AtomicInteger();
-        OtelJulHandler handler = newHandler(emitAttempts);
+        OtelJulHandler handler = new OtelJulHandler();
+        setField(handler, "loggerProvider", newFailFirstProvider(emitAttempts));
 
         // 1st record: emit() throws, the circuit breaker latches disabled = true.
         handler.publish(new LogRecord(Level.INFO, "first record - endpoint transiently down"));
@@ -49,24 +50,71 @@ class OtelJulHandlerTest {
     }
 
     @Test
-    void afterConfigurationResetsTheCircuitBreaker() throws Exception {
-        AtomicInteger emitAttempts = new AtomicInteger();
-        OtelJulHandler handler = newHandler(emitAttempts);
+    void afterConfigurationResetsTheBreakerAndUsesTheRefreshedProvider() throws Exception {
+        AtomicInteger oldProviderEmitAttempts = new AtomicInteger();
+        LoggerProvider oldProvider = newFailFirstProvider(oldProviderEmitAttempts);
+        AtomicInteger newProviderEmitAttempts = new AtomicInteger();
+        LoggerProvider newProvider = newSucceedingProvider(newProviderEmitAttempts);
+
+        OtelJulHandler handler = new OtelJulHandler();
+        setField(handler, "loggerProvider", oldProvider);
+        ReconfigurableOpenTelemetry openTelemetry = mock(ReconfigurableOpenTelemetry.class);
+        setField(handler, "openTelemetry", openTelemetry);
 
         handler.publish(new LogRecord(Level.INFO, "first record - endpoint transiently down"));
         assertTrue(getDisabled(handler), "disabled must latch true after the first emit failure");
+        assertEquals(1, oldProviderEmitAttempts.get());
 
+        // afterConfiguration() re-fetches the provider from openTelemetry.getLogsBridge(); simulate the SDK
+        // handing back a freshly (re)configured provider distinct from the one installed at construction time,
+        // so the test can tell whether afterConfiguration() actually replaced loggerProvider rather than just
+        // clearing the disabled flag.
+        when(openTelemetry.getLogsBridge()).thenReturn(newProvider);
         handler.afterConfiguration(DefaultConfigProperties.createFromMap(Collections.emptyMap()));
         assertTrue(!getDisabled(handler), "afterConfiguration() must clear the circuit breaker");
 
         handler.publish(new LogRecord(Level.INFO, "second record - after reconfiguration"));
+
         assertEquals(
-                2,
-                emitAttempts.get(),
-                "after afterConfiguration() resets the breaker, publish() must attempt emit() again");
+                1, newProviderEmitAttempts.get(), "publish() after reconfiguration must use the refreshed provider");
+        assertEquals(1, oldProviderEmitAttempts.get(), "the superseded provider must not be used again after a reset");
     }
 
-    private static OtelJulHandler newHandler(AtomicInteger emitAttempts) throws Exception {
+    @Test
+    void staleInFlightFailureDoesNotReLatchTheBreakerAfterReconfiguration() throws Exception {
+        OtelJulHandler handler = new OtelJulHandler();
+        LoggerProvider replacementProvider = newSucceedingProvider(new AtomicInteger());
+        ReconfigurableOpenTelemetry openTelemetry = mock(ReconfigurableOpenTelemetry.class);
+        when(openTelemetry.getLogsBridge()).thenReturn(replacementProvider);
+        setField(handler, "openTelemetry", openTelemetry);
+
+        AtomicInteger emitAttempts = new AtomicInteger();
+        LogRecordBuilder builder = mock(LogRecordBuilder.class, Answers.RETURNS_SELF);
+        doAnswer(invocation -> {
+                    emitAttempts.incrementAndGet();
+                    // Simulate a reconfiguration racing in and completing while this emit() call, already in
+                    // flight against the about-to-be-superseded provider below, is still running.
+                    handler.afterConfiguration(DefaultConfigProperties.createFromMap(Collections.emptyMap()));
+                    throw new IllegalStateException("stale provider failed after being superseded");
+                })
+                .when(builder)
+                .emit();
+        Logger otelLogger = mock(Logger.class);
+        when(otelLogger.logRecordBuilder()).thenReturn(builder);
+        LoggerProvider staleProvider = mock(LoggerProvider.class);
+        when(staleProvider.get(anyString())).thenReturn(otelLogger);
+        setField(handler, "loggerProvider", staleProvider);
+
+        handler.publish(new LogRecord(Level.INFO, "in-flight against the stale provider"));
+
+        assertEquals(1, emitAttempts.get());
+        assertTrue(
+                !getDisabled(handler),
+                "a failure from a publish that was already in flight before a reconfiguration completed must not"
+                        + " re-latch the breaker on behalf of a provider that has since been superseded");
+    }
+
+    private static LoggerProvider newFailFirstProvider(AtomicInteger emitAttempts) {
         LogRecordBuilder builder = mock(LogRecordBuilder.class, Answers.RETURNS_SELF);
         doAnswer(invocation -> {
                     if (emitAttempts.incrementAndGet() == 1) {
@@ -76,20 +124,26 @@ class OtelJulHandlerTest {
                 })
                 .when(builder)
                 .emit();
+        return providerFor(builder);
+    }
 
+    private static LoggerProvider newSucceedingProvider(AtomicInteger emitAttempts) {
+        LogRecordBuilder builder = mock(LogRecordBuilder.class, Answers.RETURNS_SELF);
+        doAnswer(invocation -> {
+                    emitAttempts.incrementAndGet();
+                    return null;
+                })
+                .when(builder)
+                .emit();
+        return providerFor(builder);
+    }
+
+    private static LoggerProvider providerFor(LogRecordBuilder builder) {
         Logger otelLogger = mock(Logger.class);
         when(otelLogger.logRecordBuilder()).thenReturn(builder);
         LoggerProvider provider = mock(LoggerProvider.class);
         when(provider.get(anyString())).thenReturn(otelLogger);
-
-        OtelJulHandler handler = new OtelJulHandler();
-        setField(handler, "loggerProvider", provider);
-
-        ReconfigurableOpenTelemetry openTelemetry = mock(ReconfigurableOpenTelemetry.class);
-        when(openTelemetry.getLogsBridge()).thenReturn(provider);
-        setField(handler, "openTelemetry", openTelemetry);
-
-        return handler;
+        return provider;
     }
 
     private static void setField(OtelJulHandler handler, String fieldName, Object value) throws Exception {

--- a/src/test/java/io/jenkins/plugins/opentelemetry/init/OtelJulHandlerTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/init/OtelJulHandlerTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.jenkins.plugins.opentelemetry.init;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.jenkins.plugins.opentelemetry.api.ReconfigurableOpenTelemetry;
+import io.opentelemetry.api.logs.LogRecordBuilder;
+import io.opentelemetry.api.logs.Logger;
+import io.opentelemetry.api.logs.LoggerProvider;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+
+/**
+ * Regression tests for <a href="https://github.com/jenkinsci/opentelemetry-plugin/issues/1291">issue #1291</a>:
+ * {@link OtelJulHandler} used to permanently disable log export after a single emit failure, with no code
+ * path that ever reset the circuit breaker.
+ */
+class OtelJulHandlerTest {
+
+    @Test
+    void handlerNeverRecoversWithoutAfterConfiguration() throws Exception {
+        AtomicInteger emitAttempts = new AtomicInteger();
+        OtelJulHandler handler = newHandler(emitAttempts);
+
+        // 1st record: emit() throws, the circuit breaker latches disabled = true.
+        handler.publish(new LogRecord(Level.INFO, "first record - endpoint transiently down"));
+        // 2nd record: the endpoint has recovered, but the handler short-circuits on `disabled`.
+        handler.publish(new LogRecord(Level.INFO, "second record - endpoint back up"));
+
+        assertEquals(
+                1,
+                emitAttempts.get(),
+                "without a reset path, emit() is attempted only once and every subsequent log is dropped");
+        assertTrue(getDisabled(handler), "disabled must latch true after the first emit failure");
+    }
+
+    @Test
+    void afterConfigurationResetsTheCircuitBreaker() throws Exception {
+        AtomicInteger emitAttempts = new AtomicInteger();
+        OtelJulHandler handler = newHandler(emitAttempts);
+
+        handler.publish(new LogRecord(Level.INFO, "first record - endpoint transiently down"));
+        assertTrue(getDisabled(handler), "disabled must latch true after the first emit failure");
+
+        handler.afterConfiguration(DefaultConfigProperties.createFromMap(Collections.emptyMap()));
+        assertTrue(!getDisabled(handler), "afterConfiguration() must clear the circuit breaker");
+
+        handler.publish(new LogRecord(Level.INFO, "second record - after reconfiguration"));
+        assertEquals(
+                2,
+                emitAttempts.get(),
+                "after afterConfiguration() resets the breaker, publish() must attempt emit() again");
+    }
+
+    private static OtelJulHandler newHandler(AtomicInteger emitAttempts) throws Exception {
+        LogRecordBuilder builder = mock(LogRecordBuilder.class, Answers.RETURNS_SELF);
+        doAnswer(invocation -> {
+                    if (emitAttempts.incrementAndGet() == 1) {
+                        throw new IllegalStateException("simulated transient OTLP emit failure");
+                    }
+                    return null;
+                })
+                .when(builder)
+                .emit();
+
+        Logger otelLogger = mock(Logger.class);
+        when(otelLogger.logRecordBuilder()).thenReturn(builder);
+        LoggerProvider provider = mock(LoggerProvider.class);
+        when(provider.get(anyString())).thenReturn(otelLogger);
+
+        OtelJulHandler handler = new OtelJulHandler();
+        setField(handler, "loggerProvider", provider);
+
+        ReconfigurableOpenTelemetry openTelemetry = mock(ReconfigurableOpenTelemetry.class);
+        when(openTelemetry.getLogsBridge()).thenReturn(provider);
+        setField(handler, "openTelemetry", openTelemetry);
+
+        return handler;
+    }
+
+    private static void setField(OtelJulHandler handler, String fieldName, Object value) throws Exception {
+        Field field = OtelJulHandler.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(handler, value);
+    }
+
+    private static boolean getDisabled(OtelJulHandler handler) throws Exception {
+        Field field = OtelJulHandler.class.getDeclaredField("disabled");
+        field.setAccessible(true);
+        return (boolean) field.get(handler);
+    }
+}


### PR DESCRIPTION
Fixes #1291

`OtelJulHandler` installs a circuit breaker on its JUL to OTLP log bridge: the first `RuntimeException` thrown from the emit path sets `disabled = true`, and `publish()` short-circuits on that flag from then on. Nothing in the class ever set it back to `false`. A single transient failure, for example the OTLP endpoint being briefly unavailable, or a reconfigure/shutdown race, permanently stops all controller and pipeline log export for the remaining life of the JVM. Traces are unaffected since they go through a separate exporter, which masks the outage.

The class already implements `OpenTelemetryLifecycleListener` but did not override `afterConfiguration(ConfigProperties)`, so a JCasC reload or any other SDK reconfiguration never re-fetched the logger provider or reset the breaker. The only thing that previously cleared it was a brand new handler instance, meaning a JVM restart or plugin reload.

This change overrides `afterConfiguration` to re-fetch the logger provider from `openTelemetry.getLogsBridge()` and clear `disabled`, so a reconfigure recovers a previously tripped handler. The `disabled` field is also made `volatile` since `publish()` can run on arbitrary logging threads while `afterConfiguration()` runs on the reconfiguration thread.

### Testing done

Added `OtelJulHandlerTest` with two tests:
- `handlerNeverRecoversWithoutAfterConfiguration`: reproduces the original bug, a single emit failure permanently disables the handler and every subsequent `publish()` is a no-op.
- `afterConfigurationResetsTheCircuitBreaker`: asserts calling `afterConfiguration()` clears the breaker and a subsequent `publish()` attempts to emit again.

Ran the full existing test suite locally on JDK 21 (matching this repo's Jenkinsfile): 238 tests run, 0 failures, 0 errors, 1 skipped (pre-existing skip, unrelated to this change). Also verified `./mvnw spotless:check` and `./mvnw spotbugs:check` pass clean.

### Submitter checklist
- [x] Make sure you are opening from a topic/feature/bugfix branch (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed