### PR TITLE
Fix queue metrics visibility under restricted ACL contexts

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/queue/MonitoringQueueListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/queue/MonitoringQueueListener.java
@@ -113,7 +113,11 @@ public class MonitoringQueueListener extends QueueListener implements OpenTeleme
                             waiting.incrementAndGet();
                         } else if (item instanceof Queue.LeftItem) {
                             // ignore, left items are observed via onLeft()
-                            LOGGER.log(Level.FINE, () -> "Unknown queue item class: " + item.getClass().getName());
+                        } else {
+                            LOGGER.log(
+                                    Level.FINE,
+                                    () -> "Unknown queue item class: " + item.getClass().getName());
+                            unknown.incrementAndGet();
                         }
                     });
                     queueItems.record(blocked.get(), Attributes.of(STATUS, "blocked"));
@@ -146,7 +150,7 @@ public class MonitoringQueueListener extends QueueListener implements OpenTeleme
     public void onLeft(Queue.LeftItem li) {
         this.leftItemCounter.add(1);
         this.timeInQueueInMillisCounter.add(System.currentTimeMillis() - li.getInQueueSince());
-        LOGGER.log(Level.FINE, () -> "onLeft(): " + li);
+        LOGGER.log(Level.FINE, () -> "onLeft(): " + li.getClass().getName());
     }
 
     @Override
@@ -160,7 +164,7 @@ public class MonitoringQueueListener extends QueueListener implements OpenTeleme
                         spanContext.getSpanId(),
                         spanContext.getTraceFlags().asByte(),
                         spanContext.getTraceState().asMap()));
-                LOGGER.log(Level.FINE, () -> "attach RemoteSpanAction to " + wi);
+                LOGGER.log(Level.FINE, () -> "attach RemoteSpanAction to " + wi.getClass().getName());
             }
         }
     }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/queue/MonitoringQueueListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/queue/MonitoringQueueListener.java
@@ -9,9 +9,12 @@ import static io.jenkins.plugins.opentelemetry.semconv.ExtendedJenkinsAttributes
 import static io.jenkins.plugins.opentelemetry.semconv.JenkinsMetrics.*;
 import static io.jenkins.plugins.opentelemetry.semconv.JenkinsMetrics.JENKINS_QUEUE_COUNT;
 
+import com.google.common.annotations.VisibleForTesting;
 import hudson.Extension;
 import hudson.model.Queue;
 import hudson.model.queue.QueueListener;
+import hudson.security.ACL;
+import hudson.security.ACLContext;
 import io.jenkins.plugins.opentelemetry.JenkinsControllerOpenTelemetry;
 import io.jenkins.plugins.opentelemetry.api.OpenTelemetryLifecycleListener;
 import io.jenkins.plugins.opentelemetry.semconv.ConfigurationKey;
