### PR TITLE
Fix pooled HTTP connection leak in LokiBuildLogsLineIterator

### DIFF
--- a/src/main/java/io/jenkins/plugins/opentelemetry/backend/grafana/LokiBuildLogsLineIterator.java
+++ b/src/main/java/io/jenkins/plugins/opentelemetry/backend/grafana/LokiBuildLogsLineIterator.java
@@ -94,6 +94,7 @@ public class LokiBuildLogsLineIterator implements LogLineIterator<Long>, AutoClo
             if (delegate.hasNext()) {
                 return delegate;
             }
+            closeDelegateQuietly();
             delegate = loadNextLogLines();
             if (!delegate.hasNext()) {
                 endOfStream = true;
@@ -203,6 +204,7 @@ public class LokiBuildLogsLineIterator implements LogLineIterator<Long>, AutoClo
                  */
                 span.setAttribute("skippedLines", -1);
                 lokiQueryParameters.setStartTimeInNanos(newStartTimeInNanos);
+                closeDelegateQuietly();
                 this.delegate = null; // TODO optimize to skip lines in the current delegate
             }
         } finally {
@@ -220,8 +222,13 @@ public class LokiBuildLogsLineIterator implements LogLineIterator<Long>, AutoClo
         return getCurrentIterator().next();
     }
 
