### PR TITLE
Fix NullPointerException in AuditingSecurityListener.loggedIn()

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/security/AuditingSecurityListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/security/AuditingSecurityListener.java
@@ -105,9 +105,11 @@ public class AuditingSecurityListener extends SecurityListener implements OpenTe
                 .put(UserIncubatingAttributes.USER_ID, user.map(User::getId).orElse(username));
 
         // Stapler.getCurrentRequest() returns null, it's not yet initialized
+        // SecurityContextHolder.getContext() never returns null, but its authentication can be null if this
+        // listener is invoked (directly or by a SecurityRealm) before the SecurityContextHolder is populated
         SecurityContext securityContext = SecurityContextHolder.getContext();
-        if (securityContext != null) {
-            Authentication authentication = securityContext.getAuthentication();
+        Authentication authentication = securityContext.getAuthentication();
+        if (authentication != null) {
             Object details = authentication.getDetails();
             if (details instanceof WebAuthenticationDetails webAuthenticationDetails) {
                 attributesBuilder.put(ClientAttributes.CLIENT_ADDRESS, webAuthenticationDetails.getRemoteAddress());

--- a/src/test/java/io/jenkins/plugins/opentelemetry/security/AuditingSecurityListenerTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/security/AuditingSecurityListenerTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.security;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import hudson.ExtensionList;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Regression test for {@link AuditingSecurityListener#loggedIn(String)}: {@code SecurityListener.fireLoggedIn(...)}
+ * can be invoked by a {@code SecurityRealm} before the {@link SecurityContextHolder}'s authentication has been
+ * populated for the current thread, so {@code loggedIn} must not assume it is non-null.
+ */
+@WithJenkins
+class AuditingSecurityListenerTest {
+
+    private AuditingSecurityListener listener;
+
+    @BeforeEach
+    void beforeEach(JenkinsRule j) {
+        listener = ExtensionList.lookupSingleton(AuditingSecurityListener.class);
+        SecurityContextHolder.clearContext();
+    }
+
+    @AfterEach
+    void afterEach() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void loggedInDoesNotThrowWhenSecurityContextHasNoAuthentication() {
+        assertDoesNotThrow(() -> listener.loggedIn("test-user"));
+    }
+}


### PR DESCRIPTION
### Description

`AuditingSecurityListener.loggedIn(String)` builds an audit log event for a successful login and attaches the client's remote address by reading the current `Authentication`:

```java
SecurityContext securityContext = SecurityContextHolder.getContext();
if (securityContext != null) {
    Authentication authentication = securityContext.getAuthentication();
    Object details = authentication.getDetails();
    ...
}
```

The null check guards `SecurityContextHolder.getContext()`, but per the Spring Security contract that call never returns `null` (an empty context is lazily created if none exists). The value that can actually be `null` is `securityContext.getAuthentication()`. Since `authentication.getDetails()` is called unconditionally, this throws a `NullPointerException` whenever `SecurityListener.fireLoggedIn(...)` is invoked before the current thread's security context has an authentication set. `AuditingSecurityListener` is a general `SecurityListener` extension point invoked by any `SecurityRealm`, not only the ones bundled with core, so third-party authentication mechanisms can trigger this.

Fixed by checking `authentication` for `null` instead of `securityContext`.

Fixes #1299

### Testing done

- Added `AuditingSecurityListenerTest`, which clears the `SecurityContextHolder` and invokes `loggedIn(String)` directly, asserting it does not throw.
- Verified the new test throws a `NullPointerException` against the pre-fix code and passes after the fix.
- `./mvnw spotless:apply`: no changes needed.
- `./mvnw spotbugs:check`: clean.
- Full test suite (`./mvnw test`): 252 tests run, 0 failures, 0 errors.

### Submitter checklist

- [x] Reviewed the [contributing guidelines](https://github.com/jenkinsci/opentelemetry-plugin/blob/main/CONTRIBUTING.md)
- [x] Added or updated tests for the change
- [x] Verified the change locally (build + full test suite)