@@ -24,7 +27,6 @@ import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import java.util.Arrays;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
@@ -91,45 +93,41 @@ public class MonitoringQueueListener extends QueueListener implements OpenTeleme
                 () -> {
                     LOGGER.log(Level.FINE, () -> "Recording Jenkins queue metrics...");
 
-                    Optional<Queue> queue =
-                            Optional.ofNullable(Jenkins.getInstanceOrNull()).map(Jenkins::getQueue);
-                    queue.map(Queue::getItems).ifPresent(items -> {
-                        AtomicInteger blocked = new AtomicInteger();
-                        AtomicInteger buildable = new AtomicInteger();
-                        AtomicInteger left = new AtomicInteger();
-                        AtomicInteger stuck = new AtomicInteger();
-                        AtomicInteger unknown = new AtomicInteger();
-                        AtomicInteger waiting = new AtomicInteger();
-                        Arrays.stream(items).forEach(item -> {
-                            if (item instanceof Queue.BlockedItem) {
-                                blocked.incrementAndGet();
-                            } else if (item instanceof Queue.BuildableItem) {
-                                if (item.isStuck()) {
-                                    // buildable but here for too long
-                                    stuck.incrementAndGet();
-                                } else {
-                                    buildable.incrementAndGet();
-                                }
-                            } else if (item instanceof Queue.WaitingItem) {
-                                waiting.incrementAndGet();
-                            } else if (item instanceof Queue.LeftItem) {
-                                left.incrementAndGet();
+                    Queue.Item[] items = getQueueItemsForMetrics();
+                    AtomicInteger blocked = new AtomicInteger();
+                    AtomicInteger buildable = new AtomicInteger();
+                    AtomicInteger stuck = new AtomicInteger();
+                    AtomicInteger unknown = new AtomicInteger();
+                    AtomicInteger waiting = new AtomicInteger();
+                    Arrays.stream(items).forEach(item -> {
+                        if (item instanceof Queue.BlockedItem) {
+                            blocked.incrementAndGet();
+                        } else if (item instanceof Queue.BuildableItem) {
+                            if (item.isStuck()) {
+                                // buildable but here for too long
+                                stuck.incrementAndGet();
                             } else {
-                                LOGGER.log(Level.INFO, () -> "Unknown item: " + item + " - class=" + item.getClass());
-                                unknown.incrementAndGet();
+                                buildable.incrementAndGet();
                             }
-                        });
-                        queueItems.record(blocked.get(), Attributes.of(STATUS, "blocked"));
-                        queueBlockedItems.record(blocked.get());
-                        queueItems.record(buildable.get(), Attributes.of(STATUS, "buildable"));
-                        queueBuildableItems.record(buildable.get());
-                        queueItems.record(stuck.get(), Attributes.of(STATUS, "stuck"));
-                        if (unknown.get() > 0) {
-                            queueItems.record(unknown.get(), Attributes.of(STATUS, "unknown"));
+                        } else if (item instanceof Queue.WaitingItem) {
+                            waiting.incrementAndGet();
+                        } else if (item instanceof Queue.LeftItem) {
+                            // ignore, left items are observed via onLeft()
+                        } else {
+                            LOGGER.log(Level.INFO, () -> "Unknown item: " + item + " - class=" + item.getClass());
+                            unknown.incrementAndGet();
                         }
-                        queueItems.record(waiting.get(), Attributes.of(STATUS, "waiting"));
-                        queueWaitingItems.record(waiting.get());
                     });
+                    queueItems.record(blocked.get(), Attributes.of(STATUS, "blocked"));
+                    queueBlockedItems.record(blocked.get());
+                    queueItems.record(buildable.get(), Attributes.of(STATUS, "buildable"));
+                    queueBuildableItems.record(buildable.get());
+                    queueItems.record(stuck.get(), Attributes.of(STATUS, "stuck"));
+                    if (unknown.get() > 0) {
+                        queueItems.record(unknown.get(), Attributes.of(STATUS, "unknown"));
+                    }
+                    queueItems.record(waiting.get(), Attributes.of(STATUS, "waiting"));
+                    queueWaitingItems.record(waiting.get());
                 },
                 queueItems,
                 queueWaitingItems,
@@ -166,6 +164,19 @@ public class MonitoringQueueListener extends QueueListener implements OpenTeleme
                         spanContext.getTraceState().asMap()));
                 LOGGER.log(Level.FINE, () -> "attach RemoteSpanAction to " + wi);
             }
+        }
+    }
+
+    @VisibleForTesting
+    Queue.Item[] getQueueItemsForMetrics() {
+        Jenkins jenkins = Jenkins.getInstanceOrNull();
+        if (jenkins == null) {
+            return new Queue.Item[0];
+        }
+        // Queue#getItems is permission-filtered in recent Jenkins cores.
+        // Metrics are node-level health signals and must observe the full queue.
+        try (ACLContext ignored = ACL.as2(ACL.SYSTEM2)) {
+            return jenkins.getQueue().getItems();
         }
     }
 }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/queue/MonitoringQueueListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/queue/MonitoringQueueListener.java
@@ -116,7 +116,8 @@ public class MonitoringQueueListener extends QueueListener implements OpenTeleme
                         } else {
                             LOGGER.log(
                                     Level.FINE,
-                                    () -> "Unknown queue item class: " + item.getClass().getName());
+                                    () -> "Unknown queue item class: "
+                                            + item.getClass().getName());
                             unknown.incrementAndGet();
                         }
                     });
@@ -164,7 +165,9 @@ public class MonitoringQueueListener extends QueueListener implements OpenTeleme
                         spanContext.getSpanId(),
                         spanContext.getTraceFlags().asByte(),
                         spanContext.getTraceState().asMap()));
-                LOGGER.log(Level.FINE, () -> "attach RemoteSpanAction to " + wi.getClass().getName());
+                LOGGER.log(
+                        Level.FINE,
+                        () -> "attach RemoteSpanAction to " + wi.getClass().getName());
             }
         }
     }

--- a/src/main/java/io/jenkins/plugins/opentelemetry/queue/MonitoringQueueListener.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/queue/MonitoringQueueListener.java
@@ -113,9 +113,7 @@ public class MonitoringQueueListener extends QueueListener implements OpenTeleme
                             waiting.incrementAndGet();
                         } else if (item instanceof Queue.LeftItem) {
                             // ignore, left items are observed via onLeft()
-                        } else {
-                            LOGGER.log(Level.INFO, () -> "Unknown item: " + item + " - class=" + item.getClass());
-                            unknown.incrementAndGet();
+                            LOGGER.log(Level.FINE, () -> "Unknown queue item class: " + item.getClass().getName());
                         }
                     });
                     queueItems.record(blocked.get(), Attributes.of(STATUS, "blocked"));