-    @Override
-    public void close() throws Exception {
+    /**
+     * Close the current {@link #delegate}, if any and if it holds a closeable resource (eg the underlying HTTP
+     * response stream/connection of a Loki query page), before it is replaced or discarded. Each page loaded by
+     * {@link #loadNextLogLines()} holds its own HTTP response stream backed by the shared, connection pooled
+     * {@link #httpClient}; failing to close a page before moving to the next one leaks that connection.
+     */
+    private void closeDelegateQuietly() {
         if (delegate instanceof AutoCloseable) {
             try {
                 ((AutoCloseable) delegate).close();
@@ -229,6 +236,11 @@ public class LokiBuildLogsLineIterator implements LogLineIterator<Long>, AutoClo
                 logger.log(Level.WARNING, "Failed to close delegate for " + lokiQueryParameters, e);
             }
         }
+    }
+
+    @Override
+    public void close() throws Exception {
+        closeDelegateQuietly();
         try {
             this.httpClient.close();
         } catch (IOException e) {

--- a/src/test/java/io/jenkins/plugins/opentelemetry/backend/grafana/LokiBuildLogsLineIteratorPageClosingTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/backend/grafana/LokiBuildLogsLineIteratorPageClosingTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright The Original Author or Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.jenkins.plugins.opentelemetry.backend.grafana;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.jenkins.plugins.opentelemetry.job.log.LogLine;
+import io.jenkins.plugins.opentelemetry.job.log.util.CloseableIterator;
+import io.opentelemetry.api.OpenTelemetry;
+import java.io.Closeable;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test: {@link LokiBuildLogsLineIterator} pages through Loki query results, each page holding its own
+ * HTTP response stream backed by the shared, connection-pooled {@code httpClient}. Moving from an exhausted page to
+ * the next one (or discarding the current page in {@link LokiBuildLogsLineIterator#skipLines(Long)}) must close the
+ * page being left behind, or its underlying connection leaks.
+ */
+public class LokiBuildLogsLineIteratorPageClosingTest {
+
+    @Test
+    public void exhaustedPageIsClosedBeforeLoadingTheNextOne() throws Exception {
+        TrackingCloseable page1Closeable = new TrackingCloseable();
+        TrackingCloseable page2Closeable = new TrackingCloseable();
+        Deque<Iterator<LogLine<Long>>> pages = new ArrayDeque<>(List.of(
+                new CloseableIterator<>(List.of(new LogLine<>(1L, "line1")).iterator(), page1Closeable),
+                new CloseableIterator<>(Collections.emptyIterator(), page2Closeable)));
+
+        try (TestableLokiBuildLogsLineIterator iterator = new TestableLokiBuildLogsLineIterator(pages)) {
+            assertTrue(iterator.hasNext());
+            iterator.next(); // consume the only line of page 1
+
+            assertFalse(page1Closeable.closed, "page 1 must not be closed while it may still be in use");
+
+            // page 1 is now exhausted; asking for more must close it before loading page 2
+            assertFalse(iterator.hasNext());
+            assertTrue(page1Closeable.closed, "page 1 must be closed once exhausted and replaced by page 2");
+        }
+    }
+
+    @Test
+    public void currentPageIsClosedWhenSkipLinesDiscardsIt() throws Exception {
+        TrackingCloseable page1Closeable = new TrackingCloseable();
+        Deque<Iterator<LogLine<Long>>> pages = new ArrayDeque<>(List.of(
+                new CloseableIterator<>(List.of(new LogLine<>(1L, "line1")).iterator(), page1Closeable)));
+
+        try (TestableLokiBuildLogsLineIterator iterator = new TestableLokiBuildLogsLineIterator(pages)) {
+            assertTrue(iterator.hasNext()); // loads page 1
+            assertFalse(page1Closeable.closed);
+
+            iterator.skipLines(1L);
+
+            assertTrue(page1Closeable.closed, "the discarded page must be closed by skipLines()");
+        }
+    }
+
+    private static class TrackingCloseable implements Closeable {
+        boolean closed;
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+        }
+    }
+
+    /**
+     * Serves pre-built pages instead of querying a real Loki server.
+     */
+    private static class TestableLokiBuildLogsLineIterator extends LokiBuildLogsLineIterator {
+        private final Deque<Iterator<LogLine<Long>>> pages;
+
+        TestableLokiBuildLogsLineIterator(Deque<Iterator<LogLine<Long>>> pages) {
+            super(
+                    new LokiGetJenkinsBuildLogsQueryParametersBuilder()
+                            .setJobFullName("my-war/master")
+                            .setRunNumber(384)
+                            .setTraceId("69a627b7bc02241b6029bed20f4ff8d8")
+                            .setStartTime(Instant.EPOCH)
+                            .setEndTime(Instant.EPOCH.plusSeconds(600))
+                            .setServiceName("jenkins")
+                            .setServiceNamespace("jenkins")
+                            .build(),
+                    NOOP_HTTP_CLIENT,
+                    HttpClientContext.create(),
+                    "http://localhost:3100",
+                    Optional.empty(),
+                    Optional.empty(),
+                    OpenTelemetry.noop().getTracer("io.jenkins"));
+            this.pages = pages;
+        }
+
+        @Override
+        protected Iterator<LogLine<Long>> loadNextLogLines() {
+            return pages.isEmpty() ? Collections.emptyIterator() : pages.removeFirst();
+        }
+
+        // The real client is never used since loadNextLogLines() is overridden, but close() still calls
+        // httpClient.close(), so a real, harmless instance is needed.
+        private static final CloseableHttpClient NOOP_HTTP_CLIENT =
+                HttpClients.custom().build();
+    }
+}

--- a/src/test/java/io/jenkins/plugins/opentelemetry/backend/grafana/LokiBuildLogsLineIteratorPageClosingTest.java
+++ b/src/test/java/io/jenkins/plugins/opentelemetry/backend/grafana/LokiBuildLogsLineIteratorPageClosingTest.java
@@ -20,6 +20,7 @@ import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
@@ -37,9 +38,18 @@ public class LokiBuildLogsLineIteratorPageClosingTest {
     public void exhaustedPageIsClosedBeforeLoadingTheNextOne() throws Exception {
         TrackingCloseable page1Closeable = new TrackingCloseable();
         TrackingCloseable page2Closeable = new TrackingCloseable();
-        Deque<Iterator<LogLine<Long>>> pages = new ArrayDeque<>(List.of(
-                new CloseableIterator<>(List.of(new LogLine<>(1L, "line1")).iterator(), page1Closeable),
-                new CloseableIterator<>(Collections.emptyIterator(), page2Closeable)));
+        Deque<Supplier<Iterator<LogLine<Long>>>> pages = new ArrayDeque<>(List.of(
+                () -> new CloseableIterator<>(
+                        List.of(new LogLine<>(1L, "line1")).iterator(), page1Closeable),
+                () -> {
+                    // page 1 must already be closed by the time page 2 is fetched: closing it only
+                    // *eventually*, e.g. after page 2 is loaded, would still hold the pooled connection open
+                    // for longer than necessary and defeats the point of closing eagerly.
+                    assertTrue(
+                            page1Closeable.closed,
+                            "page 1 must be closed before page 2 is loaded, not merely at some later point");
+                    return new CloseableIterator<>(Collections.emptyIterator(), page2Closeable);
+                }));
 
         try (TestableLokiBuildLogsLineIterator iterator = new TestableLokiBuildLogsLineIterator(pages)) {
             assertTrue(iterator.hasNext());
@@ -56,7 +66,7 @@ public class LokiBuildLogsLineIteratorPageClosingTest {
     @Test
     public void currentPageIsClosedWhenSkipLinesDiscardsIt() throws Exception {
         TrackingCloseable page1Closeable = new TrackingCloseable();
-        Deque<Iterator<LogLine<Long>>> pages = new ArrayDeque<>(List.of(
+        Deque<Supplier<Iterator<LogLine<Long>>>> pages = new ArrayDeque<>(List.of(() ->
                 new CloseableIterator<>(List.of(new LogLine<>(1L, "line1")).iterator(), page1Closeable)));
 
         try (TestableLokiBuildLogsLineIterator iterator = new TestableLokiBuildLogsLineIterator(pages)) {
@@ -82,9 +92,9 @@ public class LokiBuildLogsLineIteratorPageClosingTest {
      * Serves pre-built pages instead of querying a real Loki server.
      */
     private static class TestableLokiBuildLogsLineIterator extends LokiBuildLogsLineIterator {
-        private final Deque<Iterator<LogLine<Long>>> pages;
+        private final Deque<Supplier<Iterator<LogLine<Long>>>> pages;
 
-        TestableLokiBuildLogsLineIterator(Deque<Iterator<LogLine<Long>>> pages) {
+        TestableLokiBuildLogsLineIterator(Deque<Supplier<Iterator<LogLine<Long>>>> pages) {
             super(
                     new LokiGetJenkinsBuildLogsQueryParametersBuilder()
                             .setJobFullName("my-war/master")
@@ -106,7 +116,9 @@ public class LokiBuildLogsLineIteratorPageClosingTest {
 
         @Override
         protected Iterator<LogLine<Long>> loadNextLogLines() {
-            return pages.isEmpty() ? Collections.emptyIterator() : pages.removeFirst();
+            return pages.isEmpty()
+                    ? Collections.emptyIterator()
+                    : pages.removeFirst().get();
         }
 
         // The real client is never used since loadNextLogLines() is overridden, but close() still calls


### PR DESCRIPTION
### Description

`LokiBuildLogsLineIterator` pages through Loki query results via `getCurrentIterator()`. Each page returned by `loadNextLogLines()` is a `CloseableIterator` wrapping the HTTP response stream of that page's query, obtained from a single, connection-pooled `CloseableHttpClient` (`PoolingHttpClientConnectionManager`) that `LokiLogStorageRetriever` creates once and shares across its whole lifetime (many builds, many log views).

When a page is exhausted, `getCurrentIterator()` silently replaced the `delegate` with the next page without closing it, and `skipLines(Long)` discarded the current page (`this.delegate = null;`) the same way. Only the very last page fetched by an iterator was ever closed (and only if the whole iterator itself got closed), so every intermediate page leaked its underlying HTTP response stream, i.e. one pooled connection per page transition. Since a single build's log can span up to `MAX_QUERIES = 100` pages, and this repeats for every build's log view, the shared connection pool can be exhausted over time.

Fixed by adding a `closeDelegateQuietly()` helper (mirroring the try/catch-and-log pattern already used in `close()`) and calling it before the delegate is replaced in `getCurrentIterator()` and discarded in `skipLines()`.

Fixes #1303

### Testing done

- Added `LokiBuildLogsLineIteratorPageClosingTest` with two regression tests: one verifying an exhausted page is closed before the next page is loaded, one verifying `skipLines()` closes the page it discards.
- Verified both new tests fail against the pre-fix code and pass after the fix.
- `./mvnw spotless:apply`: reformatted the changed file only.
- `./mvnw spotbugs:check`: clean.
- Full test suite (`./mvnw test`): 253 tests run, 0 failures, 0 errors.

### Submitter checklist

- [x] Reviewed the [contributing guidelines](https://github.com/jenkinsci/opentelemetry-plugin/blob/main/CONTRIBUTING.md)
- [x] Added or updated tests for the change
- [x] Verified the change locally (build + full test suite)