--- a/src/test/java/io/jenkins/plugins/opentelemetry/queue/MonitoringQueueListenerTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/queue/MonitoringQueueListenerTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.queue;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+
+import hudson.ExtensionList;
+import hudson.model.FreeStyleProject;
+import hudson.model.Queue;
+import hudson.security.ACL;
+import hudson.security.ACLContext;
+import hudson.security.FullControlOnceLoggedInAuthorizationStrategy;
+import jenkins.model.Jenkins;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class MonitoringQueueListenerTest {
+
+    private JenkinsRule jenkinsRule;
+
+    @BeforeEach
+    void beforeEach(JenkinsRule jenkinsRule) {
+        this.jenkinsRule = jenkinsRule;
+    }
+
+    @Test
+    @Issue("https://github.com/jenkinsci/opentelemetry-plugin/issues/1174")
+    void queueMetricsReadItemsWithSystemAuthentication() throws Exception {
+        jenkinsRule.jenkins.setSecurityRealm(jenkinsRule.createDummySecurityRealm());
+        FullControlOnceLoggedInAuthorizationStrategy authorizationStrategy =
+                new FullControlOnceLoggedInAuthorizationStrategy();
+        authorizationStrategy.setAllowAnonymousRead(false);
+        jenkinsRule.jenkins.setAuthorizationStrategy(authorizationStrategy);
+
+        int originalNumExecutors = jenkinsRule.jenkins.getNumExecutors();
+        FreeStyleProject project = jenkinsRule.createFreeStyleProject("queued-project");
+        try {
+            jenkinsRule.jenkins.setNumExecutors(0);
+            project.scheduleBuild2(0);
+
+            await().atMost(15, SECONDS).until(() -> {
+                try (ACLContext ignored = ACL.as2(ACL.SYSTEM2)) {
+                    return jenkinsRule.jenkins.getQueue().getItems().length > 0;
+                }
+            });
+
+            Queue.Item[] anonymousVisibleItems;
+            try (ACLContext ignored = ACL.as2(Jenkins.ANONYMOUS2)) {
+                anonymousVisibleItems = jenkinsRule.jenkins.getQueue().getItems();
+            }
+            assertThat(anonymousVisibleItems.length, is(0));
+
+            MonitoringQueueListener listener = ExtensionList.lookupSingleton(MonitoringQueueListener.class);
+            Queue.Item[] metricsVisibleItems = listener.getQueueItemsForMetrics();
+            assertThat(metricsVisibleItems.length, greaterThanOrEqualTo(1));
+        } finally {
+            jenkinsRule.jenkins.getQueue().cancel(project);
+            jenkinsRule.jenkins.setNumExecutors(originalNumExecutors);
+        }
+    }
+}

--- a/src/test/java/io/jenkins/plugins/opentelemetry/queue/MonitoringQueueListenerTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/queue/MonitoringQueueListenerTest.java
@@ -56,13 +56,13 @@ class MonitoringQueueListenerTest {
             });
 
             Queue.Item[] anonymousVisibleItems;
+            Queue.Item[] metricsVisibleItems;
             try (ACLContext ignored = ACL.as2(Jenkins.ANONYMOUS2)) {
                 anonymousVisibleItems = jenkinsRule.jenkins.getQueue().getItems();
+                MonitoringQueueListener listener = ExtensionList.lookupSingleton(MonitoringQueueListener.class);
+                metricsVisibleItems = listener.getQueueItemsForMetrics();
             }
             assertThat(anonymousVisibleItems.length, is(0));
-
-            MonitoringQueueListener listener = ExtensionList.lookupSingleton(MonitoringQueueListener.class);
-            Queue.Item[] metricsVisibleItems = listener.getQueueItemsForMetrics();
             assertThat(metricsVisibleItems.length, greaterThanOrEqualTo(1));
         } finally {
             jenkinsRule.jenkins.getQueue().cancel(project);


### PR DESCRIPTION
## What problem does this solve?
`jenkins.queue.count` can report `0` for all statuses (including `stuck` / `buildable`) when queue metrics are collected in a restricted security context, even though items are visible in the Jenkins UI, Queue API, and Script Console.

This wraps queue item reads for metric collection in `ACL.SYSTEM2` so queue gauges observe the full queue.

Fixes #1174.

Based on / credits prior work in #1240 (Flamki), rebased onto current `main`.

Independent repro on Jenkins `2.568.3` + opentelemetry `3.1599`: Script Console `stuck=1` while OTLP `jenkins.queue.count{status=*}` stayed `0` — see https://github.com/jenkinsci/opentelemetry-plugin/issues/1174#issuecomment-5535319193

## How to test the change
1. `./mvnw spotless:check`
2. `./mvnw test -Dtest=MonitoringQueueListenerTest`
3. `./mvnw spotbugs:check`

## Breaking changes
None.

## Additional notes
Regression test verifies anonymous context sees no queue items while the metrics path still sees queued items via SYSTEM ACL.

Happy to help validate on a live instance; complementary `left` status recording remains in #1271.